### PR TITLE
Stop gremlin status from polluting claude -p commit messages

### DIFF
--- a/skills/_bg/session-summary.sh
+++ b/skills/_bg/session-summary.sh
@@ -9,6 +9,12 @@
 # session.
 set -u
 
+# Opt-out for callers that invoke `claude -p` for structured text output (e.g.
+# commit-message synthesis in gremlins.py `land`). The hook's "surface this
+# verbatim" directive otherwise prepends the status block to the model's reply
+# and corrupts the caller's parse.
+[[ "${CLAUDE_SKIP_GREMLIN_SUMMARY:-0}" == "1" ]] && exit 0
+
 # Missing jq → nothing to report. Bail before `set -e` would bite us anywhere.
 command -v jq >/dev/null 2>&1 || exit 0
 

--- a/skills/_bg/session-summary.sh
+++ b/skills/_bg/session-summary.sh
@@ -12,10 +12,11 @@ set -u
 # Opt-out for callers that invoke `claude -p` for structured text output (e.g.
 # commit-message synthesis in gremlins.py `land`). The hook's "surface this
 # verbatim" directive otherwise prepends the status block to the model's reply
-# and corrupts the caller's parse.
-[[ "${CLAUDE_SKIP_GREMLIN_SUMMARY:-0}" == "1" ]] && exit 0
+# and corrupts the caller's parse. Repo-scoped prefix (not `CLAUDE_`) so we
+# don't collide with Claude Code's own env-var namespace.
+[[ "${GREMLIN_SKIP_SUMMARY:-0}" == "1" ]] && exit 0
 
-# Missing jq → nothing to report. Bail before `set -e` would bite us anywhere.
+# Missing jq → nothing to report, so exit quietly.
 command -v jq >/dev/null 2>&1 || exit 0
 
 STATE_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/claude-gremlins"

--- a/skills/gremlins/gremlins.py
+++ b/skills/gremlins/gremlins.py
@@ -849,9 +849,13 @@ Requirements:
 
 Output only the commit message text, nothing else."""
 
+    # Suppress the session-summary hook so its "surface this verbatim" directive
+    # doesn't prepend the gremlin status block to the commit message.
+    env = os.environ.copy()
+    env["CLAUDE_SKIP_GREMLIN_SUMMARY"] = "1"
     result = subprocess.run(
         ["claude", "-p", "--output-format", "text"],
-        input=prompt, capture_output=True, text=True, timeout=60,
+        input=prompt, capture_output=True, text=True, timeout=60, env=env,
     )
     if result.returncode != 0:
         raise RuntimeError(f"claude -p exited {result.returncode}: {result.stderr.strip()}")

--- a/skills/gremlins/gremlins.py
+++ b/skills/gremlins/gremlins.py
@@ -817,6 +817,25 @@ def _parse_commit_output(text: str) -> tuple:
     return subject, body
 
 
+def _run_claude_p_text(prompt: str, timeout: int = 60) -> str:
+    """Run `claude -p` and return its stdout as plain text.
+
+    Suppresses the session-summary hook via `GREMLIN_SKIP_SUMMARY=1`; otherwise
+    the hook's "surface this verbatim" directive prepends the gremlin status
+    block to the model's reply and corrupts structured output. Any `claude -p`
+    caller in this repo that parses the reply as text should go through here.
+    """
+    env = os.environ.copy()
+    env["GREMLIN_SKIP_SUMMARY"] = "1"
+    result = subprocess.run(
+        ["claude", "-p", "--output-format", "text"],
+        input=prompt, capture_output=True, text=True, timeout=timeout, env=env,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"claude -p exited {result.returncode}: {result.stderr.strip()}")
+    return result.stdout
+
+
 def _synthesize_commit_message_ai(inputs: dict) -> tuple:
     """Call `claude -p` to produce a commit message from gathered inputs."""
     parts = []
@@ -849,18 +868,8 @@ Requirements:
 
 Output only the commit message text, nothing else."""
 
-    # Suppress the session-summary hook so its "surface this verbatim" directive
-    # doesn't prepend the gremlin status block to the commit message.
-    env = os.environ.copy()
-    env["CLAUDE_SKIP_GREMLIN_SUMMARY"] = "1"
-    result = subprocess.run(
-        ["claude", "-p", "--output-format", "text"],
-        input=prompt, capture_output=True, text=True, timeout=60, env=env,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"claude -p exited {result.returncode}: {result.stderr.strip()}")
-
-    subject, body = _parse_commit_output(result.stdout)
+    stdout = _run_claude_p_text(prompt)
+    subject, body = _parse_commit_output(stdout)
     if not subject:
         raise RuntimeError("claude -p returned empty subject")
     return subject, body


### PR DESCRIPTION
## Summary

- `session-summary.sh` injects a "Background gremlins — finished since last check" block with an `IMPORTANT: surface this verbatim` directive into every `claude` invocation's context via `additionalContext`.
- When `gremlins.py` `land` shells out to `claude -p` to synthesize a squash-merge commit message, that directive overrides the prompt's "output only the commit message" instruction, so landed commits end up with a subject like `**Background gremlins — finished since last check:**`.
- Fix: the hook now exits early on `CLAUDE_SKIP_GREMLIN_SUMMARY=1`, and `gremlins.py` sets that env var only when invoking `claude -p` for commit-message synthesis. Other `claude -p` callers (the pipelines themselves, the rescue agent) are untouched and still see the summary.

## Test plan

- [ ] Land a local gremlin with a non-empty unsummarized finished peer in the state dir; confirm the composed subject is a real commit title, not the status block.
- [ ] Confirm `SessionStart` / `UserPromptSubmit` hooks in a normal Claude Code session still produce the gremlin summary (env var is not set outside the synthesis path).
- [ ] Confirm the hook exits cleanly on stdin containing a hook-event JSON when `CLAUDE_SKIP_GREMLIN_SUMMARY=1`.