### PR TITLE
Extend /workflows rm to clean up worktree and branch

### DIFF
--- a/skills/localland/SKILL.md
+++ b/skills/localland/SKILL.md
@@ -1,23 +1,37 @@
 ---
 name: localland
 description: Squash-merge a finished /localimplement workflow branch onto the current branch as a single well-messaged commit, then delete the workflow branch and state directory.
-argument-hint: <workflow-id>
-allowed-tools: Bash(~/.claude/skills/localland/localland.sh:*), Bash(git *)
+argument-hint: [--gh] <workflow-id>
+allowed-tools: Bash(~/.claude/skills/localland/localland.sh:*), Bash(git *), Bash(gh *)
 ---
 
-You are running the `localland` command. It lands a finished `/localimplement` workflow onto your current branch as one clean, squashed commit, then removes all traces of the workflow.
+You are running the `localland` command. It lands a finished `/localimplement` workflow onto your current branch as one clean, squashed commit, then removes all traces of the workflow. With `--gh`, it pushes the result as a new GitHub PR against `main` instead of committing locally.
 
 ## What to do
 
-The workflow id is `$ARGUMENTS`. Fail fast at every step — if a command exits nonzero, stop and report the error to the user; do not continue.
+Parse `$ARGUMENTS` to detect the optional `--gh` flag:
+- If `$ARGUMENTS` starts with `--gh `, set `GH_MODE=true` and treat the remainder as `WF_ID`.
+- Otherwise set `GH_MODE=false` and treat `$ARGUMENTS` as `WF_ID`.
+
+Fail fast at every step — if a command exits nonzero, stop and report the error to the user; do not continue.
 
 **Step 1 — validate preconditions**
 
 ```
-~/.claude/skills/localland/localland.sh --check "$ARGUMENTS"
+~/.claude/skills/localland/localland.sh --check "$WF_ID"
 ```
 
 Parse `branch=` and `plan=` from stdout. If the script exits nonzero, report the error and stop.
+
+**Step 1b — `--gh` preflight** *(only when `GH_MODE=true`)*
+
+Derive `pr_branch=pr/$WF_ID`. Then:
+
+```
+~/.claude/skills/localland/localland.sh --gh-preflight "$WF_ID" "$pr_branch"
+```
+
+If the script exits nonzero, report the error and stop. Do not proceed to squash.
 
 **Step 2 — read the plan**
 
@@ -25,11 +39,21 @@ Read the file at the `plan=` path. You will use its `## Context` section to writ
 
 **Step 3 — stage the changes**
 
+*If `GH_MODE=false`:*
+
 ```
-~/.claude/skills/localland/localland.sh --squash "$ARGUMENTS"
+~/.claude/skills/localland/localland.sh --squash "$WF_ID"
 ```
 
-If the script exits nonzero (conflict or other failure), report the error and stop. Do not attempt cleanup.
+*If `GH_MODE=true`:*
+
+```
+~/.claude/skills/localland/localland.sh --gh-squash "$WF_ID" "$pr_branch"
+```
+
+After `--gh-squash` succeeds, the working tree is on `$pr_branch` (not the original branch).
+
+If either script exits nonzero (conflict or other failure), report the error and stop. Do not attempt cleanup.
 
 **Step 4 — inspect the staged diff**
 
@@ -45,28 +69,54 @@ Read the diff to understand what actually changed. Use it to trim or sharpen the
 - **Body** (optional): bullet points drawn from the plan's Tasks and any signal from the diff. Prose only if a single sentence captures something the subject can't. Omit if the subject is sufficient.
 - No "🤖 Generated…" footer. No ceremony.
 
-**Step 6 — commit**
+**Step 6 — commit (and push + PR when `GH_MODE=true`)**
+
+*If `GH_MODE=false`:*
 
 ```
 git commit -m "<message>"
 ```
 
+*If `GH_MODE=true`:*
+
+```
+git commit -m "<message>"
+git push -u origin "$pr_branch"
+printf '%s' "<body>" > /tmp/pr-body-$$.md
+gh pr create --base main --title "<subject>" --body-file /tmp/pr-body-$$.md
+rm -f /tmp/pr-body-$$.md
+```
+
+Write the PR body to a temp file before calling `gh pr create` to avoid shell-quoting hazards with newlines, backticks, and `$` signs in the body.
+
+Capture the PR URL from `gh pr create` stdout. If `git push` or `gh pr create` exits nonzero, stop and report the error — do not run cleanup.
+
 **Step 7 — cleanup** (only after step 6 succeeds)
 
 ```
-~/.claude/skills/localland/localland.sh --cleanup "$ARGUMENTS"
+~/.claude/skills/localland/localland.sh --cleanup "$WF_ID"
 ```
 
 **Step 8 — report**
+
+*If `GH_MODE=false`:*
 
 Tell the user:
 - Which branch was landed and onto what.
 - The commit hash (from `git rev-parse HEAD`).
 - That the workflow branch and state directory have been removed.
 
+*If `GH_MODE=true`:*
+
+Tell the user:
+- The PR URL.
+- That the PR branch `$pr_branch` was pushed and kept.
+- That the workflow branch and state directory have been removed.
+- That the working tree is now on `$pr_branch`; they can return to their previous branch with `git checkout <original_branch>`.
+
 ## Do not
 
 - Do not run `--cleanup` before step 6 has succeeded.
 - Do not add `--no-verify` to the commit.
-- Do not push.
+- Do not push (except as part of the `--gh` flow in step 6).
 - Do not squash or amend any commits other than the workflow's staged changes.

--- a/skills/localland/localland.sh
+++ b/skills/localland/localland.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # localland.sh — git operations for the /localland skill.
-# Three subcommands, called in sequence by Claude:
-#   --check  <id>  Validate preconditions; print branch= and plan= on stdout.
-#   --squash <id>  Stage the workflow's commits via git merge --squash.
-#   --cleanup <id> Delete the workflow branch and state directory.
+# Subcommands called in sequence by Claude:
+#   --check              <id>            Validate preconditions; print branch= and plan= on stdout.
+#   --squash             <id>            Stage the workflow's commits via git merge --squash.
+#   --cleanup            <id>            Delete the workflow branch and state directory.
+#   --gh-preflight       <id> <pr-branch> Pre-flight checks for --gh mode (remote, auth, branch collision).
+#   --gh-squash          <id> <pr-branch> Create PR branch off main and squash-merge the workflow branch onto it.
 set -euo pipefail
 
 STATE_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/claude-workflows"
@@ -27,7 +29,7 @@ fi
 
 die() { echo "error: $*" >&2; exit 1; }
 
-[[ $# -ge 2 ]] || die "usage: localland.sh --check|--squash|--cleanup <workflow-id>"
+[[ $# -ge 2 ]] || die "usage: localland.sh --check|--squash|--cleanup|--gh-preflight|--gh-squash <workflow-id> [pr-branch]"
 MODE="$1"
 WF_ID="$2"
 
@@ -133,7 +135,67 @@ case "$MODE" in
     ;;
 
 # ---------------------------------------------------------------------------
+--gh-preflight)
+    PR_BRANCH="${3:-}"
+    [[ -n "$PR_BRANCH" ]] || die "usage: localland.sh --gh-preflight <id> <pr-branch>"
+
+    # Must have a remote named 'origin' (push and remote branch checks both target origin).
+    git remote get-url origin >/dev/null 2>&1 \
+        || die "--gh requires a remote named 'origin'; none found (remotes: $(git remote | tr '\n' ' '))"
+
+    # gh CLI must be authenticated.
+    gh auth status >/dev/null 2>&1 || die "gh is not authenticated; run 'gh auth login' and retry"
+
+    # PR branch must not already exist locally.
+    if git show-ref --verify --quiet "refs/heads/$PR_BRANCH" 2>/dev/null; then
+        die "branch '$PR_BRANCH' already exists locally; delete it or choose a different name"
+    fi
+
+    # PR branch must not already exist remotely.
+    if git ls-remote --exit-code origin "refs/heads/$PR_BRANCH" >/dev/null 2>&1; then
+        die "branch '$PR_BRANCH' already exists on origin; delete it or choose a different name"
+    fi
+
+    echo "preflight ok: remote present, gh authenticated, '$PR_BRANCH' is free"
+    ;;
+
+# ---------------------------------------------------------------------------
+--gh-squash)
+    PR_BRANCH="${3:-}"
+    [[ -n "$PR_BRANCH" ]] || die "usage: localland.sh --gh-squash <id> <pr-branch>"
+
+    [[ -f "$STATE_FILE" ]] || die "no state.json found for workflow '$WF_ID'"
+    command -v jq >/dev/null 2>&1 || die "jq is required but not found on PATH"
+
+    setup_kind=$(jq -r '.setup_kind // "unknown"' "$STATE_FILE")
+    [[ "$setup_kind" == "worktree-branch" ]] \
+        || die "workflow '$WF_ID' is not a git workflow (setup_kind=$setup_kind); nothing to squash"
+
+    branch=$(jq -r '.branch // ""' "$STATE_FILE")
+    [[ -n "$branch" ]] || die "state.json for '$WF_ID' has no branch field"
+
+    original_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) \
+        || die "could not determine current branch"
+
+    # Create PR branch off main.
+    if ! git checkout -b "$PR_BRANCH" main 2>&1; then
+        die "could not create branch '$PR_BRANCH' off main; ensure 'main' exists and the working tree is clean"
+    fi
+
+    # Squash-merge the workflow branch onto the PR branch.
+    echo "Squash-merging $branch onto $PR_BRANCH..."
+    if ! git merge --squash "$branch" 2>&1; then
+        git checkout "$original_branch" 2>/dev/null || true
+        git branch -D "$PR_BRANCH" 2>/dev/null || true
+        die "git merge --squash failed (conflicts); restored to '$original_branch' and deleted '$PR_BRANCH'"
+    fi
+
+    echo "--- staged diff summary ---"
+    git diff --cached --stat
+    ;;
+
+# ---------------------------------------------------------------------------
 *)
-    die "unknown subcommand '$MODE'; expected --check, --squash, or --cleanup"
+    die "unknown subcommand '$MODE'; expected --check, --squash, --cleanup, --gh-preflight, or --gh-squash"
     ;;
 esac

--- a/skills/workflows/workflows.py
+++ b/skills/workflows/workflows.py
@@ -562,6 +562,14 @@ def do_ack_all():
         print("nothing to acknowledge.")
 
 
+def expected_branch(state: dict, wf_id: str):
+    """Return the durable branch name for a workflow, or None if there isn't one."""
+    kind = state.get("kind", "")
+    if kind == "localimplement":
+        return f"bg/localimplement/{wf_id}"
+    return None
+
+
 def do_rm(target: str) -> bool:
     match = resolve_workflow(target)
     if match is None:
@@ -583,8 +591,57 @@ def do_rm(target: str) -> bool:
         print(f"workflow {wf_id} is still live ({live}) — use 'stop' first, then rm")
         return False
 
-    shutil.rmtree(wdir)
-    print(f"removed workflow {wf_id} ({wdir})")
+    workdir = state.get("workdir") or ""
+
+    # Safety check: refuse if cwd is inside the worktree.
+    if workdir and os.path.exists(workdir):
+        cwd_real = os.path.realpath(os.getcwd())
+        worktree_real = os.path.realpath(workdir)
+        if cwd_real == worktree_real or cwd_real.startswith(worktree_real + os.sep):
+            print("you are inside this workflow's worktree — cd elsewhere before running rm")
+            return False
+
+    project_root = state.get("project_root") or ""
+    cwd_for_git = project_root if project_root and os.path.isdir(project_root) else None
+
+    # Remove the worktree.
+    if workdir and os.path.exists(workdir):
+        result = subprocess.run(
+            ["git", "worktree", "remove", "--force", workdir],
+            capture_output=True, text=True,
+            cwd=cwd_for_git,
+        )
+        if result.returncode == 0:
+            print(f"removed worktree {workdir}")
+        else:
+            # Fallback: plain directory removal (unregistered or already detached).
+            try:
+                shutil.rmtree(workdir)
+                print(f"removed worktree {workdir}")
+            except OSError as e:
+                print(f"warning: could not remove worktree {workdir}: {e}")
+
+    # Delete the durable branch.
+    branch = expected_branch(state, wf_id)
+    if branch:
+        result = subprocess.run(
+            ["git", "branch", "-D", branch],
+            capture_output=True, text=True,
+            cwd=cwd_for_git,
+        )
+        if result.returncode == 0:
+            print(f"deleted branch {branch}")
+        elif "not found" not in result.stderr:
+            print(f"warning: could not delete branch {branch}: {result.stderr.strip()}")
+
+    # Remove the state directory.
+    try:
+        shutil.rmtree(wdir)
+        print(f"removed state directory {wdir}")
+    except OSError as e:
+        print(f"warning: could not remove state directory {wdir}: {e}")
+
+    print(f"rm: workflow {wf_id} cleaned up")
     return True
 
 
@@ -783,7 +840,7 @@ def parse_args(argv=None):
             "Subcommands (positional, before flags):\n"
             "  stop <id>     Send SIGTERM to a running workflow and wait for it to exit.\n"
             "  rescue <id>   Diagnose and resume a dead or stalled workflow inline.\n"
-            "  rm <id>       Delete a dead/finished workflow's state directory.\n"
+            "  rm <id>       Delete a dead/finished workflow's state directory, worktree, and branch.\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         add_help=True,


### PR DESCRIPTION
`rm` now removes all local traces of a workflow:

- **Worktree** — `git worktree remove --force`, falling back to `shutil.rmtree` if the path isn't registered (e.g. externally removed).
- **Durable branch** — `bg/localimplement/<id>` for local workflows; ghimplement has no branch so that step is skipped.
- **State directory** — as before.

Missing pieces are skipped silently. Added a safety check that refuses to run if `cwd` is inside the target worktree.

Each step reports its action; a final `rm: workflow <id> cleaned up` line confirms success.
