### PR TITLE
/gremlins default shows every unclosed gremlin, running first

### DIFF
--- a/skills/_bg/session-summary.sh
+++ b/skills/_bg/session-summary.sh
@@ -77,7 +77,7 @@ fi
 NL=$'\n'
 RUNNING_BLOCK=""
 FINISHED_BLOCK=""
-NEWLY_CLOSED_DIRS=()
+NEWLY_SUMMARIZED_DIRS=()
 FINISHED_COUNT=0
 
 shopt -s nullglob
@@ -99,15 +99,16 @@ for sf in "$STATE_ROOT"/*/state.json; do
     [[ "$pr" == "$PROJECT_ROOT" ]] || continue
 
     finished_marker="$wdir/finished"
+    summarized_marker="$wdir/summarized"
     closed_marker="$wdir/closed"
     log="$wdir/log"
 
     desc_suffix=""
     [[ -n "$description" ]] && desc_suffix=" — _${description}_"
 
-    if [[ -f "$finished_marker" && ! -f "$closed_marker" ]]; then
+    if [[ -f "$finished_marker" && ! -f "$summarized_marker" && ! -f "$closed_marker" ]]; then
         FINISHED_BLOCK+="- \`$id\` ($kind): **$status**${exit_code:+ (exit $exit_code)}${desc_suffix} — log: $log${NL}"
-        NEWLY_CLOSED_DIRS+=("$wdir")
+        NEWLY_SUMMARIZED_DIRS+=("$wdir")
         FINISHED_COUNT=$((FINISHED_COUNT + 1))
         continue
     fi
@@ -174,8 +175,8 @@ if [[ -n "$SUMMARY" ]]; then
         --arg ctx   "$FULL" \
         '{hookSpecificOutput: {hookEventName: $event, additionalContext: $ctx}}'
 
-    for d in "${NEWLY_CLOSED_DIRS[@]}"; do
-        touch "$d/closed" 2>/dev/null || true
+    for d in "${NEWLY_SUMMARIZED_DIRS[@]}"; do
+        touch "$d/summarized" 2>/dev/null || true
     done
 fi
 

--- a/skills/_bg/session-summary.sh
+++ b/skills/_bg/session-summary.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # SessionStart / UserPromptSubmit hook: reports on background gremlins for the
 # current project. Running gremlins are shown at session start; newly-finished
-# gremlins are shown in both hooks (and closed on first show).
+# gremlins are shown in both hooks (and marked `summarized` on first show so
+# they aren't re-announced). The `closed` marker is reserved for the explicit
+# user action (`/gremlins close <id>`) and hides the gremlin from `/gremlins`.
 #
 # Degrades silently on any unexpected condition: hooks must never break a
 # session.

--- a/skills/gremlins/SKILL.md
+++ b/skills/gremlins/SKILL.md
@@ -26,9 +26,9 @@ The script produces a small table. Each row is one gremlin:
 
 ## Flags
 
-- (default, no flag): list all active gremlins on this machine.
+- (default, no flag): list every unclosed gremlin on this machine — running, stalled, and dead-but-not-closed — with running ones first.
 - `--here`: restrict to gremlins whose project_root matches the current working directory's git toplevel.
-- `--running`: show only gremlins whose liveness is `running`.
+- `--running`: show only gremlins whose liveness is `running` (the pre-change default view, for when you only want live processes).
 - `--dead`: show only gremlins whose liveness starts with `dead:`.
 - `--stalled`: show only gremlins whose liveness starts with `stalled:`.
 - `--kind local|gh`: filter to a specific gremlin kind (`local` from `/localgremlin`, `gh` from `/ghgremlin`). Composable with all other list flags.

--- a/skills/gremlins/gremlins.py
+++ b/skills/gremlins/gremlins.py
@@ -1030,6 +1030,11 @@ def do_list(args, here_root=None):
         include_closed=False,
     )
 
+    # Running gremlins float to the top; everything else keeps age-ascending
+    # order within its group. sort() is stable, so this composes with
+    # collect_rows' started_at sort.
+    rows.sort(key=lambda r: (r["live_full"] != "running", r["started_at"]))
+
     if not rows:
         if here_root is not None:
             print(f"No active gremlins for project: {here_root}")

--- a/skills/gremlins/gremlins.py
+++ b/skills/gremlins/gremlins.py
@@ -1030,9 +1030,8 @@ def do_list(args, here_root=None):
         include_closed=False,
     )
 
-    # Running gremlins float to the top; everything else keeps age-ascending
-    # order within its group. sort() is stable, so this composes with
-    # collect_rows' started_at sort.
+    # Running gremlins float to the top; within each group, older gremlins
+    # appear first by started_at.
     rows.sort(key=lambda r: (r["live_full"] != "running", r["started_at"]))
 
     if not rows:


### PR DESCRIPTION
## Summary

- Split the session-summary hook's auto-silence signal from the user's explicit close signal: the hook now touches a `summarized` marker instead of `closed`, so finished-but-not-acted-on gremlins remain in the default `/gremlins` view until the user runs `/gremlins close <id>`.
- Sort the default listing in `do_list` so running gremlins float to the top, with stalled/dead following in age-ascending order.
- Document the updated default behavior in `skills/gremlins/SKILL.md`.

Closes #22

## Test plan

- [ ] Confirm `/gremlins` with a mix of running and finished-unclosed gremlins shows both, running first.
- [ ] Confirm `/gremlins --running` shows only currently-running gremlins (the previous default).
- [ ] Confirm `/gremlins close <id>` hides the gremlin from the default view.
- [ ] Stage a state dir with `finished` + `summarized` but no `closed`, and verify it still appears in `/gremlins`.