### PR TITLE
Strengthen reviewer file-output contract for mechanical-case short-circuit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,15 @@ Create the file under the corresponding repo directory (`skills/<name>/SKILL.md`
 
 The `ghgremlin` skill invokes [`skills/ghgremlin/ghgremlin.sh`](skills/ghgremlin/ghgremlin.sh) to run an end-to-end GitHub-issue-driven workflow: `/ghplan`, an implementation + PR creation stage, `/ghreview` (with a scope reviewer running in parallel), and `/ghaddress`.
 
+## The local gremlin
+
+The `localgremlin` skill runs plan → implement → three parallel reviewers (holistic, detail, scope) → address-code locally via [`skills/localgremlin/localgremlin.py`](skills/localgremlin/localgremlin.py). All artifacts land in `~/.local/state/claude-gremlins/<id>/artifacts/` off the product branch.
+
 Both `/ghgremlin` and `/localgremlin` accept `--design` as a first flag to invoke `/design` before the gremlin, running an interactive spec conversation and handing off automatically when the user is ready.
 
 ## Additional skills
 
-- [`/gremlins`](skills/gremlins/SKILL.md) — on-demand status of all background gremlins on this machine. Key subcommands: `stop <id>` (SIGTERM), `rescue <id>` (diagnose and resume inline), `rm <id>` (delete state directory, worktree directory, and branch), `land <id>` (squash-land a local gremlin or merge a gh PR and clean up). Use `--here` to filter to the current repo.
+- [`/gremlins`](skills/gremlins/SKILL.md) — on-demand status of all background gremlins on this machine. Key subcommands: `stop <id>` (SIGTERM), `rescue <id>` (diagnose and resume inline), `rm <id>` (delete state directory, worktree directory, and branch), `close <id>` (mark finished gremlin closed), `land <id>` (squash-land a local gremlin or merge a gh PR and clean up). Use `--here` to filter to the current repo.
 
 ## Not tracked
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ CLAUDE.md             # repo-level doc for Claude, loaded when cwd is this repo 
 home/CLAUDE.md        # global preferences, synced to ~/.claude/CLAUDE.md
 settings.json         # harness settings: hooks, permissions, plugins
 skills/
-  _bg/                # background-gremlin scripts: launch.sh, finish.sh, session-summary.sh
+  _bg/                # background-gremlin scripts: finish.sh, launch.sh, liveness.sh, session-summary.sh, set-stage.sh
   design/             # /design: chat-driven spec writer; hands off to /ghgremlin or /localgremlin
   ghplan/             # /ghplan: draft a plan, post it as a GitHub issue
   ghgremlin/          # /ghgremlin: run the full gremlin in the background via skills/_bg/launch.sh
@@ -53,7 +53,7 @@ The skills cluster into a GitHub-issue-driven gremlin and a local gremlin (`/loc
 - [`/localgremlin`](skills/localgremlin/SKILL.md) — local (no-GitHub) counterpart to `/ghgremlin`: runs plan → implement → three parallel reviewers (holistic, detail, scope) → address-code locally via [`skills/localgremlin/localgremlin.py`](skills/localgremlin/localgremlin.py), with all artifacts written to `~/.local/state/claude-gremlins/<id>/artifacts/` (off the product branch). Accepts `--design` to invoke `/design` first.
 - [`/gremlins`](skills/gremlins/SKILL.md) — on-demand status of background gremlins. Subcommands: `stop <id>`, `rescue <id>`, `rm <id>`, `close <id>`, `land <id>` (squash-land a local gremlin or merge a gh PR). Flags include `--here`, `--running`, `--dead`, `--stalled`, `--kind`, `--since`, `--recent`, `--watch`.
 
-`skills/ghgremlin/ghgremlin.sh` chains them: `/ghplan` → implement → `/ghreview` (Copilot + Claude) → `/ghaddress`, producing a merged-ready PR from a single instruction.
+`skills/ghgremlin/ghgremlin.sh` chains them: `/ghplan` → implement → `/ghreview` (Copilot + Claude in parallel with a scope reviewer) → `/ghaddress`, producing a merged-ready PR from a single instruction.
 
 ### Background execution
 

--- a/skills/localgremlin/localgremlin.py
+++ b/skills/localgremlin/localgremlin.py
@@ -298,7 +298,7 @@ Do NOT make any code changes — only write the review file.
 
 {focus}
 
-Write your review to `{out_file}`."""
+`{out_file}` is the canonical and required location for your review output in every case, including any short-circuit one-liner the lens tells you to emit. Do not emit the verdict only to chat; write it to `{out_file}` and then stop."""
     run_claude(model, prompt, label, raw_path)
 
 


### PR DESCRIPTION
## Summary

- The `/localgremlin` pipeline was dying with `review <model> did not produce <out>` when the holistic reviewer short-circuited on a mechanical change (see #25).
- Root cause: the holistic lens (`lens-holistic-code.md:3`) tells the reviewer to *"stop immediately and output exactly one line"*; the model honored that literally and printed to chat, bypassing the outer prompt's `` Write your review to `{out_file}` `` instruction. The triple-review guard at `localgremlin.py:418` then killed the run.
- Fix: strengthen the runner prompt in `run_review()` so `{out_file}` is explicitly the canonical output location in every case, including any short-circuit one-liner. The lens files and the empty-file safety net stay untouched.

## Test plan

- [ ] Read back the constructed prompt and confirm the short-circuit case is covered unambiguously.
- [ ] Future `/localgremlin` run against a mechanical change (e.g. a pure rename) completes through address-code without the `did not produce` failure.

Closes #25