### PR TITLE
Add README explaining repo purpose and sync workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Personal [Claude Code](https://claude.com/claude-code) configuration — global 
 ## Layout
 
 ```
-CLAUDE.md             # global instructions (see CLAUDE.md)
+CLAUDE.md             # global instructions, loaded into every session's system prompt
 settings.json         # harness settings: hooks, permissions, plugins
 bin/ghimplement.sh    # chained plan → implement → review → address pipeline
 skills/
@@ -15,7 +15,7 @@ skills/
   ghaddress/          # /ghaddress: address review comments on a PR
 agents/
   pragmatic-developer.md
-commands/             # slash commands (currently empty)
+commands/             # slash commands (created on first sync; no files tracked yet)
 scripts/sync.sh       # bidirectional sync with ~/.claude and ~/bin
 ```
 
@@ -31,9 +31,9 @@ scripts/sync.sh push     # repo → ~/.claude
 scripts/sync.sh diff     # show differences (alias: status)
 ```
 
-Flags: `--dry-run` to preview, `--force` to allow deleting more than `DELETE_THRESHOLD` (5) files, `--yes` to skip the confirmation prompt.
+Flags: `-n`/`--dry-run` to preview, `-f`/`--force` to allow more than `DELETE_THRESHOLD` (5) directory-pair deletions, `-y`/`--yes` to skip the confirmation prompt.
 
-Directory pairs (`skills/`, `agents/`, `commands/`) sync with `rsync --delete`, so `push` and `pull` mirror — extras on the destination side are removed. The `DELETE_THRESHOLD` guardrail refuses any sync that would delete more than 5 files unless `--force` is passed.
+Directory pairs (`skills/`, `agents/`, `commands/`) sync with `rsync --delete`, so `push` and `pull` mirror — extras on the destination side are removed. Only those directory-pair deletions count toward `DELETE_THRESHOLD`: the guardrail refuses a non-dry-run sync that would delete more than 5 files this way unless `--force` is passed. With `--dry-run`, the script still previews the deletions but does not refuse the run.
 
 ## Skills
 
@@ -51,4 +51,5 @@ The four `gh*` skills compose into a GitHub-issue-driven workflow:
 1. Clone this repo.
 2. Review [`settings.json`](settings.json) and [`CLAUDE.md`](CLAUDE.md) — these land in `~/.claude/` on `push`.
 3. Run `scripts/sync.sh diff` to see what would change against your current `~/.claude/`.
-4. Run `scripts/sync.sh push` to install.
+4. **If you have existing content in `~/.claude/skills/`, `~/.claude/agents/`, or `~/.claude/commands/`, run `scripts/sync.sh push --dry-run` first.** `push` mirrors these directories with `rsync --delete`, so any files not present in this repo will be removed from `~/.claude/`. The `DELETE_THRESHOLD` guardrail catches large deletions, but smaller losses still slip through.
+5. Run `scripts/sync.sh push` to install.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# Claude Code config
+
+Personal [Claude Code](https://claude.com/claude-code) configuration — global instructions, settings, skills, agents, and the `ghimplement` workflow. The repo is bidirectionally mirrored with `~/.claude/` (plus `~/bin/ghimplement.sh`) via [`scripts/sync.sh`](scripts/sync.sh).
+
+## Layout
+
+```
+CLAUDE.md             # global instructions (see CLAUDE.md)
+settings.json         # harness settings: hooks, permissions, plugins
+bin/ghimplement.sh    # chained plan → implement → review → address pipeline
+skills/
+  ghplan/             # /ghplan: draft a plan, post it as a GitHub issue
+  ghimplement/        # /ghimplement: run the full pipeline via bin/ghimplement.sh
+  ghreview/           # /ghreview: review a PR and post inline comments
+  ghaddress/          # /ghaddress: address review comments on a PR
+agents/
+  pragmatic-developer.md
+commands/             # slash commands (currently empty)
+scripts/sync.sh       # bidirectional sync with ~/.claude and ~/bin
+```
+
+Intentionally untracked: `settings.local.json` and `.claude/` — see [`.gitignore`](.gitignore).
+
+## Sync workflow
+
+[`scripts/sync.sh`](scripts/sync.sh) is the source of truth. It tracks exactly the paths in `FILE_PAIRS` and `DIR_PAIRS` at the top of the script.
+
+```
+scripts/sync.sh pull     # ~/.claude → repo
+scripts/sync.sh push     # repo → ~/.claude
+scripts/sync.sh diff     # show differences (alias: status)
+```
+
+Flags: `--dry-run` to preview, `--force` to allow deleting more than `DELETE_THRESHOLD` (5) files, `--yes` to skip the confirmation prompt.
+
+Directory pairs (`skills/`, `agents/`, `commands/`) sync with `rsync --delete`, so `push` and `pull` mirror — extras on the destination side are removed. The `DELETE_THRESHOLD` guardrail refuses any sync that would delete more than 5 files unless `--force` is passed.
+
+## Skills
+
+The four `gh*` skills compose into a GitHub-issue-driven workflow:
+
+- [`/ghplan`](skills/ghplan/SKILL.md) — draft a plan and post it as a new GitHub issue.
+- [`/ghimplement`](skills/ghimplement/SKILL.md) — run the full pipeline end-to-end via [`bin/ghimplement.sh`](bin/ghimplement.sh).
+- [`/ghreview`](skills/ghreview/SKILL.md) — review a PR and post inline comments.
+- [`/ghaddress`](skills/ghaddress/SKILL.md) — address review comments on a PR and reply to each thread.
+
+`bin/ghimplement.sh` chains them: `/ghplan` → implement → `/ghreview` (Copilot + Claude) → `/ghaddress`, producing a merged-ready PR from a single instruction.
+
+## Getting started
+
+1. Clone this repo.
+2. Review [`settings.json`](settings.json) and [`CLAUDE.md`](CLAUDE.md) — these land in `~/.claude/` on `push`.
+3. Run `scripts/sync.sh diff` to see what would change against your current `~/.claude/`.
+4. Run `scripts/sync.sh push` to install.


### PR DESCRIPTION
## Summary
- Adds a top-level `README.md` orienting readers to this personal Claude Code config repo.
- Documents the layout (tracked paths, intentionally gitignored files), the `scripts/sync.sh` `pull`/`push`/`diff` contract, the `DELETE_THRESHOLD=5` guardrail, and the `--dry-run` / `--force` / `--yes` flags.
- One-line descriptions of the four `gh*` skills and how `bin/ghimplement.sh` chains them. Links out to `CLAUDE.md`, `settings.json`, `scripts/sync.sh`, `bin/ghimplement.sh`, and each `SKILL.md` to avoid drift.

Closes #3

## Test plan
- [ ] Render the README on GitHub and confirm all relative links resolve.
- [ ] Cross-check the layout section against `FILE_PAIRS` and `DIR_PAIRS` in `scripts/sync.sh`.
- [ ] Confirm `.gitignore` still covers `settings.local.json` and `.claude/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)