### PR TITLE
Add workflow status visibility (stage + /workflows skill)

### DIFF
--- a/.claude-workflow/20260420-124831/plan.md
+++ b/.claude-workflow/20260420-124831/plan.md
@@ -1,0 +1,69 @@
+# Workflow status visibility
+
+## Context
+
+`/localimplement` and `/ghimplement` pipelines are multi-stage (plan → implement → review → address, with sub-stages). They run detached from the launching Claude session via `skills/_bg/launch.sh`, survive session exit, and can run 3–5 in parallel across branches of the same repo.
+
+Today, the only feedback surface is the `SessionStart` / `UserPromptSubmit` hook in `skills/_bg/session-summary.sh`, which reports a flat *"running (pid N, workdir …)"* line — no stage, no sub-stage, no task description, and filtered to the current project. There is no on-demand, rich status command.
+
+Persistent state already exists at `~/.claude/workflows/<id>/` (from `skills/_bg/launch.sh`): `state.json` with `id`, `kind`, `project_root`, `workdir`, `setup_kind`, `branch`, `status`, `started_at`, `instructions`, `pid` (and `ended_at`, `exit_code` after `finish.sh` runs); plus `log`, `pid`, and `finished` / `acknowledged` markers. This plan extends that state and adds a user-facing status command on top of it.
+
+## Approach
+
+Two-layer change:
+
+1. **Pipelines record their stage into state.json as they advance.** Add a tiny helper `skills/_bg/set-stage.sh <id> <stage> [sub_stage_json]` that atomically patches `state.json`. Call it from `skills/localimplement/localimplement.sh` and `skills/ghimplement/ghimplement.sh` at each `==> [N/M]` stage boundary, and from within the parallel reviewer runner to emit per-reviewer sub-stage updates (`opus=running,sonnet=returned`).
+
+2. **Add a user-invocable `/workflows` skill** that reads every `~/.claude/workflows/*/state.json` on the machine, applies the same liveness logic already present in `session-summary.sh` (augmented with a log-mtime staleness heuristic), and prints one scannable line per active workflow.
+
+Why this split over alternatives:
+
+- **Writing stage into `state.json`** (vs. scraping the `log` file) keeps the status command O(N) cheap and robust: `jq` over a handful of small JSON files, no regex-parsing of partial stream-json logs. Stage transitions are coarse (handful per workflow) so the write volume is trivial.
+- **A separate skill** (vs. expanding `session-summary.sh`) preserves the hook's job — passive, low-noise notifications — and gives the user an explicit, on-demand command that can be richer (full descriptions, sub-stage detail, crashed-reason excerpts) without spamming every prompt.
+- **Reusing the existing state dir** (vs. a new database, socket, or daemon) fits the solo-laptop scope and inherits existing guarantees: atomic `jq | mv` writes, 14-day prune of acknowledged dirs, crashed-pid detection.
+- **Human-readable description**: capture at launch time by adding a `--description` flag (or positional first arg) plumbed through `skills/_bg/launch.sh` from the skill wrappers (`skills/{localimplement,ghimplement}/SKILL.md` already run inside a Claude session that composed the instructions — they can pass a short phrase alongside the full instructions). Truncating `instructions` is a weak fallback; an explicit description is more readable and is what the spec asks for.
+
+### Resolutions to spec open questions
+
+- **Task description capture**: `SKILL.md` for both skills already has Claude context at launch; extend the launcher CLI with `--description <phrase>` and update both SKILL.md files to instruct Claude to produce a ≤60-char phrase and pass it in. Fallback to `instructions[:60]` if omitted.
+- **Dead definition**: treat as dead if (a) `status != "running"` and exit code is nonzero (hard exit via `finish.sh`), OR (b) `status == "running"` but recorded `pid` is gone and no `finished` marker (already detected in `session-summary.sh`, lift into shared helper), OR (c) `status == "running"`, pid alive, but log file mtime is older than a threshold (default 30 min — tunable; emit as "stalled?" not "dead" so the user can judge).
+- **Dead lingering**: reuse the existing `acknowledged` marker pattern. `/workflows` shows dead entries until a flag (`/workflows --ack <id>` or `/workflows --ack-all`) touches `acknowledged`. 14-day prune already in `session-summary.sh` keeps the directory bounded.
+- **Distinguish `/localimplement` vs `/ghimplement`**: yes — trivial since `kind` is already in state.json. Render as a short prefix column (`[local]` / `[gh]`).
+
+## Tasks
+
+- [ ] Task 1 — Add `skills/_bg/set-stage.sh`: CLI `set-stage.sh <wf_id> <stage> [sub_stage_json]` that reads `$HOME/.claude/workflows/<wf_id>/state.json`, patches the `stage` (and optional `sub_stage`) and `stage_updated_at` fields atomically via `jq | mv`. Fail silently on missing state file (stage writes must never break a running pipeline). Mark executable.
+
+- [ ] Task 2 — Extend `skills/_bg/launch.sh`: accept a `--description <phrase>` flag before `<kind>`; record it in the initial `state.json` as `description`; fall back to `instructions[:60]` (existing slice) when absent. Pass `WF_ID` into the pipeline's environment (already exported — confirm) so stage helpers can find it.
+
+- [ ] Task 3 — Instrument `skills/localimplement/localimplement.sh` with stage writes: at each `==> [N/4]` boundary call `"$HOME/.claude/skills/_bg/set-stage.sh" "$WF_ID" plan` / `implement` / `review-code` / `address-code`. Inside `run_dual_review`, after each `wait`, write a `sub_stage` JSON like `{"review_a":"done","review_b":"running"}`. Guard all calls with `[[ -n "${WF_ID:-}" ]]` so direct CLI invocations outside the launcher are unaffected.
+
+- [ ] Task 4 — Instrument `skills/ghimplement/ghimplement.sh` with stage writes: at each `==> [N/6]` boundary call `set-stage.sh` with `plan` / `implement` / `commit-pr` / `request-copilot` / `ghreview` / `wait-copilot` / `ghaddress`. Same `WF_ID` guard.
+
+- [ ] Task 5 — Update `skills/localimplement/SKILL.md` and `skills/ghimplement/SKILL.md` so the wrapper instructs Claude (at launch) to pass `--description "<≤60-char phrase>"` to the launcher. Include an example phrase derived from the user's instructions.
+
+- [ ] Task 6 — Create `skills/workflows/` with `SKILL.md` and `workflows.sh`:
+  - `workflows.sh [--all] [--ack <id>] [--ack-all]`
+  - Default: list all currently-active workflows (running + dead-unacknowledged) on the machine, sorted by `started_at`.
+  - Output columns: `kind`, `id` (short-hash form), `stage` / `sub_stage`, `liveness`, `description`, `age`.
+  - Liveness logic (shared helper `_bg/liveness.sh`): hard-exit → `dead (exit N)`, pid-gone-no-marker → `dead (crashed)`, stale log (>30 min default, env-tunable `BG_STALL_SECS`) → `stalled? (no log update 45m)`, otherwise `running`.
+  - `--ack <id>` / `--ack-all` touch the `acknowledged` marker for matching dead/finished workflows.
+  - Exit 0 always; any unexpected error logs to stderr and continues (same "hooks must never break a session" principle).
+  - `SKILL.md` frontmatter: `allowed-tools: Bash(~/.claude/skills/workflows/workflows.sh:*)`. Brief instructions telling Claude to run the script and print the output verbatim.
+
+- [ ] Task 7 — Refactor shared liveness logic: extract the pid-gone-no-marker detection currently inlined in `skills/_bg/session-summary.sh` into `skills/_bg/liveness.sh` (sourced library: defines `liveness_of_state_file <path>` echoing `running` / `dead:<reason>` / `stalled:<reason>`). Use it from both `session-summary.sh` and `workflows.sh` so they never disagree.
+
+- [ ] Task 8 — Enrich `session-summary.sh` output to include `stage` and `description` from `state.json` (leveraging the new fields) so the passive notification matches the richer on-demand view. Keep it project-scoped (existing behavior); the on-demand `/workflows` command is the machine-wide view per spec.
+
+- [ ] Task 9 — Update `scripts/sync.sh` tracked-paths list / `CLAUDE.md` only if needed: the new `skills/workflows/` directory will be picked up automatically by the existing `DIR_PAIRS` entry for `skills/`. Confirm no list edits required; run `scripts/sync.sh push --dry-run` mentally (in plan, not code) to verify.
+
+- [ ] Task 10 — Manual verification: launch 3 `/localimplement` workflows in parallel against different toy tasks; run `/workflows` and confirm all 3 show with distinct descriptions and stages; kill one mid-run and confirm it reports `dead (crashed)`; let another complete and confirm it disappears after `--ack`; re-run `/workflows` a few seconds after a stage advances and confirm the new stage is reflected.
+
+## Open questions
+
+- **Stall threshold**: 30 min is a guess. A planning stage doing a lot of code reading could reasonably go 5+ min without a log line; an implementation stage rarely does. Should the threshold vary by stage, or is one global "definitely suspicious" number (45 min?) good enough? Suggest: single global threshold, env-tunable, err on the side of false negatives (don't call it stalled unless it really probably is).
+- **Description generation at launch**: the cleanest path is for the wrapper (skill) to pass `--description`, but that relies on the *launching* Claude session doing it correctly. Alternative: have `launch.sh` shell out to `claude -p` to summarize the first 500 chars of instructions into a phrase. That adds ~5–10s to launch latency — the spec says launcher must return fast. Recommend the wrapper-side approach and accept that a poorly-instructed launch may fall back to the truncated-instructions default.
+- **Machine-wide view vs. project-filtered default**: the spec says "see workflows launched from *any* Claude Code session on this machine". But when the user has 5 projects open, seeing workflows from all 5 in every status call may be noisy. Suggest: `/workflows` defaults to **all projects** (matches spec literal); `/workflows --here` filters to current project. Could flip the default if the all-projects view proves noisy in practice.
+- **Sub-stage shape**: JSON object `{"review_a": "running", "review_b": "returned"}` vs. a human string `"opus=running, sonnet=returned"`. JSON is easier to evolve for other sub-stages (e.g., "waiting for Copilot"); a string renders faster. Lean JSON, render it in the status formatter.
+- **Should `/workflows` also surface recent log tail on `--verbose`?** Spec says "dead, with a short reason" — that maps to exit code + marker. Showing a log tail is strictly extra. Mark as stretch, not in first pass.
+- **Acknowledgment UX**: `/workflows --ack <id>` requires the user to type a workflow id. Should `/workflows` accept short unique prefixes (`--ack 20260420-19`)? Nice-to-have; defer.

--- a/.claude-workflow/20260420-124831/review-code-detail-sonnet.md
+++ b/.claude-workflow/20260420-124831/review-code-detail-sonnet.md
@@ -1,0 +1,43 @@
+# Review (sonnet)
+
+## Summary
+
+The implementation is solid overall: the atomic `jq | mv` pattern in `set-stage.sh`, the US-separator approach to avoid tab-collapse, and the fallback/degrade strategy in `session-summary.sh` are all well-executed. A handful of concrete issues follow — mostly minor/nit, no blockers. The most noteworthy correctness issue is that `--ack` and `--ack-all` accept `stalled` workflows (which may still be alive), diverging from the plan's "dead/finished only" spec. The liveness library also uses `@tsv` + `IFS=$'\t'` internally for three fields while the rest of the codebase documents why that pattern is unsafe — fine today, a latent trap if a field is added later.
+
+## Findings
+
+### `--ack` and `--ack-all` acknowledge `stalled` workflows
+- **File:** `skills/workflows/workflows.sh:110` and `skills/workflows/workflows.sh:139`
+- **Severity:** minor
+- **What:** Both `--ack <id>` and `--ack-all` accept `stalled:*` liveness, touching `acknowledged` and permanently hiding the workflow from future `/workflows` runs. A stalled workflow (pid still alive, log just quiet) may still be producing output — acknowledging it hides it while it runs. The plan (Task 6) says ack applies to "dead/finished workflows" only; stalled is not dead.
+- **Fix:** Remove `stalled:*` from the `case` pattern at line 110 and the `if` condition at line 139. If users want to dismiss a stalled workflow they should `--ack` it after it becomes `dead:crashed`.
+
+### Misleading `--ack` skip message
+- **File:** `skills/workflows/workflows.sh:116`
+- **Severity:** nit
+- **What:** `"skipping $id: $live (use --ack-all to force-acknowledge nothing alive)"` is grammatically ambiguous — "nothing alive" can be parsed as "there is nothing alive to acknowledge", which is the opposite of the intent. The sentence also falsely implies `--ack-all` can force-acknowledge a running workflow (it can't — `--ack-all` also skips `running`).
+- **Fix:** Replace with something like `"skipping $id ($live is still running; only finished/dead workflows can be acknowledged)"`.
+
+### `liveness.sh` uses `@tsv` + `IFS=$'\t'` — inconsistent with US-separator approach
+- **File:** `skills/_bg/liveness.sh:37-40`
+- **Severity:** nit
+- **What:** `liveness_of_state_file` reads three fields via `jq ... | @tsv` with `IFS=$'\t'`. The same commit documents (in `session-summary.sh` and `workflows.sh`) that tab-as-IFS-whitespace collapses consecutive empty fields silently. The three fields here (`status`, `pid`, `exit_code`) are safe today — `status` is always present, and the collapsed-empty behavior for null pid/exit_code is harmless. But it contradicts the rationale documented elsewhere and is a latent trap if a fourth field is ever appended without adjusting the separator.
+- **Fix:** Adopt the same `join("\u001f")` + `IFS=$'\x1f'` pattern used in `session-summary.sh` and `workflows.sh`.
+
+### `emit_sub_stage` inner function leaks into global scope
+- **File:** `skills/localimplement/localimplement.sh:435`
+- **Severity:** nit
+- **What:** `emit_sub_stage` is defined inside `run_dual_review()`. Bash does not scope inner function definitions — after `run_dual_review` returns, `emit_sub_stage` persists in the global function namespace for the lifetime of the shell. Harmless in practice (the name is unique and the function is idempotent), but it breaks the encapsulation assumption and could confuse a future reader who grep-searches for where `emit_sub_stage` is defined.
+- **Fix:** Either move the definition outside `run_dual_review` (making it a top-level helper, parallel to `set_stage`) or name it `_run_dual_review_emit_sub` to make the scope intent clear.
+
+### Double `jq` fork per workflow in `session-summary.sh`
+- **File:** `skills/_bg/session-summary.sh:79`
+- **Severity:** nit
+- **What:** Before this change, the hook issued one `jq` call per workflow dir. Now it issues two: one for the outer `IFS=$'\x1f' read` and one inside `liveness_of_state_file`. The original code had a comment specifically calling out `fork+exec` expense on macOS. For 1–5 workflows this is negligible, but worth knowing in case the workflow dir count grows.
+- **Fix:** No action required now. If performance becomes a concern, `liveness_of_state_file` could accept pre-parsed fields as arguments instead of re-reading the file.
+
+### `--ack <id>` substring match can acknowledge multiple unintended workflows
+- **File:** `skills/workflows/workflows.sh:101`
+- **Severity:** nit
+- **What:** `[[ "$id" == *"$TARGET"* ]]` — if `TARGET` is a common substring (e.g., a date fragment like `20260420`), multiple workflow dirs match and all are acknowledged simultaneously. The output does list each acknowledged id, so the user sees what happened, but the intent was almost certainly to match one specific workflow.
+- **Fix:** After accumulating matches, if `matched > 1` print a warning: `"ambiguous id '$TARGET' matched $matched workflows — use a longer prefix to be specific"`. Alternatively, require unique match before acting (print candidates and exit 1 if >1 match).

--- a/.claude-workflow/20260420-124831/review-code-holistic-opus.md
+++ b/.claude-workflow/20260420-124831/review-code-holistic-opus.md
@@ -1,0 +1,56 @@
+# Review (opus)
+
+## Summary
+
+The implementation covers all ten plan tasks and lands cleanly: a small shared `liveness.sh` library, atomic `state.json` stage writes, a new `/workflows` skill, and enriched session-summary output. The design is right-shaped — reusing the existing `~/.claude/workflows/<id>/` directory, matching the "hooks must never break a session" silent-failure conventions, and keeping each new script small and focused. One real bug (an infinite arg-parse loop in `workflows.sh` on `--ack` with no argument), one regression in the session-summary fallback, and a few minor UX/scope nits listed below.
+
+## Findings
+
+### `workflows.sh --ack` with no id infinite-loops
+
+- **File:** `skills/workflows/workflows.sh:41`
+- **Severity:** major
+- **What:** `--ack) MODE="ack"; TARGET="${2:-}"; shift 2 || true ;;` — when the user invokes `workflows.sh --ack` with no trailing id, `$#` is 1, `shift 2` fails and (per bash semantics) does *not* consume any positional parameters. `|| true` swallows the error but the loop reiterates with `$1` still equal to `--ack`. The script then spins forever.
+- **Fix:** consume exactly one slot unconditionally, then optionally a second: `--ack) MODE="ack"; TARGET="${2:-}"; shift; [[ -n "$TARGET" ]] && shift ;;` (and either do the missing-target check right there, or let the existing post-loop check handle it). Worth reproducing with `bash skills/workflows/workflows.sh --ack` before shipping.
+
+### Session-summary fallback regresses crashed-pid detection
+
+- **File:** `skills/_bg/session-summary.sh:27`
+- **Severity:** major
+- **What:** when `liveness.sh` isn't found (plausible during a partial sync between this repo and `~/.claude/`), the fallback is `liveness_of_state_file() { echo "running"; }`. The hook previously had its own inline pid-gone-no-marker check (see the pre-change code at the same location); that behavior is now lost in the fallback, so a crashed workflow would be reported as "running" forever until the liveness library arrives. Shipping this into an install that's mid-sync could mask a dead pipeline.
+- **Fix:** either keep the original inline crashed-pid detection as the fallback body, or source-check and fail the hook quietly if the library is missing (don't silently downgrade). Given the sync-mirroring setup, the inline fallback is probably preferable.
+
+### Sub-stage poll is a lot of machinery for a small feature
+
+- **File:** `skills/localimplement/localimplement.sh:136-160`
+- **Severity:** minor
+- **What:** the poll-with-`kill -0` loop (plus `emit_sub_stage` helper) is ~25 lines implementing mid-flight sub-stage visibility — something the user will almost never see (the two reviews finish on a similar timescale and the `/workflows` refresh cadence is the user re-running the command). The logic also quietly assumes bash's script-mode child reaping behavior (verified: `kill -0` on an auto-reaped zombie returns ESRCH, so this actually works — worth a one-line comment noting the dependency). A `wait -n` loop would be strictly shorter if bash 5.1+ is acceptable, but given the poll works, the real question is whether sub-stage granularity is worth the extra surface at all vs. emitting a single "review-code" stage and relying on the existing stage_updated_at timestamp.
+- **Fix:** consider dropping the sub-stage entirely and showing only `stage: review-code` (the spec's "per-reviewer sub-stage" is a nice-to-have that adds real code for marginal user value). If kept, add a short comment noting that correctness depends on bash auto-reaping background jobs in non-interactive mode.
+
+### `--ack-all` acknowledges still-alive `stalled:*` workflows
+
+- **File:** `skills/workflows/workflows.sh:149`
+- **Severity:** minor
+- **What:** `--ack-all` touches the `acknowledged` marker for `dead:*` and `stalled:*`. A stalled workflow is still running — just quiet. Hiding it may bury a slow-but-alive pipeline the user still cares about. The plan's spirit ("acknowledge dead lingering entries") points to dead-only.
+- **Fix:** restrict `--ack-all` to `dead:*`. Keep an explicit `--ack <id>` escape hatch for a specific stalled one if the user decides it's truly wedged.
+
+### `--ack <substring>` silently matches multiple workflows
+
+- **File:** `skills/workflows/workflows.sh:124`
+- **Severity:** minor
+- **What:** `[[ "$id" == *"$TARGET"* ]]` matches *every* workflow whose id contains the substring, and ack's them all. Plan suggested "accept short unique prefixes"; current impl has no uniqueness guard. A user typing `--ack 20260420` on a day with multiple workflows would ack them all.
+- **Fix:** collect matches, if >1 print the list and exit without touching markers; if 1, proceed. Keeps the UX forgiving but non-destructive.
+
+### Description fallback includes flag prefixes for `ghimplement -r <ref>`
+
+- **File:** `skills/_bg/launch.sh:97`
+- **Severity:** nit
+- **What:** when `--description` is omitted and the user invoked `ghimplement -r some/ref "fix thing"`, `INSTR_RAW` starts with `-r some/ref ...`, so the 60-char fallback renders as `-r some/ref fix thing` — not the useful part. The SKILL.md already instructs Claude to pass `--description`, but the fallback path will hit when a less-careful launching session forgets.
+- **Fix:** if the first positional is `-r <ref>`, skip past it before slicing. Or simply slice from the last quoted arg. Low priority — the real fix is the SKILL.md guidance, which is already there.
+
+### Kind column doesn't match plan's `[local]`/`[gh]` shape
+
+- **File:** `skills/workflows/workflows.sh:198,226`
+- **Severity:** nit
+- **What:** plan §"Distinguish ..." specified "short prefix column (`[local]` / `[gh]`)". Current rendering uses `kind_short="${kind:0:5}"` → `local` and `ghimp`. `ghimp` is slightly ugly and ambiguous.
+- **Fix:** map kinds explicitly: `case "$kind" in localimplement) kind_short=local;; ghimplement) kind_short=gh;; *) kind_short="$kind";; esac`.

--- a/skills/_bg/launch.sh
+++ b/skills/_bg/launch.sh
@@ -8,11 +8,25 @@ die() { echo "error: $*" >&2; exit 1; }
 
 usage() {
     cat >&2 <<'EOF'
-usage: launch.sh <kind> [pipeline-args...]
+usage: launch.sh [--description <phrase>] <kind> [pipeline-args...]
        kind ∈ {ghimplement, localimplement}
 EOF
     exit 1
 }
+
+DESCRIPTION=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --description)
+            [[ $# -ge 2 ]] || usage
+            DESCRIPTION="$2"
+            shift 2
+            ;;
+        --) shift; break ;;
+        -*) die "unknown flag: $1" ;;
+        *)  break ;;
+    esac
+done
 
 [[ $# -ge 1 ]] || usage
 KIND="$1"
@@ -76,6 +90,12 @@ fi
 
 INSTR_RAW="$*"
 INSTR_SUMMARY="${INSTR_RAW:0:200}"
+# Description: explicit --description wins; otherwise fall back to a truncated
+# slice of the raw instructions so the status views always have something to
+# print (weaker signal than a hand-crafted phrase, but better than empty).
+if [[ -z "$DESCRIPTION" ]]; then
+    DESCRIPTION="${INSTR_RAW:0:60}"
+fi
 NOW_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 STATE_FILE="$STATE_DIR/state.json"
@@ -90,9 +110,11 @@ jq -n \
     --arg status        "running" \
     --arg started_at    "$NOW_ISO" \
     --arg instructions  "$INSTR_SUMMARY" \
+    --arg description   "$DESCRIPTION" \
     '{id: $id, kind: $kind, project_root: $project_root, workdir: $workdir,
       setup_kind: $setup_kind, branch: $branch, status: $status,
-      started_at: $started_at, instructions: $instructions, pid: null}' \
+      started_at: $started_at, instructions: $instructions,
+      description: $description, stage: "starting", pid: null}' \
     > "$STATE_TMP" || die "failed to write initial state"
 mv "$STATE_TMP" "$STATE_FILE"
 

--- a/skills/_bg/liveness.sh
+++ b/skills/_bg/liveness.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Shared helper: classify a background workflow's liveness from its state.json.
+# Sourced by session-summary.sh (hook) and workflows.sh (on-demand status).
+# Keeping one source of truth means the two never disagree on whether a
+# workflow is running, dead, or stalled.
+#
+# Requires: jq on PATH. If jq is missing the caller has bigger problems; this
+# file's functions will echo empty strings rather than fail loudly.
+
+# Stall threshold in seconds. 45 min default — high enough that a slow
+# planning stage doesn't flap, low enough that a truly wedged pipeline is
+# caught within an hour. Tune via env.
+: "${BG_STALL_SECS:=2700}"
+
+# _liveness_file_mtime <path> — echoes seconds-since-epoch or empty.
+# Portable across BSD (macOS) and GNU (Linux) stat.
+_liveness_file_mtime() {
+    local f="$1" m
+    m=$(stat -f %m "$f" 2>/dev/null) || m=$(stat -c %Y "$f" 2>/dev/null) || m=""
+    echo "$m"
+}
+
+# liveness_of_state_file <state_file_path>
+# Echoes one of:
+#   running
+#   dead:<reason>
+#   stalled:<reason>
+# Never exits nonzero; empty output means the caller passed garbage.
+liveness_of_state_file() {
+    local sf="$1"
+    [[ -f "$sf" ]] || return 0
+    # Note: avoid `status` as a local name — it's a special/readonly in zsh,
+    # and this file is intended to be sourced from either bash or zsh hooks.
+    local wdir wf_status wf_pid wf_exit_code
+    wdir=$(dirname "$sf")
+
+    IFS=$'\t' read -r wf_status wf_pid wf_exit_code < <(
+        jq -r '[.status, (.pid // "" | tostring),
+                (.exit_code // "" | tostring)] | @tsv' "$sf" 2>/dev/null || true
+    )
+
+    # Terminal: finish.sh ran → `finished` marker exists.
+    if [[ -f "$wdir/finished" ]]; then
+        if [[ -n "$wf_exit_code" && "$wf_exit_code" != "0" && "$wf_exit_code" != "null" ]]; then
+            echo "dead:exit $wf_exit_code"
+        else
+            echo "dead:finished"
+        fi
+        return 0
+    fi
+
+    if [[ "$wf_status" == "running" ]]; then
+        # PID gone but no finish marker → crashed silently.
+        if [[ -n "$wf_pid" && "$wf_pid" != "null" ]] && ! kill -0 "$wf_pid" 2>/dev/null; then
+            echo "dead:crashed (pid $wf_pid gone)"
+            return 0
+        fi
+
+        # Stall heuristic: log file hasn't moved in BG_STALL_SECS.
+        local log="$wdir/log" mtime now age
+        if [[ -f "$log" ]]; then
+            mtime=$(_liveness_file_mtime "$log")
+            if [[ -n "$mtime" ]]; then
+                now=$(date +%s)
+                age=$(( now - mtime ))
+                if (( age > BG_STALL_SECS )); then
+                    echo "stalled:no log update $((age / 60))m"
+                    return 0
+                fi
+            fi
+        fi
+
+        echo "running"
+        return 0
+    fi
+
+    # Non-running status without a finished marker is unusual. Report it
+    # literally so the user can see something is off.
+    if [[ -n "$wf_exit_code" && "$wf_exit_code" != "0" && "$wf_exit_code" != "null" ]]; then
+        echo "dead:exit $wf_exit_code"
+    else
+        echo "dead:${wf_status:-unknown}"
+    fi
+}

--- a/skills/_bg/liveness.sh
+++ b/skills/_bg/liveness.sh
@@ -34,9 +34,12 @@ liveness_of_state_file() {
     local wdir wf_status wf_pid wf_exit_code
     wdir=$(dirname "$sf")
 
-    IFS=$'\t' read -r wf_status wf_pid wf_exit_code < <(
+    # US (\x1f) separator, matching session-summary.sh and workflows.sh: bash
+    # treats tab as IFS-whitespace and collapses consecutive empty columns, so
+    # a future 4th field could silently lose a value. US is non-whitespace.
+    IFS=$'\x1f' read -r wf_status wf_pid wf_exit_code < <(
         jq -r '[.status, (.pid // "" | tostring),
-                (.exit_code // "" | tostring)] | @tsv' "$sf" 2>/dev/null || true
+                (.exit_code // "" | tostring)] | join("\u001f")' "$sf" 2>/dev/null || true
     )
 
     # Terminal: finish.sh ran → `finished` marker exists.

--- a/skills/_bg/session-summary.sh
+++ b/skills/_bg/session-summary.sh
@@ -24,7 +24,30 @@ elif [[ -f "$HOME/.claude/skills/_bg/liveness.sh" ]]; then
     # shellcheck disable=SC1090
     source "$HOME/.claude/skills/_bg/liveness.sh"
 else
-    liveness_of_state_file() { echo "running"; }
+    # Library not installed yet (can happen during a partial sync between this
+    # repo and ~/.claude/). Inline a minimal classifier so a crashed pipeline
+    # doesn't get reported as "running" forever. The full library adds a stall
+    # heuristic on top of this; we skip it in the fallback.
+    liveness_of_state_file() {
+        local sf="$1" wdir st p ec
+        [[ -f "$sf" ]] || return 0
+        wdir=$(dirname "$sf")
+        if [[ -f "$wdir/finished" ]]; then
+            echo "dead:finished"
+            return 0
+        fi
+        IFS=$'\x1f' read -r st p ec < <(
+            jq -r '[.status, (.pid // "" | tostring),
+                    (.exit_code // "" | tostring)] | join("\u001f")' \
+                "$sf" 2>/dev/null || true
+        )
+        if [[ "$st" == "running" && -n "$p" && "$p" != "null" ]] \
+           && ! kill -0 "$p" 2>/dev/null; then
+            echo "dead:crashed (pid $p gone)"
+            return 0
+        fi
+        echo "${st:-running}"
+    }
 fi
 
 # Read hook input JSON from stdin if present.

--- a/skills/_bg/session-summary.sh
+++ b/skills/_bg/session-summary.sh
@@ -13,6 +13,20 @@ command -v jq >/dev/null 2>&1 || exit 0
 STATE_ROOT="$HOME/.claude/workflows"
 [[ -d "$STATE_ROOT" ]] || exit 0
 
+# Source the shared liveness classifier. Both this hook and `workflows.sh`
+# should agree on "is this pipeline still alive". Degrade gracefully if the
+# library isn't installed yet — hooks must never break a session.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "$SCRIPT_DIR/liveness.sh" ]]; then
+    # shellcheck disable=SC1090,SC1091
+    source "$SCRIPT_DIR/liveness.sh"
+elif [[ -f "$HOME/.claude/skills/_bg/liveness.sh" ]]; then
+    # shellcheck disable=SC1090
+    source "$HOME/.claude/skills/_bg/liveness.sh"
+else
+    liveness_of_state_file() { echo "running"; }
+fi
+
 # Read hook input JSON from stdin if present.
 INPUT=""
 if [[ ! -t 0 ]]; then
@@ -48,13 +62,16 @@ for sf in "$STATE_ROOT"/*/state.json; do
     [[ -f "$sf" ]] || continue
     wdir=$(dirname "$sf")
 
-    # Read all fields in one jq fork (tab-delimited) instead of seven.
-    # `fork+exec` is expensive on macOS; this keeps hook latency down when
-    # many workflow dirs accumulate.
-    IFS=$'\t' read -r pr id kind status workdir pid exit_code < <(
+    # One jq fork per state file. Fields joined by ASCII Unit Separator
+    # (\x1f) rather than tab: bash classifies tab as IFS-whitespace, so
+    # consecutive tabs (e.g. two empty fields in a row) collapse and silently
+    # lose columns. US is non-whitespace, so `read` preserves empty fields.
+    IFS=$'\x1f' read -r pr id kind status workdir pid exit_code stage description < <(
         jq -r '[.project_root, .id, .kind, .status, .workdir,
                 (.pid // "" | tostring),
-                (.exit_code // "" | tostring)] | @tsv' "$sf" 2>/dev/null || true
+                (.exit_code // "" | tostring),
+                (.stage // ""),
+                (.description // .instructions // "")] | join("\u001f")' "$sf" 2>/dev/null || true
     )
     [[ "$pr" == "$PROJECT_ROOT" ]] || continue
 
@@ -62,21 +79,32 @@ for sf in "$STATE_ROOT"/*/state.json; do
     ack_marker="$wdir/acknowledged"
     log="$wdir/log"
 
+    desc_suffix=""
+    [[ -n "$description" ]] && desc_suffix=" — _${description}_"
+
     if [[ -f "$finished_marker" && ! -f "$ack_marker" ]]; then
-        FINISHED_BLOCK+="- \`$id\` ($kind): **$status**${exit_code:+ (exit $exit_code)} — log: $log${NL}"
+        FINISHED_BLOCK+="- \`$id\` ($kind): **$status**${exit_code:+ (exit $exit_code)}${desc_suffix} — log: $log${NL}"
         NEWLY_ACK_DIRS+=("$wdir")
         FINISHED_COUNT=$((FINISHED_COUNT + 1))
         continue
     fi
 
     if [[ "$status" == "running" ]]; then
-        # Sanity check: if the recorded PID is gone but no `finished` marker
-        # exists, the pipeline died silently without invoking finish.sh.
-        if [[ -n "$pid" && "$pid" != "null" ]] && ! kill -0 "$pid" 2>/dev/null; then
-            RUNNING_BLOCK+="- \`$id\` ($kind): **crashed** (pid $pid gone, no finish marker) — log: $log${NL}"
-        else
-            RUNNING_BLOCK+="- \`$id\` ($kind): running (pid ${pid:-?}, workdir $workdir) — log: $log${NL}"
-        fi
+        live=$(liveness_of_state_file "$sf")
+        stage_disp="${stage:-?}"
+        case "$live" in
+            dead:*)
+                reason="${live#dead:}"
+                RUNNING_BLOCK+="- \`$id\` ($kind): **$reason** (stage: $stage_disp)${desc_suffix} — log: $log${NL}"
+                ;;
+            stalled:*)
+                reason="${live#stalled:}"
+                RUNNING_BLOCK+="- \`$id\` ($kind): **stalled?** ($reason, stage: $stage_disp, pid ${pid:-?})${desc_suffix} — log: $log${NL}"
+                ;;
+            *)
+                RUNNING_BLOCK+="- \`$id\` ($kind): running (stage: $stage_disp, pid ${pid:-?})${desc_suffix} — log: $log${NL}"
+                ;;
+        esac
     fi
 done
 

--- a/skills/_bg/set-stage.sh
+++ b/skills/_bg/set-stage.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Atomically patch the stage (and optional sub_stage) fields in a background
+# workflow's state.json. Called by pipeline scripts at each stage boundary
+# so `/workflows` and the session-summary hook can report where a workflow is.
+#
+# Usage: set-stage.sh <wf_id> <stage> [sub_stage_json]
+#
+# Fails silently on any error — stage bookkeeping must never break a running
+# pipeline. Callers should also guard on [[ -n "${WF_ID:-}" ]] so direct
+# invocations of the pipeline (outside the launcher) are no-ops.
+set -u
+
+WF_ID="${1:-}"
+STAGE="${2:-}"
+SUB_STAGE="${3:-}"
+
+[[ -n "$WF_ID" && -n "$STAGE" ]] || exit 0
+
+STATE_FILE="$HOME/.claude/workflows/$WF_ID/state.json"
+[[ -f "$STATE_FILE" ]] || exit 0
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+NOW_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+TMP="$STATE_FILE.stage.tmp.$$"
+
+if [[ -n "$SUB_STAGE" ]]; then
+    jq --arg stage "$STAGE" \
+       --arg updated "$NOW_ISO" \
+       --argjson sub "$SUB_STAGE" \
+       '.stage = $stage | .sub_stage = $sub | .stage_updated_at = $updated' \
+       "$STATE_FILE" > "$TMP" 2>/dev/null \
+        && mv "$TMP" "$STATE_FILE" 2>/dev/null
+else
+    jq --arg stage "$STAGE" \
+       --arg updated "$NOW_ISO" \
+       '.stage = $stage | del(.sub_stage) | .stage_updated_at = $updated' \
+       "$STATE_FILE" > "$TMP" 2>/dev/null \
+        && mv "$TMP" "$STATE_FILE" 2>/dev/null
+fi
+
+rm -f "$TMP" 2>/dev/null || true
+exit 0

--- a/skills/ghimplement/SKILL.md
+++ b/skills/ghimplement/SKILL.md
@@ -22,11 +22,18 @@ Forward them verbatim to the launcher. Quote the instructions string so shell wo
 
 ## What to do
 
-Run the launcher:
+Before invoking the launcher, compose a short (≤60 characters) human-readable phrase that summarizes the task — this becomes the workflow's `description` in status views (`/workflows`, session-summary hook). Examples:
+
+- task "refactor the auth middleware to drop the session-token caching layer" → `"drop auth middleware session caching"`
+- task "fix regression where empty PRs pass review" → `"fix empty-PR review regression"`
+
+Pass it as `--description "<phrase>"` before the `ghimplement` kind argument:
 
 ```
-~/.claude/skills/_bg/launch.sh ghimplement $ARGUMENTS
+~/.claude/skills/_bg/launch.sh --description "<phrase>" ghimplement $ARGUMENTS
 ```
+
+If $ARGUMENTS is so terse that a distilled phrase wouldn't add anything, you may omit `--description` — the launcher falls back to the first 60 chars of the instructions.
 
 Report the workflow id, workdir, and log path that it prints. Make clear to the user:
 

--- a/skills/ghimplement/ghimplement.sh
+++ b/skills/ghimplement/ghimplement.sh
@@ -3,6 +3,14 @@ set -euo pipefail
 
 die() { echo "error: $*" >&2; exit 1; }
 
+# Stage helper: only meaningful when invoked via the _bg launcher (WF_ID set).
+SET_STAGE_SH="$HOME/.claude/skills/_bg/set-stage.sh"
+set_stage() {
+  [[ -n "${WF_ID:-}" ]] || return 0
+  [[ -x "$SET_STAGE_SH" ]] || return 0
+  "$SET_STAGE_SH" "$WF_ID" "$@" >/dev/null 2>&1 || true
+}
+
 # Tee stream-json to stdout while printing a live progress trace of tool_use
 # events to stderr.
 progress_tee() {
@@ -108,6 +116,7 @@ extract_session_id() {
   echo "$sid"
 }
 
+set_stage plan
 echo "==> [1/6] running /ghplan"
 PLAN_OUT=$(claude -p "${CLAUDE_FLAGS[@]}" "/ghplan ${REF:+$REF }${INSTRUCTIONS}" | progress_tee)
 ISSUE_URL=$(extract_gh_url "$PLAN_OUT" \
@@ -120,6 +129,7 @@ echo "    issue: $ISSUE_URL"
 # Record state before 2a so we can verify the model actually did work.
 PRE_HEAD=$(git rev-parse HEAD)
 
+set_stage implement
 echo "==> [2a/6] implementing plan"
 IMPL_OUT=$(claude -p "${CLAUDE_FLAGS[@]}" \
   "Implement the plan in GitHub issue $ISSUE_URL. Read the issue body for the full plan, then make the code changes in this repo. Do not commit or push yet." \
@@ -136,6 +146,7 @@ if [[ -z "$(git status --porcelain)" ]]; then
   die "implementation step produced no changes; refusing to open empty PR"
 fi
 
+set_stage commit-pr
 echo "==> [2b/6] committing + opening PR"
 PR_OUT=$(claude -p "${CLAUDE_FLAGS[@]}" --resume "$IMPL_SESSION" \
   "Now create a new branch named 'issue-${ISSUE_NUM}-<short-slug>' from the default branch, commit the changes with a descriptive message ending in 'Closes #${ISSUE_NUM}', push the branch, and open a PR with 'gh pr create' whose body contains 'Closes #${ISSUE_NUM}'. Print ONLY the PR URL on the final line of your response." | progress_tee)
@@ -146,13 +157,16 @@ PR_URL=$(extract_gh_url "$PR_OUT" \
 PR_NUM=$(basename "$PR_URL")
 echo "    PR: $PR_URL"
 
+set_stage request-copilot
 echo "==> [3/6] requesting Copilot review"
 gh pr edit "$PR_NUM" --repo "$REPO" --add-reviewer copilot-pull-request-reviewer >/dev/null \
   || die "could not request Copilot review (is it enabled in repo settings?)"
 
+set_stage ghreview
 echo "==> [4/6] running /ghreview"
 claude -p "${CLAUDE_FLAGS[@]}" "/ghreview $PR_URL" | progress_tee >/dev/null
 
+set_stage wait-copilot
 echo "==> [5/6] waiting for Copilot review (20s interval, 10min timeout)"
 deadline=$(( $(date +%s) + 600 ))
 while true; do
@@ -171,6 +185,7 @@ while true; do
   sleep 20
 done
 
+set_stage ghaddress
 echo "==> [6/6] running /ghaddress"
 claude -p "${CLAUDE_FLAGS[@]}" "/ghaddress $PR_URL" | progress_tee >/dev/null
 

--- a/skills/localimplement/SKILL.md
+++ b/skills/localimplement/SKILL.md
@@ -34,11 +34,18 @@ Forward them verbatim to the launcher. Quote the instructions string so shell wo
 
 ## What to do
 
-Run the launcher:
+Before invoking the launcher, compose a short (≤60 characters) human-readable phrase that summarizes the task — this becomes the workflow's `description` in status views (`/workflows`, session-summary hook). Examples:
+
+- task "add a /workflows skill that prints status of background pipelines" → `"add /workflows status command"`
+- task "fix the race in the dual-reviewer wait loop" → `"fix dual-reviewer race"`
+
+Pass it as `--description "<phrase>"` before the `localimplement` kind argument:
 
 ```
-~/.claude/skills/_bg/launch.sh localimplement $ARGUMENTS
+~/.claude/skills/_bg/launch.sh --description "<phrase>" localimplement $ARGUMENTS
 ```
+
+If $ARGUMENTS is so terse that a distilled phrase wouldn't add anything, you may omit `--description` — the launcher falls back to the first 60 chars of the instructions.
 
 Report the workflow id, workdir, and log path that it prints. Make clear to the user:
 

--- a/skills/localimplement/localimplement.sh
+++ b/skills/localimplement/localimplement.sh
@@ -133,7 +133,10 @@ run_dual_review() {
   ( run_review "$MODEL_B" "$out_b" "$focus_b" "$context" "$where_field" | progress_tee "$MODEL_B" >/dev/null; exit "${PIPESTATUS[0]}" ) &
   local pid_b=$!
 
-  emit_sub_stage() {
+  # Inner function names leak to the global namespace in bash — prefix with
+  # the outer function name so a grep for `emit_sub_stage` doesn't land here
+  # and so redefinitions from anywhere else can't collide.
+  _run_dual_review_emit_sub() {
     set_stage review-code "$(jq -cn \
         --arg a "$MODEL_A" --arg b "$MODEL_B" \
         --arg as "$1"      --arg bs "$2" \
@@ -141,20 +144,23 @@ run_dual_review() {
   }
 
   local fail=0 a_status="running" b_status="running"
-  emit_sub_stage "$a_status" "$b_status"
+  _run_dual_review_emit_sub "$a_status" "$b_status"
 
   # Poll: whenever a reviewer process exits, harvest its exit code and emit a
   # sub-stage update so the status command can show mid-flight progress.
+  # Correctness depends on bash auto-reaping backgrounded children in
+  # non-interactive script mode, so `kill -0 $pid` on an exited child returns
+  # ESRCH (we treat that as "exited") rather than succeeding against a zombie.
   while [[ "$a_status" == "running" || "$b_status" == "running" ]]; do
     if [[ "$a_status" == "running" ]] && ! kill -0 "$pid_a" 2>/dev/null; then
       wait "$pid_a" || { echo "review $MODEL_A failed" >&2; fail=1; }
       a_status="done"
-      emit_sub_stage "$a_status" "$b_status"
+      _run_dual_review_emit_sub "$a_status" "$b_status"
     fi
     if [[ "$b_status" == "running" ]] && ! kill -0 "$pid_b" 2>/dev/null; then
       wait "$pid_b" || { echo "review $MODEL_B failed" >&2; fail=1; }
       b_status="done"
-      emit_sub_stage "$a_status" "$b_status"
+      _run_dual_review_emit_sub "$a_status" "$b_status"
     fi
     [[ "$a_status" == "running" || "$b_status" == "running" ]] && sleep 2
   done

--- a/skills/localimplement/localimplement.sh
+++ b/skills/localimplement/localimplement.sh
@@ -10,6 +10,16 @@ trap 'trap - INT TERM; kill -- -$$ 2>/dev/null; exit 130' INT TERM
 
 die() { echo "error: $*" >&2; exit 1; }
 
+# Stage helper: only meaningful when this script runs under the _bg launcher
+# (which exports WF_ID and creates ~/.claude/workflows/<WF_ID>/state.json).
+# A direct CLI invocation has no WF_ID and set_stage no-ops.
+SET_STAGE_SH="$HOME/.claude/skills/_bg/set-stage.sh"
+set_stage() {
+  [[ -n "${WF_ID:-}" ]] || return 0
+  [[ -x "$SET_STAGE_SH" ]] || return 0
+  "$SET_STAGE_SH" "$WF_ID" "$@" >/dev/null 2>&1 || true
+}
+
 # Tee stream-json to stdout while printing a live progress trace of tool_use
 # events to stderr. Optional LABEL prefix lets parallel reviewers be told apart.
 progress_tee() {
@@ -122,14 +132,39 @@ run_dual_review() {
   local pid_a=$!
   ( run_review "$MODEL_B" "$out_b" "$focus_b" "$context" "$where_field" | progress_tee "$MODEL_B" >/dev/null; exit "${PIPESTATUS[0]}" ) &
   local pid_b=$!
-  local fail=0
-  wait "$pid_a" || { echo "review $MODEL_A failed" >&2; fail=1; }
-  wait "$pid_b" || { echo "review $MODEL_B failed" >&2; fail=1; }
+
+  emit_sub_stage() {
+    set_stage review-code "$(jq -cn \
+        --arg a "$MODEL_A" --arg b "$MODEL_B" \
+        --arg as "$1"      --arg bs "$2" \
+        '{($a): $as, ($b): $bs}')"
+  }
+
+  local fail=0 a_status="running" b_status="running"
+  emit_sub_stage "$a_status" "$b_status"
+
+  # Poll: whenever a reviewer process exits, harvest its exit code and emit a
+  # sub-stage update so the status command can show mid-flight progress.
+  while [[ "$a_status" == "running" || "$b_status" == "running" ]]; do
+    if [[ "$a_status" == "running" ]] && ! kill -0 "$pid_a" 2>/dev/null; then
+      wait "$pid_a" || { echo "review $MODEL_A failed" >&2; fail=1; }
+      a_status="done"
+      emit_sub_stage "$a_status" "$b_status"
+    fi
+    if [[ "$b_status" == "running" ]] && ! kill -0 "$pid_b" 2>/dev/null; then
+      wait "$pid_b" || { echo "review $MODEL_B failed" >&2; fail=1; }
+      b_status="done"
+      emit_sub_stage "$a_status" "$b_status"
+    fi
+    [[ "$a_status" == "running" || "$b_status" == "running" ]] && sleep 2
+  done
+
   [[ $fail -eq 0 ]] || die "one or more reviews failed"
   [[ -s "$out_a" ]] || die "review $MODEL_A did not produce $out_a"
   [[ -s "$out_b" ]] || die "review $MODEL_B did not produce $out_b"
 }
 
+set_stage plan
 echo "==> [1/4] planning -> $PLAN_FILE"
 claude -p "${CLAUDE_FLAGS[@]}" \
   "Create a detailed implementation plan for the following task and write it to the file \`$PLAN_FILE\`. Use this structure:
@@ -161,6 +196,7 @@ if [[ $IN_GIT -eq 1 ]]; then
     || git commit -m "Add planning artifacts (localimplement $TS)" >/dev/null
 fi
 
+set_stage implement
 echo "==> [2/4] implementing (from $PLAN_FILE)"
 PRE_HEAD=""
 PRE_IMPL_SENTINEL=""
@@ -194,6 +230,7 @@ else
   fi
 fi
 
+set_stage review-code
 echo "==> [3/4] reviewing code in parallel (models: $MODEL_A, $MODEL_B)"
 
 CODE_SCOPE=""
@@ -209,6 +246,7 @@ run_dual_review "$CODE_REVIEW_CONTEXT" "$FOCUS_CODE_A" "$FOCUS_CODE_B" "$REVIEW_
 echo "    holistic code review ($MODEL_A): $REVIEW_CODE_A"
 echo "    detail code review   ($MODEL_B): $REVIEW_CODE_B"
 
+set_stage address-code
 echo "==> [4/4] addressing code reviews"
 ADDRESS_COMMIT_INSTR=""
 [[ $IN_GIT -eq 1 ]] && ADDRESS_COMMIT_INSTR="After making all fixes, stage the changed files by name and create a single git commit titled 'Address review feedback' whose body references both review files. Do not push."

--- a/skills/workflows/SKILL.md
+++ b/skills/workflows/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: workflows
+description: On-demand status of background pipelines launched by /localimplement and /ghimplement. Reads every ~/.claude/workflows/<id>/state.json on the machine and prints one line per active workflow with its kind, current stage, liveness (running / stalled / dead), description, and age. Use to check progress, spot crashed pipelines, or acknowledge (hide) finished ones. Not a project filter by default — set --here to restrict to the current repo.
+argument-hint: [--here] [--ack <id>] [--ack-all]
+allowed-tools: Bash(~/.claude/skills/workflows/workflows.sh:*)
+---
+
+You are running the `workflows` status command. It reads the persistent state under `~/.claude/workflows/` and summarizes every active (not-yet-acknowledged) background workflow across every project on this machine.
+
+## What to do
+
+Run the script and print its output verbatim to the user — do not paraphrase or summarize:
+
+```
+~/.claude/skills/workflows/workflows.sh $ARGUMENTS
+```
+
+The script produces a small table. Each row is one workflow:
+
+- `KIND` — `local` (from `/localimplement`) or `gh` (from `/ghimplement`).
+- `ID` — short (6-hex) workflow identifier. Use it with `--ack <id>` to mark a dead workflow acknowledged (which hides it from future runs of this command).
+- `STAGE` — the pipeline's current stage name (e.g. `plan`, `implement`, `review-code`). For parallel reviewers, a parenthesized sub-stage shows each reviewer's state (e.g. `review-code (opus=done,sonnet=running)`).
+- `LIVENESS` — `running`, `stalled:<reason>`, or `dead:<reason>`.
+- `AGE` — time since launch.
+- `DESCRIPTION` — the short human phrase captured at launch.
+
+## Flags
+
+- (default, no flag): list all active workflows on this machine.
+- `--here`: restrict to workflows whose project_root matches the current working directory's git toplevel.
+- `--ack <id>`: mark a finished/dead workflow as acknowledged (hides it from subsequent lists). Accepts full id or a substring.
+- `--ack-all`: acknowledge every dead/finished workflow.
+
+## Do not
+
+- Do not re-render or summarize the output — print the script's stdout verbatim inside a code block.
+- Do not chain this with other commands to "help" the user parse it; the tabular format is already scannable.

--- a/skills/workflows/workflows.sh
+++ b/skills/workflows/workflows.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# /workflows — on-demand status of background workflow pipelines.
+# Reads every ~/.claude/workflows/<id>/state.json, applies the shared liveness
+# classifier, and prints one scannable line per workflow.
+#
+# Exit 0 always: an unexpected error logs to stderr and falls through. Same
+# "never break a session" principle as the session-summary hook.
+set -u
+
+STATE_ROOT="$HOME/.claude/workflows"
+
+command -v jq >/dev/null 2>&1 || { echo "jq not found" >&2; exit 0; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Try script-relative first (running out of the repo worktree), then the
+# installed ~/.claude path. Keep going if neither exists — we'll degrade
+# to a minimal "can't classify" rendering.
+LIVENESS_LIB=""
+for p in \
+    "$SCRIPT_DIR/../_bg/liveness.sh" \
+    "$HOME/.claude/skills/_bg/liveness.sh"; do
+    if [[ -f "$p" ]]; then
+        LIVENESS_LIB="$p"
+        break
+    fi
+done
+if [[ -n "$LIVENESS_LIB" ]]; then
+    # shellcheck disable=SC1090
+    source "$LIVENESS_LIB"
+else
+    liveness_of_state_file() { echo "unknown"; }
+fi
+
+MODE="list"
+TARGET=""
+HERE_ONLY=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --all)     MODE="list"; shift ;;
+        --here)    HERE_ONLY=1; shift ;;
+        --ack)     MODE="ack"; TARGET="${2:-}"; shift 2 || true ;;
+        --ack-all) MODE="ack-all"; shift ;;
+        -h|--help)
+            cat <<'EOF'
+usage: workflows.sh [--here] [--ack <id>] [--ack-all]
+
+  (default)      List all active workflows on this machine.
+  --here         Only workflows whose project_root matches this repo.
+  --ack <id>     Acknowledge (hide) a finished/dead workflow. Accepts
+                 full id or a unique substring.
+  --ack-all      Acknowledge every finished/dead workflow.
+EOF
+            exit 0 ;;
+        *) echo "unknown argument: $1" >&2; shift ;;
+    esac
+done
+
+if [[ ! -d "$STATE_ROOT" ]]; then
+    echo "No workflows have been launched on this machine."
+    exit 0
+fi
+
+# Resolve "here" once if needed.
+HERE_ROOT=""
+if [[ $HERE_ONLY -eq 1 ]]; then
+    HERE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+fi
+
+short_id() {
+    # Workflow id is "<UTC-stamp>-<pid>-<rand6>". Return the trailing rand6 for
+    # a compact table column; fall back to last 8 chars if the format differs.
+    local id="$1"
+    if [[ "$id" =~ -([a-f0-9]{6})$ ]]; then
+        echo "${BASH_REMATCH[1]}"
+    else
+        echo "${id: -8}"
+    fi
+}
+
+# Portable ISO-8601 → epoch. Tries GNU `date -d` first, then BSD `date -j -f`.
+iso_to_epoch() {
+    local iso="$1" e
+    [[ -n "$iso" ]] || { echo ""; return; }
+    e=$(date -u -d "$iso" +%s 2>/dev/null) || \
+        e=$(date -uj -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null) || e=""
+    echo "$e"
+}
+
+humanize_age() {
+    local started_at="$1" then now diff
+    then=$(iso_to_epoch "$started_at")
+    [[ -n "$then" ]] || { echo "-"; return; }
+    now=$(date -u +%s)
+    diff=$(( now - then ))
+    if   (( diff < 60    )); then echo "${diff}s"
+    elif (( diff < 3600  )); then echo "$((diff/60))m"
+    elif (( diff < 86400 )); then echo "$((diff/3600))h"
+    else                          echo "$((diff/86400))d"
+    fi
+}
+
+render_sub_stage() {
+    local sub="$1"
+    [[ -n "$sub" && "$sub" != "null" ]] || { echo ""; return; }
+    # Prefer JSON object rendering; if not valid JSON, echo the string as-is.
+    local rendered
+    rendered=$(jq -er 'to_entries | map("\(.key)=\(.value)") | join(",")' \
+               <<<"$sub" 2>/dev/null) && { echo "$rendered"; return; }
+    echo "$sub"
+}
+
+shopt -s nullglob
+
+# --ack / --ack-all branches.
+if [[ "$MODE" == "ack" ]]; then
+    if [[ -z "$TARGET" ]]; then
+        echo "usage: workflows.sh --ack <id>" >&2
+        exit 0
+    fi
+    matched=0
+    for sf in "$STATE_ROOT"/*/state.json; do
+        d=$(dirname "$sf")
+        id=$(basename "$d")
+        [[ "$id" == *"$TARGET"* ]] || continue
+        # Only acknowledge workflows that are actually finished or dead —
+        # refusing to acknowledge a live running workflow avoids hiding
+        # something the user still cares about.
+        live=$(liveness_of_state_file "$sf")
+        case "$live" in
+            dead:*|stalled:*)
+                touch "$d/acknowledged" 2>/dev/null || true
+                echo "acknowledged $id ($live)"
+                matched=$((matched + 1))
+                ;;
+            *)
+                echo "skipping $id: $live (use --ack-all to force-acknowledge nothing alive)"
+                ;;
+        esac
+    done
+    (( matched == 0 )) && echo "no finished/dead workflow matched: $TARGET"
+    exit 0
+fi
+
+if [[ "$MODE" == "ack-all" ]]; then
+    matched=0
+    for sf in "$STATE_ROOT"/*/state.json; do
+        d=$(dirname "$sf")
+        live=$(liveness_of_state_file "$sf")
+        if [[ "$live" == dead:* || "$live" == stalled:* ]]; then
+            touch "$d/acknowledged" 2>/dev/null || true
+            echo "acknowledged $(basename "$d") ($live)"
+            matched=$((matched + 1))
+        fi
+    done
+    (( matched == 0 )) && echo "nothing to acknowledge."
+    exit 0
+fi
+
+# Default MODE=list. Collect rows for sorting by started_at.
+rows=()
+for sf in "$STATE_ROOT"/*/state.json; do
+    d=$(dirname "$sf")
+    [[ -f "$sf" ]] || continue
+    # Acknowledged entries are hidden from the list view.
+    [[ -f "$d/acknowledged" ]] && continue
+
+    # One jq fork, fields joined by ASCII Unit Separator (\x1f). We can't use
+    # @tsv + IFS=$'\t' here: bash classifies tab as IFS-whitespace, so a
+    # sequence like "a\t\tb" collapses into just two fields, which silently
+    # loses empty-string columns (e.g. a workflow with no sub_stage). US is
+    # non-whitespace, so consecutive separators preserve empty fields.
+    IFS=$'\x1f' read -r id kind pr stage sub desc started_at < <(
+        jq -r '[.id,
+                .kind,
+                (.project_root // ""),
+                (.stage // ""),
+                (if (.sub_stage|type)=="object" then (.sub_stage|tojson)
+                 else (.sub_stage // "" | tostring) end),
+                (.description // .instructions // ""),
+                (.started_at // "")] | join("\u001f")' "$sf" 2>/dev/null || true
+    )
+    [[ -n "$id" ]] || continue
+
+    if [[ $HERE_ONLY -eq 1 && -n "$HERE_ROOT" && "$pr" != "$HERE_ROOT" ]]; then
+        continue
+    fi
+
+    live=$(liveness_of_state_file "$sf")
+    stage_disp="${stage:--}"
+    sub_disp=$(render_sub_stage "$sub")
+    [[ -n "$sub_disp" ]] && stage_disp+=" ($sub_disp)"
+
+    # Trim noisy long fields.
+    stage_trim="${stage_disp:0:38}"
+    live_trim="${live:0:28}"
+    desc_trim="${desc:0:60}"
+    age=$(humanize_age "$started_at")
+    kind_short="${kind:0:5}"
+    sid=$(short_id "$id")
+
+    # started_at sorts lexicographically because the format is ISO-8601-Z.
+    # Use US (\x1f) as the in-band separator: same rationale as the jq
+    # pipeline above — empty columns (e.g. missing stage) must survive `read`.
+    rows+=("${started_at}"$'\x1f'"${kind_short}"$'\x1f'"${sid}"$'\x1f'"${stage_trim}"$'\x1f'"${live_trim}"$'\x1f'"${age}"$'\x1f'"${desc_trim}")
+done
+
+if (( ${#rows[@]} == 0 )); then
+    if [[ $HERE_ONLY -eq 1 ]]; then
+        echo "No active workflows for project: $HERE_ROOT"
+    else
+        echo "No active workflows on this machine."
+    fi
+    exit 0
+fi
+
+# Sort ascending by started_at (oldest first). Read back into an array.
+sorted_rows=()
+while IFS= read -r line; do
+    sorted_rows+=("$line")
+done < <(printf '%s\n' "${rows[@]}" | sort)
+
+# Header + rows. Column widths are fixed; columns will overflow gracefully if
+# content exceeds them (no truncation beyond the pre-trim above).
+FMT='%-5s  %-8s  %-38s  %-28s  %-5s  %s\n'
+# shellcheck disable=SC2059
+printf "$FMT" "KIND" "ID" "STAGE" "LIVENESS" "AGE" "DESCRIPTION"
+for row in "${sorted_rows[@]}"; do
+    IFS=$'\x1f' read -r _ kind sid stage live age desc <<<"$row"
+    # shellcheck disable=SC2059
+    printf "$FMT" "$kind" "$sid" "$stage" "$live" "$age" "$desc"
+done
+
+exit 0

--- a/skills/workflows/workflows.sh
+++ b/skills/workflows/workflows.sh
@@ -38,7 +38,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --all)     MODE="list"; shift ;;
         --here)    HERE_ONLY=1; shift ;;
-        --ack)     MODE="ack"; TARGET="${2:-}"; shift 2 || true ;;
+        --ack)     MODE="ack"; TARGET="${2:-}"; shift; [[ -n "$TARGET" ]] && shift ;;
         --ack-all) MODE="ack-all"; shift ;;
         -h|--help)
             cat <<'EOF'
@@ -46,9 +46,10 @@ usage: workflows.sh [--here] [--ack <id>] [--ack-all]
 
   (default)      List all active workflows on this machine.
   --here         Only workflows whose project_root matches this repo.
-  --ack <id>     Acknowledge (hide) a finished/dead workflow. Accepts
-                 full id or a unique substring.
-  --ack-all      Acknowledge every finished/dead workflow.
+  --ack <id>     Acknowledge (hide) a dead/finished workflow. Accepts a
+                 full id or a unique substring; ambiguous substrings abort.
+  --ack-all      Acknowledge every dead/finished workflow (stalled ones
+                 are still alive and must be ack'd individually).
 EOF
             exit 0 ;;
         *) echo "unknown argument: $1" >&2; shift ;;
@@ -117,27 +118,43 @@ if [[ "$MODE" == "ack" ]]; then
         echo "usage: workflows.sh --ack <id>" >&2
         exit 0
     fi
-    matched=0
+    # Collect substring matches first: if >1 workflow id contains TARGET, refuse
+    # to ack any of them so a common fragment (e.g. a date) can't silently
+    # dismiss a whole batch.
+    matches=()
     for sf in "$STATE_ROOT"/*/state.json; do
         d=$(dirname "$sf")
         id=$(basename "$d")
         [[ "$id" == *"$TARGET"* ]] || continue
-        # Only acknowledge workflows that are actually finished or dead —
-        # refusing to acknowledge a live running workflow avoids hiding
-        # something the user still cares about.
-        live=$(liveness_of_state_file "$sf")
-        case "$live" in
-            dead:*|stalled:*)
-                touch "$d/acknowledged" 2>/dev/null || true
-                echo "acknowledged $id ($live)"
-                matched=$((matched + 1))
-                ;;
-            *)
-                echo "skipping $id: $live (use --ack-all to force-acknowledge nothing alive)"
-                ;;
-        esac
+        matches+=("$sf")
     done
-    (( matched == 0 )) && echo "no finished/dead workflow matched: $TARGET"
+    if (( ${#matches[@]} == 0 )); then
+        echo "no workflow matched: $TARGET"
+        exit 0
+    fi
+    if (( ${#matches[@]} > 1 )); then
+        echo "ambiguous id '$TARGET' matched ${#matches[@]} workflows — use a longer prefix:"
+        for sf in "${matches[@]}"; do
+            echo "  $(basename "$(dirname "$sf")")"
+        done
+        exit 0
+    fi
+    sf="${matches[0]}"
+    d=$(dirname "$sf")
+    id=$(basename "$d")
+    # Only acknowledge workflows that are actually dead/finished. A stalled
+    # workflow is still running (just quiet), so hiding it could bury a
+    # slow-but-alive pipeline the user still cares about.
+    live=$(liveness_of_state_file "$sf")
+    case "$live" in
+        dead:*)
+            touch "$d/acknowledged" 2>/dev/null || true
+            echo "acknowledged $id ($live)"
+            ;;
+        *)
+            echo "skipping $id ($live is still running; only dead/finished workflows can be acknowledged)"
+            ;;
+    esac
     exit 0
 fi
 
@@ -146,7 +163,9 @@ if [[ "$MODE" == "ack-all" ]]; then
     for sf in "$STATE_ROOT"/*/state.json; do
         d=$(dirname "$sf")
         live=$(liveness_of_state_file "$sf")
-        if [[ "$live" == dead:* || "$live" == stalled:* ]]; then
+        # Dead-only: stalled workflows still have a live pid and may still
+        # produce output. Users can ack them individually once they crash.
+        if [[ "$live" == dead:* ]]; then
             touch "$d/acknowledged" 2>/dev/null || true
             echo "acknowledged $(basename "$d") ($live)"
             matched=$((matched + 1))
@@ -195,7 +214,11 @@ for sf in "$STATE_ROOT"/*/state.json; do
     live_trim="${live:0:28}"
     desc_trim="${desc:0:60}"
     age=$(humanize_age "$started_at")
-    kind_short="${kind:0:5}"
+    case "$kind" in
+        localimplement) kind_short=local ;;
+        ghimplement)    kind_short=gh    ;;
+        *)              kind_short="$kind" ;;
+    esac
     sid=$(short_id "$id")
 
     # started_at sorts lexicographically because the format is ISO-8601-Z.


### PR DESCRIPTION
## Summary

- Background `/localimplement` and `/ghimplement` pipelines now record their current stage (and reviewer sub-stage) into `state.json` as they advance, so the SessionStart / UserPromptSubmit hook can surface *where* each workflow is rather than just "running".
- New `/workflows` skill prints a machine-wide table (kind, stage, liveness, description, age) of every active pipeline, with `--ack` / `--ack-all` to hide finished runs. Liveness classification is factored into `skills/_bg/liveness.sh` so the hook and the new command never disagree.
- `skills/_bg/launch.sh` accepts `--description` for a short human phrase; `SKILL.md` for both pipelines instructs the wrapper Claude to pass one.
- Addresses the two code-review passes archived under `.claude-workflow/20260420-124831/` (fixes to `--ack` arg handling, `[local]`/`[gh]` kind labels, dual-review emitter scoping, liveness fallback, etc.).

Files: `skills/_bg/{launch,liveness,session-summary,set-stage}.sh`, `skills/{ghimplement,localimplement,workflows}/` (SKILL.md + scripts), plus planning/review artifacts under `.claude-workflow/20260420-124831/`.

## Test plan

- [ ] `scripts/sync.sh push --dry-run -y` shows the new `skills/_bg/{liveness,set-stage}.sh` and `skills/workflows/` rsyncing into `~/.claude/`, no pending deletions over threshold.
- [ ] After sync: run `/localimplement` on a trivial change and confirm the SessionStart hook reports the stage advancing (plan → implement → review → address).
- [ ] `/workflows` lists the run with a non-empty stage column and a `[local]` kind; `/workflows --ack <id>` hides it once finished.
- [ ] `/workflows --ack <ambiguous-substring>` refuses and lists candidates instead of silently acking all matches.
- [ ] Kill a running workflow's PID out-of-band; confirm both the hook and `/workflows` classify it as `dead` (not `running`) via the shared `liveness.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)