### PR TITLE
Strengthen reviewer file-output contract for mechanical-case short-circuit

### DIFF
--- a/skills/localgremlin/localgremlin.py
+++ b/skills/localgremlin/localgremlin.py
@@ -298,7 +298,7 @@ Do NOT make any code changes — only write the review file.
 
 {focus}
 
-Write your review to `{out_file}`."""
+`{out_file}` is the canonical and required location for your review output in every case, including any short-circuit one-liner the lens tells you to emit. Do not emit the verdict only to chat; write it to `{out_file}` and then stop."""
     run_claude(model, prompt, label, raw_path)
 
 


### PR DESCRIPTION
## Summary

- The `/localgremlin` pipeline was dying with `review <model> did not produce <out>` when the holistic reviewer short-circuited on a mechanical change (see #25).
- Root cause: the holistic lens (`lens-holistic-code.md:3`) tells the reviewer to *"stop immediately and output exactly one line"*; the model honored that literally and printed to chat, bypassing the outer prompt's `` Write your review to `{out_file}` `` instruction. The triple-review guard at `localgremlin.py:418` then killed the run.
- Fix: strengthen the runner prompt in `run_review()` so `{out_file}` is explicitly the canonical output location in every case, including any short-circuit one-liner. The lens files and the empty-file safety net stay untouched.

## Test plan

- [ ] Read back the constructed prompt and confirm the short-circuit case is covered unambiguously.
- [ ] Future `/localgremlin` run against a mechanical change (e.g. a pure rename) completes through address-code without the `did not produce` failure.

Closes #25