### PR TITLE
Move workflow runtime state out of ~/.claude/ to XDG_STATE_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The skills cluster into a GitHub-issue-driven pipeline and a local pipeline (`/l
 - [`/ghimplement`](skills/ghimplement/SKILL.md) — run the full pipeline end-to-end via [`skills/ghimplement/ghimplement.sh`](skills/ghimplement/ghimplement.sh).
 - [`/ghreview`](skills/ghreview/SKILL.md) — review a PR and post inline comments.
 - [`/ghaddress`](skills/ghaddress/SKILL.md) — address review comments on a PR and reply to each thread.
-- [`/localimplement`](skills/localimplement/SKILL.md) — local (no-GitHub) counterpart to `/ghimplement`: runs plan → implement → review-code ×2 → address-code locally via [`skills/localimplement/localimplement.sh`](skills/localimplement/localimplement.sh), with all artifacts written to `~/.claude/workflows/<id>/artifacts/` (off the product branch).
+- [`/localimplement`](skills/localimplement/SKILL.md) — local (no-GitHub) counterpart to `/ghimplement`: runs plan → implement → review-code ×2 → address-code locally via [`skills/localimplement/localimplement.sh`](skills/localimplement/localimplement.sh), with all artifacts written to `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<id>/artifacts/` (off the product branch).
 
 `skills/ghimplement/ghimplement.sh` chains them: `/ghplan` → implement → `/ghreview` (Copilot + Claude) → `/ghaddress`, producing a merged-ready PR from a single instruction.
 
@@ -59,7 +59,7 @@ Both `/ghimplement` and `/localimplement` run **in the background**. Their SKILL
 
 - Creates an isolated worktree (via `git worktree add --detach` for git projects, `cp -a` otherwise) so concurrent invocations don't collide.
 - Spawns the pipeline detached (subshell + `nohup`), so it survives `Ctrl-C`, shell exit, and Claude Code quitting.
-- Records per-workflow state under `~/.claude/workflows/<id>/` (`state.json`, combined `log`, `finished` / `acknowledged` markers) — intentionally **not** synced, since it's runtime state, not config. [`skills/_bg/finish.sh`](skills/_bg/finish.sh) writes the terminal `status` / `exit_code` and drops the `finished` marker that `session-summary.sh` keys off.
+- Records per-workflow state under `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<id>/` (`state.json`, combined `log`, `finished` / `acknowledged` markers) — deliberately rooted outside `~/.claude/` so Claude Code's sensitive-file guardrail doesn't block subagent writes. [`skills/_bg/finish.sh`](skills/_bg/finish.sh) writes the terminal `status` / `exit_code` and drops the `finished` marker that `session-summary.sh` keys off.
 - Returns within ~1s with the workflow id, workdir, log path, and state-file path.
 
 A pair of hooks (`SessionStart` + `UserPromptSubmit`, wired in [`settings.json`](settings.json)) invokes [`skills/_bg/session-summary.sh`](skills/_bg/session-summary.sh), which reports running and newly-finished workflows for the current project so you're notified the next time you open Claude Code in that tree. Acknowledged state dirs older than 14 days are pruned on the next hook firing.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The skills cluster into a GitHub-issue-driven pipeline and a local pipeline (`/l
 - [`/ghimplement`](skills/ghimplement/SKILL.md) — run the full pipeline end-to-end via [`skills/ghimplement/ghimplement.sh`](skills/ghimplement/ghimplement.sh).
 - [`/ghreview`](skills/ghreview/SKILL.md) — review a PR and post inline comments.
 - [`/ghaddress`](skills/ghaddress/SKILL.md) — address review comments on a PR and reply to each thread.
-- [`/localimplement`](skills/localimplement/SKILL.md) — local (no-GitHub) counterpart to `/ghimplement`: runs plan → implement → review-code ×2 → address-code locally via [`skills/localimplement/localimplement.sh`](skills/localimplement/localimplement.sh), with all artifacts written to `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<id>/artifacts/` (off the product branch).
+- [`/localimplement`](skills/localimplement/SKILL.md) — local (no-GitHub) counterpart to `/ghimplement`: runs plan → implement → review-code ×2 → address-code locally via [`skills/localimplement/localimplement.sh`](skills/localimplement/localimplement.sh), with all artifacts written to `~/.local/state/claude-workflows/<id>/artifacts/` (off the product branch).
 
 `skills/ghimplement/ghimplement.sh` chains them: `/ghplan` → implement → `/ghreview` (Copilot + Claude) → `/ghaddress`, producing a merged-ready PR from a single instruction.
 
@@ -59,7 +59,7 @@ Both `/ghimplement` and `/localimplement` run **in the background**. Their SKILL
 
 - Creates an isolated worktree (via `git worktree add --detach` for git projects, `cp -a` otherwise) so concurrent invocations don't collide.
 - Spawns the pipeline detached (subshell + `nohup`), so it survives `Ctrl-C`, shell exit, and Claude Code quitting.
-- Records per-workflow state under `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<id>/` (`state.json`, combined `log`, `finished` / `acknowledged` markers) — deliberately rooted outside `~/.claude/` so Claude Code's sensitive-file guardrail doesn't block subagent writes. [`skills/_bg/finish.sh`](skills/_bg/finish.sh) writes the terminal `status` / `exit_code` and drops the `finished` marker that `session-summary.sh` keys off.
+- Records per-workflow state under `~/.local/state/claude-workflows/<id>/` — or `$XDG_STATE_HOME/claude-workflows/<id>/` if `XDG_STATE_HOME` is set — (`state.json`, combined `log`, `finished` / `acknowledged` markers), deliberately rooted outside `~/.claude/` so Claude Code's sensitive-file guardrail doesn't block subagent writes. [`skills/_bg/finish.sh`](skills/_bg/finish.sh) writes the terminal `status` / `exit_code` and drops the `finished` marker that `session-summary.sh` keys off.
 - Returns within ~1s with the workflow id, workdir, log path, and state-file path.
 
 A pair of hooks (`SessionStart` + `UserPromptSubmit`, wired in [`settings.json`](settings.json)) invokes [`skills/_bg/session-summary.sh`](skills/_bg/session-summary.sh), which reports running and newly-finished workflows for the current project so you're notified the next time you open Claude Code in that tree. Acknowledged state dirs older than 14 days are pruned on the next hook firing.

--- a/settings.json
+++ b/settings.json
@@ -4,12 +4,12 @@
       "Bash(gh *)",
       "Bash(grep *)",
       "Bash(find *)",
-      "Write($HOME/.local/state/claude-workflows/**)",
-      "Edit($HOME/.local/state/claude-workflows/**)",
-      "Bash(mkdir -p $HOME/.local/state/claude-workflows/**)",
-      "Bash(tee $HOME/.local/state/claude-workflows/**)",
-      "Bash(cat > $HOME/.local/state/claude-workflows/**)",
-      "Bash(cat >> $HOME/.local/state/claude-workflows/**)"
+      "Write(~/.local/state/claude-workflows/**)",
+      "Edit(~/.local/state/claude-workflows/**)",
+      "Bash(mkdir -p ~/.local/state/claude-workflows/**)",
+      "Bash(tee ~/.local/state/claude-workflows/**)",
+      "Bash(cat > ~/.local/state/claude-workflows/**)",
+      "Bash(cat >> ~/.local/state/claude-workflows/**)"
     ],
     "defaultMode": "auto"
   },

--- a/settings.json
+++ b/settings.json
@@ -3,7 +3,13 @@
     "allow": [
       "Bash(gh *)",
       "Bash(grep *)",
-      "Bash(find *)"
+      "Bash(find *)",
+      "Write($HOME/.local/state/claude-workflows/**)",
+      "Edit($HOME/.local/state/claude-workflows/**)",
+      "Bash(mkdir -p $HOME/.local/state/claude-workflows/**)",
+      "Bash(tee $HOME/.local/state/claude-workflows/**)",
+      "Bash(cat > $HOME/.local/state/claude-workflows/**)",
+      "Bash(cat >> $HOME/.local/state/claude-workflows/**)"
     ],
     "defaultMode": "auto"
   },

--- a/skills/_bg/finish.sh
+++ b/skills/_bg/finish.sh
@@ -18,7 +18,7 @@ EC="$2"
 # but --argjson will hard-fail on non-JSON input).
 [[ "$EC" =~ ^-?[0-9]+$ ]] || EC=1
 
-STATE_DIR="$HOME/.claude/workflows/$WF_ID"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/$WF_ID"
 STATE_FILE="$STATE_DIR/state.json"
 [[ -f "$STATE_FILE" ]] || die "no state file at $STATE_FILE"
 

--- a/skills/_bg/launch.sh
+++ b/skills/_bg/launch.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Generic launcher for background skill workflows (ghimplement, localimplement).
-# Sets up an isolated workdir, writes per-workflow state under ~/.claude/workflows/,
-# spawns the real pipeline detached from the caller's session, and returns fast.
+# Sets up an isolated workdir, writes per-workflow state under
+# ${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/, spawns the real
+# pipeline detached from the caller's session, and returns fast.
 set -euo pipefail
 
 die() { echo "error: $*" >&2; exit 1; }
@@ -155,7 +156,7 @@ RANDHEX=$(LC_ALL=C tr -dc 'a-f0-9' </dev/urandom 2>/dev/null | head -c 6 || true
 [[ -n "$RANDHEX" ]] || RANDHEX="xxxxxx"
 WF_ID="${SLUG}-${RANDHEX}"
 
-STATE_ROOT="$HOME/.claude/workflows"
+STATE_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows"
 STATE_DIR="$STATE_ROOT/$WF_ID"
 mkdir -p "$STATE_DIR" || die "could not create state dir: $STATE_DIR"
 

--- a/skills/_bg/session-summary.sh
+++ b/skills/_bg/session-summary.sh
@@ -188,4 +188,18 @@ while IFS= read -r ack; do
     esac
 done < <(find "$STATE_ROOT" -maxdepth 2 -name acknowledged -mtime +14 -print 2>/dev/null || true)
 
+# Prune old direct-CLI session dirs (>14 days by dir mtime). Direct
+# invocations of `localimplement.sh` write artifacts under
+# `$STATE_ROOT/direct/<ts>-<rand>/` but never drop a `state.json` or
+# `acknowledged` marker, so the acknowledged-based sweep above would leave
+# them to accumulate forever. Match by dir mtime instead; the artifacts
+# subtree under each direct session is self-contained.
+if [[ -d "$STATE_ROOT/direct" ]]; then
+    while IFS= read -r d; do
+        case "$d" in
+            "$STATE_ROOT"/direct/*) rm -rf "$d" 2>/dev/null || true ;;
+        esac
+    done < <(find "$STATE_ROOT/direct" -mindepth 1 -maxdepth 1 -type d -mtime +14 -print 2>/dev/null || true)
+fi
+
 exit 0

--- a/skills/_bg/session-summary.sh
+++ b/skills/_bg/session-summary.sh
@@ -10,7 +10,7 @@ set -u
 # Missing jq → nothing to report. Bail before `set -e` would bite us anywhere.
 command -v jq >/dev/null 2>&1 || exit 0
 
-STATE_ROOT="$HOME/.claude/workflows"
+STATE_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows"
 [[ -d "$STATE_ROOT" ]] || exit 0
 
 # Source the shared liveness classifier. Both this hook and `workflows.sh`

--- a/skills/_bg/set-stage.sh
+++ b/skills/_bg/set-stage.sh
@@ -16,7 +16,7 @@ SUB_STAGE="${3:-}"
 
 [[ -n "$WF_ID" && -n "$STAGE" ]] || exit 0
 
-STATE_FILE="$HOME/.claude/workflows/$WF_ID/state.json"
+STATE_FILE="${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/$WF_ID/state.json"
 [[ -f "$STATE_FILE" ]] || exit 0
 
 command -v jq >/dev/null 2>&1 || exit 0

--- a/skills/ghimplement/SKILL.md
+++ b/skills/ghimplement/SKILL.md
@@ -9,7 +9,7 @@ You are running the `ghimplement` workflow **in the background**. The skill is a
 
 1. Creates an isolated git worktree of the current project (detached HEAD).
 2. Spawns the real pipeline (`~/.claude/skills/ghimplement/ghimplement.sh`) detached from this session — it survives Ctrl-C, shell exit, and Claude Code quitting.
-3. Records per-workflow state under `~/.claude/workflows/<workflow-id>/` (`state.json`, combined `log`, markers).
+3. Records per-workflow state under `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<workflow-id>/` (`state.json`, combined `log`, markers).
 4. Returns within ~1s.
 
 A `SessionStart` / `UserPromptSubmit` hook notifies a future Claude session for this project when the workflow finishes.

--- a/skills/ghimplement/SKILL.md
+++ b/skills/ghimplement/SKILL.md
@@ -9,7 +9,7 @@ You are running the `ghimplement` workflow **in the background**. The skill is a
 
 1. Creates an isolated git worktree of the current project (detached HEAD).
 2. Spawns the real pipeline (`~/.claude/skills/ghimplement/ghimplement.sh`) detached from this session — it survives Ctrl-C, shell exit, and Claude Code quitting.
-3. Records per-workflow state under `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<workflow-id>/` (`state.json`, combined `log`, markers).
+3. Records per-workflow state under `~/.local/state/claude-workflows/<workflow-id>/` (or `$XDG_STATE_HOME/claude-workflows/<workflow-id>/` if `XDG_STATE_HOME` is set) — `state.json`, combined `log`, markers.
 4. Returns within ~1s.
 
 A `SessionStart` / `UserPromptSubmit` hook notifies a future Claude session for this project when the workflow finishes.

--- a/skills/localimplement/SKILL.md
+++ b/skills/localimplement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: localimplement
-description: Run the end-to-end plan → implement → review-code → address-code workflow in the background by invoking ~/.claude/skills/_bg/launch.sh. Plan and code reviews land in `~/.claude/workflows/<workflow-id>/artifacts/` alongside the run log (kept off the product branch); the code review uses two different models in parallel. The launcher returns immediately; you'll be notified when the pipeline finishes.
+description: Run the end-to-end plan → implement → review-code → address-code workflow in the background by invoking ~/.claude/skills/_bg/launch.sh. Plan and code reviews land in `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<workflow-id>/artifacts/` alongside the run log (kept off the product branch); the code review uses two different models in parallel. The launcher returns immediately; you'll be notified when the pipeline finishes.
 argument-hint: [-a <model>] [-b <model>] <instructions>
 allowed-tools: Bash(~/.claude/skills/_bg/launch.sh:*)
 ---
@@ -9,7 +9,7 @@ You are running the `localimplement` workflow **in the background**. The skill i
 
 1. Creates an isolated git worktree of the current project on a fresh branch named `bg/localimplement/<workflow-id>` (or `cp -a` copies the tree for non-git projects).
 2. Spawns the real pipeline (`~/.claude/skills/localimplement/localimplement.sh`) detached from this session — it survives Ctrl-C, shell exit, and Claude Code quitting.
-3. Records per-workflow state under `~/.claude/workflows/<workflow-id>/` (`state.json`, combined `log`, markers).
+3. Records per-workflow state under `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<workflow-id>/` (`state.json`, combined `log`, markers).
 4. Returns within ~1s.
 
 A `SessionStart` / `UserPromptSubmit` hook notifies a future Claude session for this project when the workflow finishes.
@@ -18,10 +18,10 @@ A `SessionStart` / `UserPromptSubmit` hook notifies a future Claude session for 
 
 Plan and code-review artifacts live outside the product branch — they are scaffolding, not product. Point the user at:
 
-- `~/.claude/workflows/<workflow-id>/artifacts/plan.md` — the implementation plan.
-- `~/.claude/workflows/<workflow-id>/artifacts/review-code-holistic-<model>.md` and `review-code-detail-<model>.md` — the two parallel code reviews.
-- `~/.claude/workflows/<workflow-id>/log` — combined stdout/stderr of the pipeline.
-- `~/.claude/workflows/<workflow-id>/state.json` — workflow status, exit code, workdir path, branch name.
+- `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<workflow-id>/artifacts/plan.md` — the implementation plan.
+- `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<workflow-id>/artifacts/review-code-holistic-<model>.md` and `review-code-detail-<model>.md` — the two parallel code reviews.
+- `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<workflow-id>/log` — combined stdout/stderr of the pipeline.
+- `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<workflow-id>/state.json` — workflow status, exit code, workdir path, branch name.
 - `bg/localimplement/<workflow-id>` — durable branch with **only** the code changes (no scaffolding). From the main working tree: `git checkout bg/localimplement/<workflow-id>` to inspect, merge, or discard. A squash-merge pulls in product code cleanly.
 
 Commits on the branch, in order: implementation → "Address review feedback" (absent if reviewers found nothing).

--- a/skills/localimplement/SKILL.md
+++ b/skills/localimplement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: localimplement
-description: Run the end-to-end plan → implement → review-code → address-code workflow in the background by invoking ~/.claude/skills/_bg/launch.sh. Plan and code reviews land in `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<workflow-id>/artifacts/` alongside the run log (kept off the product branch); the code review uses two different models in parallel. The launcher returns immediately; you'll be notified when the pipeline finishes.
+description: Run the end-to-end plan → implement → review-code → address-code workflow in the background by invoking ~/.claude/skills/_bg/launch.sh. Plan and code reviews land in `~/.local/state/claude-workflows/<workflow-id>/artifacts/` alongside the run log (kept off the product branch); the code review uses two different models in parallel. The launcher returns immediately; you'll be notified when the pipeline finishes.
 argument-hint: [-a <model>] [-b <model>] <instructions>
 allowed-tools: Bash(~/.claude/skills/_bg/launch.sh:*)
 ---
@@ -9,7 +9,7 @@ You are running the `localimplement` workflow **in the background**. The skill i
 
 1. Creates an isolated git worktree of the current project on a fresh branch named `bg/localimplement/<workflow-id>` (or `cp -a` copies the tree for non-git projects).
 2. Spawns the real pipeline (`~/.claude/skills/localimplement/localimplement.sh`) detached from this session — it survives Ctrl-C, shell exit, and Claude Code quitting.
-3. Records per-workflow state under `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<workflow-id>/` (`state.json`, combined `log`, markers).
+3. Records per-workflow state under `~/.local/state/claude-workflows/<workflow-id>/` (or `$XDG_STATE_HOME/claude-workflows/<workflow-id>/` if `XDG_STATE_HOME` is set) — `state.json`, combined `log`, markers.
 4. Returns within ~1s.
 
 A `SessionStart` / `UserPromptSubmit` hook notifies a future Claude session for this project when the workflow finishes.
@@ -18,10 +18,10 @@ A `SessionStart` / `UserPromptSubmit` hook notifies a future Claude session for 
 
 Plan and code-review artifacts live outside the product branch — they are scaffolding, not product. Point the user at:
 
-- `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<workflow-id>/artifacts/plan.md` — the implementation plan.
-- `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<workflow-id>/artifacts/review-code-holistic-<model>.md` and `review-code-detail-<model>.md` — the two parallel code reviews.
-- `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<workflow-id>/log` — combined stdout/stderr of the pipeline.
-- `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<workflow-id>/state.json` — workflow status, exit code, workdir path, branch name.
+- `~/.local/state/claude-workflows/<workflow-id>/artifacts/plan.md` — the implementation plan.
+- `~/.local/state/claude-workflows/<workflow-id>/artifacts/review-code-holistic-<model>.md` and `review-code-detail-<model>.md` — the two parallel code reviews.
+- `~/.local/state/claude-workflows/<workflow-id>/log` — combined stdout/stderr of the pipeline.
+- `~/.local/state/claude-workflows/<workflow-id>/state.json` — workflow status, exit code, workdir path, branch name.
 - `bg/localimplement/<workflow-id>` — durable branch with **only** the code changes (no scaffolding). From the main working tree: `git checkout bg/localimplement/<workflow-id>` to inspect, merge, or discard. A squash-merge pulls in product code cleanly.
 
 Commits on the branch, in order: implementation → "Address review feedback" (absent if reviewers found nothing).

--- a/skills/localimplement/localimplement.sh
+++ b/skills/localimplement/localimplement.sh
@@ -11,7 +11,8 @@ trap 'trap - INT TERM; kill -- -$$ 2>/dev/null; exit 130' INT TERM
 die() { echo "error: $*" >&2; exit 1; }
 
 # Stage helper: only meaningful when this script runs under the _bg launcher
-# (which exports WF_ID and creates ~/.claude/workflows/<WF_ID>/state.json).
+# (which exports WF_ID and creates the workflow's state.json under
+# ${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<WF_ID>/).
 # A direct CLI invocation has no WF_ID and set_stage no-ops.
 SET_STAGE_SH="$HOME/.claude/skills/_bg/set-stage.sh"
 set_stage() {
@@ -23,8 +24,9 @@ set_stage() {
 # Tee stream-json to a per-stage raw file under $SESSION_DIR while writing a
 # human-readable trace of every meaningful event (init / assistant text /
 # tool_use / tool_result / final result) to stderr. Under the _bg launcher
-# stderr is redirected to ~/.claude/workflows/<id>/log; the raw file is the
-# diagnostic artifact that survives even when the trace is lost.
+# stderr is redirected to the workflow's log under
+# ${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<id>/log; the raw
+# file is the diagnostic artifact that survives even when the trace is lost.
 #
 # Replaces an older `progress_tee` that used `tee >(jq ... >&2)` — the
 # process-substitution stderr empirically didn't reach the log under _bg, so
@@ -98,23 +100,26 @@ done
 command -v claude >/dev/null || die "claude CLI not found"
 command -v jq >/dev/null     || die "jq not found"
 
-# Session directory. Under the _bg launcher (WF_ID set) artifacts live under
-# ~/.claude/workflows/<WF_ID>/artifacts/ so they stay out of the product branch
-# and survive worktree removal. Direct CLI invocation falls back to the old
-# in-tree `.claude-workflow/<ts>/` path — convenient for ad-hoc use, but the
-# user is on their own to gitignore or clean it up.
+# Session directory. Artifacts always live under the XDG state root so they
+# stay out of the product branch and survive worktree removal. Under the _bg
+# launcher WF_ID names the workflow dir; a direct CLI invocation synthesizes a
+# "<ts>-direct-<rand>" id for symmetry.
 #
-# WF_ID is interpolated into a filesystem path under $HOME, so validate it
-# against a conservative charset to prevent path traversal (e.g. "../") or
-# embedded slashes when it's set externally. The _bg launcher produces IDs
-# matching ^[a-z0-9-]+$, so this pattern is a strict superset.
+# WF_ID is interpolated into a filesystem path, so validate it against a
+# conservative charset to prevent path traversal (e.g. "../") or embedded
+# slashes when it's set externally. The _bg launcher produces IDs matching
+# ^[a-z0-9-]+$, so this pattern is a strict superset.
+STATE_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows"
 TS=$(date +%Y%m%d-%H%M%S)
 if [[ -n "${WF_ID:-}" ]]; then
   [[ "$WF_ID" =~ ^[A-Za-z0-9._-]+$ ]] || die "invalid WF_ID: $WF_ID"
-  SESSION_DIR="$HOME/.claude/workflows/$WF_ID/artifacts"
+  SESSION_ID="$WF_ID"
 else
-  SESSION_DIR=".claude-workflow/$TS"
+  RAND=$(LC_ALL=C tr -dc 'a-f0-9' </dev/urandom 2>/dev/null | head -c 6 || true)
+  [[ -n "$RAND" ]] || RAND="xxxxxx"
+  SESSION_ID="$TS-direct-$RAND"
 fi
+SESSION_DIR="$STATE_ROOT/$SESSION_ID/artifacts"
 mkdir -p "$SESSION_DIR"
 PLAN_FILE="$SESSION_DIR/plan.md"
 REVIEW_CODE_A="$SESSION_DIR/review-code-holistic-$MODEL_A.md"
@@ -267,8 +272,8 @@ fi
 
 IMPL_COMMIT_INSTR="."
 # The commit message references `plan.md` (the artifact basename) rather than
-# `$PLAN_FILE` — under the _bg launcher the latter is an absolute user-specific
-# path under ~/.claude/workflows/ that would end up in git history otherwise.
+# `$PLAN_FILE` — the latter is an absolute user-specific path under the XDG
+# state root that would end up in git history otherwise.
 [[ $IN_GIT -eq 1 ]] && IMPL_COMMIT_INSTR=", stage the changed files by name and create a single git commit with a clear message that references the implementation plan (refer to it as \`plan.md\` in the commit message, not by absolute path). Do NOT create any meta/scaffolding files in the repo — no \`.claude-workflow/\` directory, no \`plan.md\`, no review docs, no notes-to-self. Do not push."
 
 claude -p --model "$MODEL_IMPL" "${CLAUDE_FLAGS[@]}" \

--- a/skills/localimplement/localimplement.sh
+++ b/skills/localimplement/localimplement.sh
@@ -102,8 +102,12 @@ command -v jq >/dev/null     || die "jq not found"
 
 # Session directory. Artifacts always live under the XDG state root so they
 # stay out of the product branch and survive worktree removal. Under the _bg
-# launcher WF_ID names the workflow dir; a direct CLI invocation synthesizes a
-# "<ts>-direct-<rand>" id for symmetry.
+# launcher WF_ID names the workflow dir directly under $STATE_ROOT, and the
+# launcher/session-summary hook manage its lifecycle (state.json, finished,
+# acknowledged markers, 14-day prune). Direct CLI invocations have no such
+# lifecycle, so they're nested under `$STATE_ROOT/direct/<ts>-<rand>/` — a
+# dedicated subdir keeps them visually separated from real workflow state
+# and lets `session-summary.sh` prune them on a simpler age-based heuristic.
 #
 # WF_ID is interpolated into a filesystem path, so validate it against a
 # conservative charset to prevent path traversal (e.g. "../") or embedded
@@ -113,13 +117,12 @@ STATE_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows"
 TS=$(date +%Y%m%d-%H%M%S)
 if [[ -n "${WF_ID:-}" ]]; then
   [[ "$WF_ID" =~ ^[A-Za-z0-9._-]+$ ]] || die "invalid WF_ID: $WF_ID"
-  SESSION_ID="$WF_ID"
+  SESSION_DIR="$STATE_ROOT/$WF_ID/artifacts"
 else
   RAND=$(LC_ALL=C tr -dc 'a-f0-9' </dev/urandom 2>/dev/null | head -c 6 || true)
   [[ -n "$RAND" ]] || RAND="xxxxxx"
-  SESSION_ID="$TS-direct-$RAND"
+  SESSION_DIR="$STATE_ROOT/direct/$TS-$RAND/artifacts"
 fi
-SESSION_DIR="$STATE_ROOT/$SESSION_ID/artifacts"
 mkdir -p "$SESSION_DIR"
 PLAN_FILE="$SESSION_DIR/plan.md"
 REVIEW_CODE_A="$SESSION_DIR/review-code-holistic-$MODEL_A.md"

--- a/skills/workflows/SKILL.md
+++ b/skills/workflows/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: workflows
-description: On-demand status of background pipelines launched by /localimplement and /ghimplement. Reads every ~/.claude/workflows/<id>/state.json on the machine and prints one line per active workflow with its kind, current stage, liveness (running / stalled / dead), description, and age. Use to check progress, spot crashed pipelines, or acknowledge (hide) finished ones. Not a project filter by default — set --here to restrict to the current repo.
+description: On-demand status of background pipelines launched by /localimplement and /ghimplement. Reads every ${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<id>/state.json on the machine and prints one line per active workflow with its kind, current stage, liveness (running / stalled / dead), description, and age. Use to check progress, spot crashed pipelines, or acknowledge (hide) finished ones. Not a project filter by default — set --here to restrict to the current repo.
 argument-hint: [--here] [--ack <id>] [--ack-all]
 allowed-tools: Bash(~/.claude/skills/workflows/workflows.sh:*)
 ---
 
-You are running the `workflows` status command. It reads the persistent state under `~/.claude/workflows/` and summarizes every active (not-yet-acknowledged) background workflow across every project on this machine.
+You are running the `workflows` status command. It reads the persistent state under `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/` and summarizes every active (not-yet-acknowledged) background workflow across every project on this machine.
 
 ## What to do
 

--- a/skills/workflows/SKILL.md
+++ b/skills/workflows/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: workflows
-description: On-demand status of background pipelines launched by /localimplement and /ghimplement. Reads every ${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<id>/state.json on the machine and prints one line per active workflow with its kind, current stage, liveness (running / stalled / dead), description, and age. Use to check progress, spot crashed pipelines, or acknowledge (hide) finished ones. Not a project filter by default — set --here to restrict to the current repo.
+description: On-demand status of background pipelines launched by /localimplement and /ghimplement. Reads every ~/.local/state/claude-workflows/<id>/state.json on the machine and prints one line per active workflow with its kind, current stage, liveness (running / stalled / dead), description, and age. Use to check progress, spot crashed pipelines, or acknowledge (hide) finished ones. Not a project filter by default — set --here to restrict to the current repo.
 argument-hint: [--here] [--ack <id>] [--ack-all]
 allowed-tools: Bash(~/.claude/skills/workflows/workflows.sh:*)
 ---
 
-You are running the `workflows` status command. It reads the persistent state under `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/` and summarizes every active (not-yet-acknowledged) background workflow across every project on this machine.
+You are running the `workflows` status command. It reads the persistent state under `~/.local/state/claude-workflows/` (or `$XDG_STATE_HOME/claude-workflows/` if `XDG_STATE_HOME` is set) and summarizes every active (not-yet-acknowledged) background workflow across every project on this machine.
 
 ## What to do
 

--- a/skills/workflows/workflows.sh
+++ b/skills/workflows/workflows.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # /workflows — on-demand status of background workflow pipelines.
-# Reads every ~/.claude/workflows/<id>/state.json, applies the shared liveness
-# classifier, and prints one scannable line per workflow.
+# Reads every ${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<id>/state.json,
+# applies the shared liveness classifier, and prints one scannable line per workflow.
 #
 # Exit 0 always: an unexpected error logs to stderr and falls through. Same
 # "never break a session" principle as the session-summary hook.
 set -u
 
-STATE_ROOT="$HOME/.claude/workflows"
+STATE_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows"
 
 command -v jq >/dev/null 2>&1 || { echo "jq not found" >&2; exit 0; }
 


### PR DESCRIPTION
## Summary

Closes #17.

- Relocate every workflow runtime path (state.json, log, pid, markers, artifacts, stream jsonl) from `~/.claude/workflows/<id>/` to `${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows/<id>/`, escaping Claude Code's sensitive-file guardrail that was probabilistically breaking `/localimplement` artifact writes under `--permission-mode bypassPermissions`.
- Collapse `localimplement.sh`'s WF_ID-set vs. unset branches into a single path: direct-CLI runs now synthesize `<ts>-direct-<rand>` session ids under the same XDG root instead of writing to an in-tree `.claude-workflow/<ts>/` dir.
- `settings.json`: auto-approve `Write`/`Edit`/`Bash` writes under `$HOME/.local/state/claude-workflows/**` so interactive sessions don't prompt. Uses a hardcoded `$HOME` path (not `${XDG_STATE_HOME:-...}`) per issue guidance — shell-based matchers don't expand parameter defaults.

Existing state under `~/.claude/workflows/` is intentionally **not** migrated — orphaned in place per the issue's non-goals.

## Files changed

- `skills/_bg/launch.sh`, `finish.sh`, `set-stage.sh`, `session-summary.sh` — new STATE_ROOT.
- `skills/workflows/workflows.sh` — new STATE_ROOT.
- `skills/localimplement/localimplement.sh` — unified session-dir logic.
- `skills/localimplement/SKILL.md`, `skills/ghimplement/SKILL.md`, `skills/workflows/SKILL.md`, `README.md` — doc path updates.
- `settings.json` — permission allowlist entries.

## Test plan

- [ ] Run `/localimplement <task>` end-to-end; confirm `plan.md`, both review files, `stream-*.jsonl`, `state.json`, `log`, `pid`, and `finished`/`acknowledged` markers all land under `$HOME/.local/state/claude-workflows/<id>/` and nothing new appears under `~/.claude/workflows/`.
- [ ] Run `/ghimplement <task>` end-to-end; confirm state/log/pid/markers land under the new root and nothing new under `~/.claude/workflows/`.
- [ ] Run `/workflows`, `/workflows --here`, `/workflows --ack <id>`, `/workflows --ack-all` — all read/write the new root.
- [ ] Confirm `SessionStart`/`UserPromptSubmit` hook surfaces running + just-finished workflows correctly against the new root.
- [ ] Run `skills/localimplement/localimplement.sh "<instructions>"` directly (no WF_ID); confirm session dir at `$HOME/.local/state/claude-workflows/<ts>-direct-<rand>/artifacts/` and that no `.claude-workflow/` dir is created in the repo tree.
- [ ] Confirm no permission prompts fire on artifact writes during a fresh `/localimplement` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)