### PR TITLE
Split CLAUDE.md into repo-level doc and synced global preferences

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,30 @@
-# Global Preferences
+# This repo
 
-## Workflow: Plans and GitHub Issues
-When creating implementation plans, don't ask "how would you like to implement this?" — instead, default to posting the plan as a GitHub issue (or comment on an existing issue). Plans should live in GitHub issues where they can be discussed and refined, not immediately executed. When iterating on an issue, keep the conversation anchored to the issue content and update it as decisions are made. Don't move on to plan execution until the issue content is finalized and agreed upon.
+Personal Claude Code config, bidirectionally mirrored with `~/.claude/` (plus `~/bin/ghimplement.sh`) via [`scripts/sync.sh`](scripts/sync.sh). See [`README.md`](README.md) for the full overview.
+
+## Source of truth
+
+`scripts/sync.sh` is authoritative for what is tracked. Do not hand-edit files under `~/.claude/` without running `scripts/sync.sh pull` afterward, and do not edit repo files without running `scripts/sync.sh push` to propagate.
+
+## Tracked paths
+
+Only the paths in `FILE_PAIRS` and `DIR_PAIRS` at the top of `scripts/sync.sh` are synced. Anything outside those paths is untracked by the sync.
+
+- `FILE_PAIRS`: `home/CLAUDE.md` → `~/.claude/CLAUDE.md`, `settings.json` → `~/.claude/settings.json`, `bin/ghimplement.sh` → `~/bin/ghimplement.sh`.
+- `DIR_PAIRS`: `skills/`, `agents/`, `commands/` ↔ `~/.claude/{skills,agents,commands}/`.
+
+## Directory mirroring caveat
+
+`DIR_PAIRS` sync with `rsync --delete` — deletions on either side are real. Pending deletions count toward `DELETE_THRESHOLD` (5); above that, `push`/`pull` refuse without `--force`.
+
+## Adding a new skill / agent / command
+
+Create the file under the corresponding repo directory (`skills/<name>/SKILL.md`, `agents/<name>.md`, `commands/<name>.md`), then run `scripts/sync.sh push`.
+
+## The `gh*` skill pipeline
+
+[`bin/ghimplement.sh`](bin/ghimplement.sh) chains the four `gh*` skills (`/ghplan` → implement → `/ghreview` → `/ghaddress`) into an end-to-end GitHub-issue-driven workflow.
+
+## Not tracked
+
+`settings.local.json` and `.claude/` are intentionally ignored — see [`.gitignore`](.gitignore).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,14 +8,14 @@ Personal Claude Code config, bidirectionally mirrored with `~/.claude/` (plus `~
 
 ## Tracked paths
 
-Only the paths in `FILE_PAIRS` and `DIR_PAIRS` at the top of `scripts/sync.sh` are synced. Anything outside those paths is untracked by the sync.
+Only the paths in `FILE_PAIRS` and `DIR_PAIRS` at the top of `scripts/sync.sh` are synced. Anything outside those paths is untracked by the sync. The list below is kept in sync manually with `scripts/sync.sh` — update both together.
 
 - `FILE_PAIRS`: `home/CLAUDE.md` → `~/.claude/CLAUDE.md`, `settings.json` → `~/.claude/settings.json`, `bin/ghimplement.sh` → `~/bin/ghimplement.sh`.
-- `DIR_PAIRS`: `skills/`, `agents/`, `commands/` ↔ `~/.claude/{skills,agents,commands}/`.
+- `DIR_PAIRS`: `skills/`, `agents/`, `commands/` ↔ `~/.claude/{skills,agents,commands}/`. A tracked directory that doesn't yet exist on the source side is skipped (not created) — e.g. `commands/` is tracked but currently empty and won't be mirrored until it has contents.
 
 ## Directory mirroring caveat
 
-`DIR_PAIRS` sync with `rsync --delete` — deletions on either side are real. Pending deletions count toward `DELETE_THRESHOLD` (5); above that, `push`/`pull` refuse without `--force`.
+`DIR_PAIRS` sync with `rsync --delete` — deletions on either side are real. Pending deletions count toward `DELETE_THRESHOLD` (5); non-dry-run `push`/`pull` refuse above that threshold unless `--force` is used, while `--dry-run` still previews the deletions.
 
 ## Adding a new skill / agent / command
 
@@ -23,7 +23,7 @@ Create the file under the corresponding repo directory (`skills/<name>/SKILL.md`
 
 ## The `gh*` skill pipeline
 
-[`bin/ghimplement.sh`](bin/ghimplement.sh) chains the four `gh*` skills (`/ghplan` → implement → `/ghreview` → `/ghaddress`) into an end-to-end GitHub-issue-driven workflow.
+The `ghimplement` skill invokes [`bin/ghimplement.sh`](bin/ghimplement.sh) to run an end-to-end GitHub-issue-driven workflow: `/ghplan`, an implementation + PR creation stage, `/ghreview`, and `/ghaddress`.
 
 ## Not tracked
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Personal [Claude Code](https://claude.com/claude-code) configuration — global 
 ## Layout
 
 ```
-CLAUDE.md             # global instructions, loaded into every session's system prompt
+CLAUDE.md             # repo-level doc for Claude, loaded when cwd is this repo (not synced)
+home/CLAUDE.md        # global preferences, synced to ~/.claude/CLAUDE.md
 settings.json         # harness settings: hooks, permissions, plugins
 bin/ghimplement.sh    # chained plan → implement → review → address pipeline
 skills/
@@ -49,7 +50,7 @@ The four `gh*` skills compose into a GitHub-issue-driven workflow:
 ## Getting started
 
 1. Clone this repo.
-2. Review [`settings.json`](settings.json) and [`CLAUDE.md`](CLAUDE.md) — these land in `~/.claude/` on `push`.
+2. Review [`settings.json`](settings.json) and [`home/CLAUDE.md`](home/CLAUDE.md) — these land in `~/.claude/` on `push`.
 3. Run `scripts/sync.sh diff` to see what would change against your current `~/.claude/`.
 4. **If you have existing content in `~/.claude/skills/`, `~/.claude/agents/`, or `~/.claude/commands/`, run `scripts/sync.sh push --dry-run` first.** `push` mirrors these directories with `rsync --delete`, so any files not present in this repo will be removed from `~/.claude/`. The `DELETE_THRESHOLD` guardrail catches large deletions, but smaller losses still slip through.
 5. Run `scripts/sync.sh push` to install.

--- a/home/CLAUDE.md
+++ b/home/CLAUDE.md
@@ -1,0 +1,4 @@
+# Global Preferences
+
+## Workflow: Plans and GitHub Issues
+When creating implementation plans, don't ask "how would you like to implement this?" — instead, default to posting the plan as a GitHub issue (or comment on an existing issue). Plans should live in GitHub issues where they can be discussed and refined, not immediately executed. When iterating on an issue, keep the conversation anchored to the issue content and update it as decisions are made. Don't move on to plan execution until the issue content is finalized and agreed upon.

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -17,7 +17,7 @@ DELETE_THRESHOLD=5
 
 # "<repo-relative-path>:<absolute-home-path>"
 FILE_PAIRS=(
-    "CLAUDE.md:$CLAUDE_DIR/CLAUDE.md"
+    "home/CLAUDE.md:$CLAUDE_DIR/CLAUDE.md"
     "settings.json:$CLAUDE_DIR/settings.json"
     "bin/ghimplement.sh:$HOME/bin/ghimplement.sh"
 )


### PR DESCRIPTION
## Summary
- Moves the global-preferences content to `home/CLAUDE.md`, which is what `scripts/sync.sh` now mirrors to `~/.claude/CLAUDE.md`.
- Rewrites `CLAUDE.md` at the repo root as a repo-level doc (source of truth, tracked paths, mirroring caveat, how to add a skill/agent/command, `gh*` pipeline pointer, not-tracked list). Not synced anywhere.
- Updates `scripts/sync.sh` `FILE_PAIRS` entry from `CLAUDE.md:$CLAUDE_DIR/CLAUDE.md` to `home/CLAUDE.md:$CLAUDE_DIR/CLAUDE.md`.
- Updates `README.md` Layout and Getting started to reflect the two-file split.

## Test plan
- [x] `scripts/sync.sh diff` is clean after the change.
- [x] `scripts/sync.sh push --dry-run -y` reports no pending deletions and resolves `home/CLAUDE.md` correctly.
- [ ] After merge, run `scripts/sync.sh push` locally to confirm `~/.claude/CLAUDE.md` still matches and no repo-level content leaks into global sessions.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)