### PR TITLE
Keep workflow artifacts off the product branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The skills cluster into a GitHub-issue-driven pipeline and a local pipeline (`/l
 - [`/ghimplement`](skills/ghimplement/SKILL.md) — run the full pipeline end-to-end via [`skills/ghimplement/ghimplement.sh`](skills/ghimplement/ghimplement.sh).
 - [`/ghreview`](skills/ghreview/SKILL.md) — review a PR and post inline comments.
 - [`/ghaddress`](skills/ghaddress/SKILL.md) — address review comments on a PR and reply to each thread.
-- [`/localimplement`](skills/localimplement/SKILL.md) — local (no-GitHub) counterpart to `/ghimplement`: runs plan → implement → review-code ×2 → address-code locally via [`skills/localimplement/localimplement.sh`](skills/localimplement/localimplement.sh), with all artifacts written to `.claude-workflow/<timestamp>/`.
+- [`/localimplement`](skills/localimplement/SKILL.md) — local (no-GitHub) counterpart to `/ghimplement`: runs plan → implement → review-code ×2 → address-code locally via [`skills/localimplement/localimplement.sh`](skills/localimplement/localimplement.sh), with all artifacts written to `~/.claude/workflows/<id>/artifacts/` (off the product branch).
 
 `skills/ghimplement/ghimplement.sh` chains them: `/ghplan` → implement → `/ghreview` (Copilot + Claude) → `/ghaddress`, producing a merged-ready PR from a single instruction.
 

--- a/skills/_bg/finish.sh
+++ b/skills/_bg/finish.sh
@@ -47,8 +47,9 @@ SETUP_KIND=$(jq  -r '.setup_kind   // empty' "$STATE_FILE" 2>/dev/null || true)
 
 # Worktree cleanup: on success only, for both setup kinds. ghimplement
 # (SETUP_KIND=worktree) has already pushed its branch; localimplement
-# (SETUP_KIND=worktree-branch) has committed its .claude-workflow/<ts>/
-# artifacts to the branch, which persists after worktree removal.
+# (SETUP_KIND=worktree-branch) has committed code changes to its branch, and
+# its plan/review artifacts live under $STATE_DIR/artifacts/ — outside the
+# worktree, so they survive removal independently.
 # On failure (EC != 0) we leave the worktree in place for debugging.
 if [[ "$EC" == "0" \
       && ( "$SETUP_KIND" == "worktree" || "$SETUP_KIND" == "worktree-branch" ) \

--- a/skills/_bg/launch.sh
+++ b/skills/_bg/launch.sh
@@ -161,10 +161,9 @@ mkdir -p "$STATE_DIR" || die "could not create state dir: $STATE_DIR"
 
 # Isolated workdir setup. For localimplement in a git repo we create a named
 # branch (bg/localimplement/<WF_ID>) so the commits the pipeline makes stay
-# reachable after finish.sh runs — the worktree itself is also preserved on
-# disk so the user can inspect .claude-workflow/<ts>/ artifacts. For
-# ghimplement we use --detach because the pipeline's stage 2b creates and
-# pushes its own issue-N-<slug> branch; a named bg/* ref would be a no-op.
+# reachable after finish.sh runs. For ghimplement we use --detach because the
+# pipeline's stage 2b creates and pushes its own issue-N-<slug> branch; a
+# named bg/* ref would be a no-op.
 BRANCH=""
 if [[ $IS_GIT -eq 1 ]]; then
     WORKDIR=$(mktemp -d -t "aibg-$KIND.XXXXXX") || die "mktemp failed"

--- a/skills/ghimplement/ghimplement.sh
+++ b/skills/ghimplement/ghimplement.sh
@@ -132,7 +132,7 @@ PRE_HEAD=$(git rev-parse HEAD)
 set_stage implement
 echo "==> [2a/6] implementing plan"
 IMPL_OUT=$(claude -p "${CLAUDE_FLAGS[@]}" \
-  "Implement the plan in GitHub issue $ISSUE_URL. Read the issue body for the full plan, then make the code changes in this repo. Do not commit or push yet." \
+  "Implement the plan in GitHub issue $ISSUE_URL. Read the issue body for the full plan, then make the code changes in this repo. Do not commit or push yet. Do NOT create any meta/scaffolding files in the repo — no \`.claude-workflow/\` directory, no \`plan.md\`, no review docs, no notes-to-self. The plan lives in the GitHub issue and reviews go to PR comments; the only changes in this working tree should be product code." \
   | progress_tee)
 IMPL_SESSION=$(extract_session_id "$IMPL_OUT")
 

--- a/skills/localimplement/SKILL.md
+++ b/skills/localimplement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: localimplement
-description: Run the end-to-end plan → implement → review-code → address-code workflow in the background by invoking ~/.claude/skills/_bg/launch.sh. All artifacts (plan, code reviews) land inside the isolated workdir's `.claude-workflow/<timestamp>/`; the code review uses two different models in parallel. The launcher returns immediately; you'll be notified when the pipeline finishes.
+description: Run the end-to-end plan → implement → review-code → address-code workflow in the background by invoking ~/.claude/skills/_bg/launch.sh. Plan and code reviews land in `~/.claude/workflows/<workflow-id>/artifacts/` alongside the run log (kept off the product branch); the code review uses two different models in parallel. The launcher returns immediately; you'll be notified when the pipeline finishes.
 argument-hint: [-a <model>] [-b <model>] <instructions>
 allowed-tools: Bash(~/.claude/skills/_bg/launch.sh:*)
 ---
@@ -16,15 +16,17 @@ A `SessionStart` / `UserPromptSubmit` hook notifies a future Claude session for 
 
 ## Where artifacts go
 
-The pipeline commits both code changes and `.claude-workflow/<timestamp>/` artifacts to the `bg/localimplement/<workflow-id>` branch in the user's main repo. Point the user at:
+Plan and code-review artifacts live outside the product branch — they are scaffolding, not product. Point the user at:
 
+- `~/.claude/workflows/<workflow-id>/artifacts/plan.md` — the implementation plan.
+- `~/.claude/workflows/<workflow-id>/artifacts/review-code-holistic-<model>.md` and `review-code-detail-<model>.md` — the two parallel code reviews.
 - `~/.claude/workflows/<workflow-id>/log` — combined stdout/stderr of the pipeline.
 - `~/.claude/workflows/<workflow-id>/state.json` — workflow status, exit code, workdir path, branch name.
-- `bg/localimplement/<workflow-id>` — durable branch with the code changes plus `.claude-workflow/<ts>/` (plan.md, review-code-*.md). From the main working tree: `git checkout bg/localimplement/<workflow-id>` to inspect, merge, or discard.
+- `bg/localimplement/<workflow-id>` — durable branch with **only** the code changes (no scaffolding). From the main working tree: `git checkout bg/localimplement/<workflow-id>` to inspect, merge, or discard. A squash-merge pulls in product code cleanly.
 
-Commits on the branch, in order: planning artifacts → implementation → "Address review feedback" (absent if reviewers found nothing) → code-review artifacts.
+Commits on the branch, in order: implementation → "Address review feedback" (absent if reviewers found nothing).
 
-On success the isolated worktree is removed — `state.json`'s `workdir` field will point to a nonexistent path, which is expected (the branch is the durable artifact). On failure the worktree is preserved for debugging at the path still recorded in `state.json`.
+On success the isolated worktree is removed — `state.json`'s `workdir` field will point to a nonexistent path, which is expected (the branch is the durable code record; the artifacts directory is the durable review record). On failure the worktree is preserved for debugging at the path still recorded in `state.json`.
 
 ## Arguments
 

--- a/skills/localimplement/localimplement.sh
+++ b/skills/localimplement/localimplement.sh
@@ -62,8 +62,14 @@ command -v jq >/dev/null     || die "jq not found"
 # and survive worktree removal. Direct CLI invocation falls back to the old
 # in-tree `.claude-workflow/<ts>/` path — convenient for ad-hoc use, but the
 # user is on their own to gitignore or clean it up.
+#
+# WF_ID is interpolated into a filesystem path under $HOME, so validate it
+# against a conservative charset to prevent path traversal (e.g. "../") or
+# embedded slashes when it's set externally. The _bg launcher produces IDs
+# matching ^[a-z0-9-]+$, so this pattern is a strict superset.
 TS=$(date +%Y%m%d-%H%M%S)
 if [[ -n "${WF_ID:-}" ]]; then
+  [[ "$WF_ID" =~ ^[A-Za-z0-9._-]+$ ]] || die "invalid WF_ID: $WF_ID"
   SESSION_DIR="$HOME/.claude/workflows/$WF_ID/artifacts"
 else
   SESSION_DIR=".claude-workflow/$TS"
@@ -212,7 +218,10 @@ else
 fi
 
 IMPL_COMMIT_INSTR="."
-[[ $IN_GIT -eq 1 ]] && IMPL_COMMIT_INSTR=", stage the changed files by name and create a single git commit with a clear message that references \`$PLAN_FILE\`. Do not push."
+# The commit message references `plan.md` (the artifact basename) rather than
+# `$PLAN_FILE` — under the _bg launcher the latter is an absolute user-specific
+# path under ~/.claude/workflows/ that would end up in git history otherwise.
+[[ $IN_GIT -eq 1 ]] && IMPL_COMMIT_INSTR=", stage the changed files by name and create a single git commit with a clear message that references the implementation plan (refer to it as \`plan.md\` in the commit message, not by absolute path). Do NOT create any meta/scaffolding files in the repo — no \`.claude-workflow/\` directory, no \`plan.md\`, no review docs, no notes-to-self. Do not push."
 
 claude -p "${CLAUDE_FLAGS[@]}" \
   "Read the implementation plan at \`$PLAN_FILE\` and implement every task in it by editing code in this repo. When the implementation is complete${IMPL_COMMIT_INSTR}" \

--- a/skills/localimplement/localimplement.sh
+++ b/skills/localimplement/localimplement.sh
@@ -57,11 +57,17 @@ done
 command -v claude >/dev/null || die "claude CLI not found"
 command -v jq >/dev/null     || die "jq not found"
 
-# Session directory under CWD. Everything produced by this run — the plan,
-# both code reviews, and implicitly any working-tree diff — lives here so the
-# user can inspect or discard the full artifact set as a unit.
+# Session directory. Under the _bg launcher (WF_ID set) artifacts live under
+# ~/.claude/workflows/<WF_ID>/artifacts/ so they stay out of the product branch
+# and survive worktree removal. Direct CLI invocation falls back to the old
+# in-tree `.claude-workflow/<ts>/` path — convenient for ad-hoc use, but the
+# user is on their own to gitignore or clean it up.
 TS=$(date +%Y%m%d-%H%M%S)
-SESSION_DIR=".claude-workflow/$TS"
+if [[ -n "${WF_ID:-}" ]]; then
+  SESSION_DIR="$HOME/.claude/workflows/$WF_ID/artifacts"
+else
+  SESSION_DIR=".claude-workflow/$TS"
+fi
 mkdir -p "$SESSION_DIR"
 PLAN_FILE="$SESSION_DIR/plan.md"
 REVIEW_CODE_A="$SESSION_DIR/review-code-holistic-$MODEL_A.md"
@@ -194,14 +200,6 @@ Task: $INSTRUCTIONS" \
   | progress_tee >/dev/null
 [[ -s "$PLAN_FILE" ]] || die "plan stage did not produce $PLAN_FILE"
 
-# Commit planning artifacts to the branch so the session dir survives worktree
-# removal. -f bypasses a user-side .gitignore that lists .claude-workflow/.
-if [[ $IN_GIT -eq 1 ]]; then
-  git add -f "$SESSION_DIR"
-  git diff --cached --quiet \
-    || git commit -m "Add planning artifacts (localimplement $TS)" >/dev/null
-fi
-
 set_stage implement
 echo "==> [2/4] implementing (from $PLAN_FILE)"
 PRE_HEAD=""
@@ -214,7 +212,7 @@ else
 fi
 
 IMPL_COMMIT_INSTR="."
-[[ $IN_GIT -eq 1 ]] && IMPL_COMMIT_INSTR=", stage the changed files by name and create a single git commit with a clear message that references \`$PLAN_FILE\`. Do NOT stage anything under \`.claude-workflow/\` — those files are owned by the workflow script and will be committed separately. Do not push."
+[[ $IN_GIT -eq 1 ]] && IMPL_COMMIT_INSTR=", stage the changed files by name and create a single git commit with a clear message that references \`$PLAN_FILE\`. Do not push."
 
 claude -p "${CLAUDE_FLAGS[@]}" \
   "Read the implementation plan at \`$PLAN_FILE\` and implement every task in it by editing code in this repo. When the implementation is complete${IMPL_COMMIT_INSTR}" \
@@ -268,14 +266,6 @@ $ADDRESS_COMMIT_INSTR
 
 End with a short summary (to stdout) of: what you addressed, what you skipped and why." \
   | progress_tee >/dev/null
-
-# Commit code-review artifacts. The guard is load-bearing: the model's
-# "Address review feedback" commit above may already have swept in review files.
-if [[ $IN_GIT -eq 1 ]]; then
-  git add -f "$SESSION_DIR"
-  git diff --cached --quiet \
-    || git commit -m "Add code-review artifacts (localimplement $TS)" >/dev/null
-fi
 
 echo ""
 echo "done. session artifacts in: $SESSION_DIR"


### PR DESCRIPTION
## Summary

- `/localimplement` artifacts (plan + code reviews) now land in `~/.claude/workflows/<WF_ID>/artifacts/` instead of being committed to the `bg/localimplement/<id>` branch. The branch carries only product commits (implementation → "Address review feedback"), so a squash-merge pulls in clean code with no scaffolding tail.
- `/ghimplement`'s step-2a prompt gains a defensive clause forbidding the model from creating `.claude-workflow/`, `plan.md`, or review docs in the repo, preserving the PR-diff-is-product-only invariant explicitly.
- Direct CLI use of `localimplement.sh` (no `WF_ID`) still falls back to in-tree `.claude-workflow/<ts>/`.
- Doc/comment churn: `SKILL.md`, `README.md`, `launch.sh`, `finish.sh` updated to match.

Closes #13

## Test plan

- [ ] Run `/localimplement` end-to-end; `git log --stat bg/localimplement/<id>` shows zero `.claude-workflow/` paths in any commit.
- [ ] `~/.claude/workflows/<id>/artifacts/` contains `plan.md` plus both `review-code-*.md` files.
- [ ] `~/.claude/workflows/<id>/` still contains `log`, `state.json`, `pid`, `finished`.
- [ ] Squash-merge the branch into a throwaway branch; diff contains only product code, no scaffolding.
- [ ] Run `/ghimplement` end-to-end; `gh pr diff <num>` contains zero `.claude-workflow/` paths.
- [ ] Kill the pipeline mid-run (e.g. during stage 2); artifacts produced up to that point are readable under `~/.claude/workflows/<id>/artifacts/`.
- [ ] Run `localimplement.sh` directly (no launcher, `WF_ID` unset); artifacts land in `.claude-workflow/<ts>/` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)