### PR TITLE
Add headless mode to /gremlins rescue

### DIFF
--- a/skills/_bg/launch.sh
+++ b/skills/_bg/launch.sh
@@ -147,6 +147,11 @@ if [[ -n "$RESUME_GR_ID" ]]; then
     # pipeline's first set-stage call. The resumed pipeline will repopulate
     # stage_updated_at via set-stage.sh; sub_stage will reappear only when
     # the stage actually re-enters a sub-staged phase (e.g. review-code).
+    # Clear bail markers too: stale .bail_class would false-fire check_bail
+    # on the resumed stage (e.g. /ghreview finds nothing to flag but the
+    # old class is still present); stale .bail_reason / .bail_detail would
+    # mislabel a successfully-finished gremlin as `dead:bailed:<old>` in
+    # the liveness classifier, which prefers bail_reason over exit_code=0.
     jq --arg    status             "running" \
        --arg    stage              "$STAGE" \
        --arg    rescued_at         "$NOW_ISO" \
@@ -157,6 +162,9 @@ if [[ -n "$RESUME_GR_ID" ]]; then
         | del(.ended_at)
         | del(.sub_stage)
         | del(.stage_updated_at)
+        | del(.bail_class)
+        | del(.bail_reason)
+        | del(.bail_detail)
         | .rescue_count = ((.rescue_count // 0) + 1)
         | .rescued_at = $rescued_at
         | .resumed_from_stage = $resumed_from_stage

--- a/skills/_bg/liveness.sh
+++ b/skills/_bg/liveness.sh
@@ -40,7 +40,7 @@ liveness_of_state_file() {
     IFS=$'\x1f' read -r gr_status gr_pid gr_exit_code gr_bail_reason < <(
         jq -r '[.status, (.pid // "" | tostring),
                 (.exit_code // "" | tostring),
-                (.bail_reason // "")] | join("")' "$sf" 2>/dev/null || true
+                (.bail_reason // "")] | join("\u001f")' "$sf" 2>/dev/null || true
     )
 
     # Terminal: finish.sh (or headless rescue's bail path) wrote the

--- a/skills/_bg/liveness.sh
+++ b/skills/_bg/liveness.sh
@@ -31,20 +31,26 @@ liveness_of_state_file() {
     [[ -f "$sf" ]] || return 0
     # Note: avoid `status` as a local name — it's a special/readonly in zsh,
     # and this file is intended to be sourced from either bash or zsh hooks.
-    local wdir gr_status gr_pid gr_exit_code
+    local wdir gr_status gr_pid gr_exit_code gr_bail_reason
     wdir=$(dirname "$sf")
 
     # US (\x1f) separator, matching session-summary.sh and gremlins.py: bash
     # treats tab as IFS-whitespace and collapses consecutive empty columns, so
-    # a future 4th field could silently lose a value. US is non-whitespace.
-    IFS=$'\x1f' read -r gr_status gr_pid gr_exit_code < <(
+    # a future 5th field could silently lose a value. US is non-whitespace.
+    IFS=$'\x1f' read -r gr_status gr_pid gr_exit_code gr_bail_reason < <(
         jq -r '[.status, (.pid // "" | tostring),
-                (.exit_code // "" | tostring)] | join("\u001f")' "$sf" 2>/dev/null || true
+                (.exit_code // "" | tostring),
+                (.bail_reason // "")] | join("")' "$sf" 2>/dev/null || true
     )
 
-    # Terminal: finish.sh ran → `finished` marker exists.
+    # Terminal: finish.sh (or headless rescue's bail path) wrote the
+    # `finished` marker. A bail_reason takes precedence over the generic
+    # exit code so listings show *why* rescue gave up rather than just
+    # "dead:exit 2".
     if [[ -f "$wdir/finished" ]]; then
-        if [[ -n "$gr_exit_code" && "$gr_exit_code" != "0" && "$gr_exit_code" != "null" ]]; then
+        if [[ -n "$gr_bail_reason" ]]; then
+            echo "dead:bailed:$gr_bail_reason"
+        elif [[ -n "$gr_exit_code" && "$gr_exit_code" != "0" && "$gr_exit_code" != "null" ]]; then
             echo "dead:exit $gr_exit_code"
         else
             echo "dead:finished"

--- a/skills/_bg/set-bail.sh
+++ b/skills/_bg/set-bail.sh
@@ -35,7 +35,7 @@ TMP="$STATE_FILE.bail.tmp.$$"
 if jq --arg cls "$BAIL_CLASS" \
       --arg det "$BAIL_DETAIL" \
       '.bail_class = $cls
-       | (if $det == "" then . else .bail_detail = $det end)' \
+       | (if $det == "" then del(.bail_detail) else .bail_detail = $det end)' \
       "$STATE_FILE" > "$TMP" 2>/dev/null; then
     mv "$TMP" "$STATE_FILE" 2>/dev/null || rm -f "$TMP" 2>/dev/null
 else

--- a/skills/_bg/set-bail.sh
+++ b/skills/_bg/set-bail.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Atomically write bail_class (and optional bail_detail) to a background
+# gremlin's state.json. Stages — both shell (ghgremlin.sh, /ghreview,
+# /ghaddress) and python (localgremlin.py) — call this when they decline
+# to proceed so /gremlins rescue --headless can decide whether to attempt
+# recovery.
+#
+# Usage: set-bail.sh <gr_id> <bail_class> [bail_detail]
+#
+# Vocabulary for bail_class:
+#   reviewer_requested_changes  — code review flagged blocker findings
+#   security                    — review flagged security concern(s)
+#   secrets                     — change touches secrets/credentials
+#   other                       — generic; pair with a useful bail_detail
+#
+# Headless rescue refuses to run for the first three classes. `other` is
+# attempted with the full diagnose-and-fix path.
+#
+# Fails silently on any error: writing the marker must never break the
+# stage that's bailing.
+set -u
+
+GR_ID="${1:-}"
+BAIL_CLASS="${2:-}"
+BAIL_DETAIL="${3:-}"
+
+[[ -n "$GR_ID" && -n "$BAIL_CLASS" ]] || exit 0
+
+STATE_FILE="${XDG_STATE_HOME:-$HOME/.local/state}/claude-gremlins/$GR_ID/state.json"
+[[ -f "$STATE_FILE" ]] || exit 0
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+TMP="$STATE_FILE.bail.tmp.$$"
+if jq --arg cls "$BAIL_CLASS" \
+      --arg det "$BAIL_DETAIL" \
+      '.bail_class = $cls
+       | (if $det == "" then . else .bail_detail = $det end)' \
+      "$STATE_FILE" > "$TMP" 2>/dev/null; then
+    mv "$TMP" "$STATE_FILE" 2>/dev/null || rm -f "$TMP" 2>/dev/null
+else
+    rm -f "$TMP" 2>/dev/null
+fi
+exit 0

--- a/skills/ghaddress/SKILL.md
+++ b/skills/ghaddress/SKILL.md
@@ -4,7 +4,7 @@ description: Address review comments on a GitHub PR. Fixes issues raised by revi
 argument-hint: <pr-reference> [instructions]
 context: fork
 agent: general-purpose
-allowed-tools: Bash(gh *) Read Glob Grep Edit
+allowed-tools: Bash(gh *) Bash(~/.claude/skills/_bg/set-bail.sh:*) Read Glob Grep Edit
 ---
 
 You are addressing review comments on a GitHub pull request. Your job is to fix the issues raised by reviewers and reply to each comment thread.
@@ -43,3 +43,23 @@ $ARGUMENTS[1:]
    - For questions or acknowledgements (no code change needed), reply briefly.
    - Skip comments that have already been resolved.
 5. Summarize what was done.
+
+## Bail markers (only when running under a gremlin)
+
+If the env var `GR_ID` is set, you are running inside a background gremlin pipeline. If you cannot safely address one or more comments, write a structured bail marker before finishing — `/gremlins rescue --headless` reads it to decide whether to attempt automated recovery. Do NOT make speculative changes when bailing; just record why and stop.
+
+Use the helper:
+
+- A comment touches **secrets** (credential management, API keys, encryption material) and you cannot safely make the requested change:
+
+  ```
+  ~/.claude/skills/_bg/set-bail.sh "$GR_ID" secrets "<one-line reason>"
+  ```
+
+- For any other reason you decline to proceed (ambiguous reviewer ask, conflicting comments, scope outside this PR, etc.):
+
+  ```
+  ~/.claude/skills/_bg/set-bail.sh "$GR_ID" other "<one-line reason>"
+  ```
+
+In both cases, also state in your final summary that you bailed and why. If you successfully addressed every actionable comment, do not write a bail marker — just exit normally.

--- a/skills/ghgremlin/ghgremlin.sh
+++ b/skills/ghgremlin/ghgremlin.sh
@@ -106,6 +106,20 @@ patch_state() {
   fi
 }
 
+# check_bail <stage-label> — if the just-completed stage wrote a bail_class
+# into state.json (via _bg/set-bail.sh), die so the gremlin pipeline halts
+# cleanly. /gremlins rescue --headless then reads bail_class to decide
+# whether to attempt automated recovery; for excluded classes (security,
+# secrets, reviewer_requested_changes) it refuses outright.
+check_bail() {
+  [[ -n "$STATE_FILE" && -f "$STATE_FILE" ]] || return 0
+  local label="${1:-stage}" cls
+  cls=$(jq -r '.bail_class // ""' "$STATE_FILE" 2>/dev/null)
+  if [[ -n "$cls" ]]; then
+    die "$label bailed: bail_class=$cls (see state.json bail_detail)"
+  fi
+}
+
 command -v claude >/dev/null || die "claude CLI not found"
 command -v gh >/dev/null     || die "gh CLI not found"
 command -v jq >/dev/null     || die "jq not found"
@@ -331,6 +345,7 @@ If the diff is scoped correctly, write exactly: 'Scoped correctly — nothing to
 
   wait "$pid_ghreview" || { kill "$pid_scope" 2>/dev/null; wait "$pid_scope" 2>/dev/null; die "/ghreview failed"; }
   wait "$pid_scope"    || die "scope reviewer failed"
+  check_bail "/ghreview"
 fi
 
 if run_stage wait-copilot; then
@@ -358,6 +373,7 @@ if run_stage ghaddress; then
   set_stage ghaddress
   echo "==> [6/6] running /ghaddress"
   claude -p "${CLAUDE_FLAGS[@]}" "/ghaddress $PR_URL" | progress_tee >/dev/null
+  check_bail "/ghaddress"
 fi
 
 echo ""

--- a/skills/ghreview/SKILL.md
+++ b/skills/ghreview/SKILL.md
@@ -3,7 +3,7 @@ name: ghreview
 description: Review a GitHub PR and post the review with inline comments. Takes a PR number or URL as argument.
 disable-model-invocation: true
 argument-hint: [pr-number-or-url]
-allowed-tools: Bash(gh *), Read, Grep, Glob
+allowed-tools: Bash(gh *), Bash(~/.claude/skills/_bg/set-bail.sh:*), Read, Grep, Glob
 ---
 
 # Review a GitHub PR and post inline comments
@@ -68,3 +68,23 @@ gh api repos/{owner}/{repo}/pulls/{number}/reviews --input /dev/stdin <<< '$JSON
 Write the JSON to a temp file if it's large, then pass it via `--input`.
 
 After posting, print a link to the PR so the user can see the review.
+
+## Step 5: Emit a bail marker (only when running under a gremlin)
+
+If the env var `GR_ID` is set, you are running inside a background gremlin pipeline. After posting the review, classify your findings and — if any are blocker-severity — write a structured bail marker so `/gremlins rescue --headless` knows not to autonomously address them:
+
+- **Security-related blocker** (auth gaps, injection, credential exposure, OWASP top 10 issues): the review identified one or more blocker-severity findings that are security-related. Run:
+
+  ```
+  ~/.claude/skills/_bg/set-bail.sh "$GR_ID" security "<one-line summary>"
+  ```
+
+- **Other blocker-severity findings** (correctness, design, anything else a human should weigh in on): run:
+
+  ```
+  ~/.claude/skills/_bg/set-bail.sh "$GR_ID" reviewer_requested_changes "<one-line summary>"
+  ```
+
+If the review has no blocker-severity findings (or `GR_ID` is unset because this is a direct human invocation), do not run the helper — exit normally.
+
+The bail marker is the signal the gremlin pipeline checks after this stage; you do not need to call `exit` yourself, the wrapper handles it.

--- a/skills/gremlins/SKILL.md
+++ b/skills/gremlins/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gremlins
 description: On-demand status of background gremlins launched by /localgremlin and /ghgremlin. Reads every ~/.local/state/claude-gremlins/<id>/state.json on the machine and prints one line per active gremlin with its kind, current stage, liveness (running / stalled / dead), description, and age. Use to check progress, spot crashed gremlins, close finished ones, stop a running gremlin, rescue a dead/stalled one, or land a finished gremlin onto its target branch. Not a project filter by default — set --here to restrict to the current repo.
-argument-hint: [stop|rescue|rm|close|land <id>] [--here] [--running] [--dead] [--stalled] [--kind local|gh] [--since <dur>] [--recent [N]] [--watch [sec]] [<id-prefix>]
+argument-hint: [stop|rescue [--headless]|rm|close|land <id>] [--here] [--running] [--dead] [--stalled] [--kind local|gh] [--since <dur>] [--recent [N]] [--watch [sec]] [<id-prefix>]
 allowed-tools: Bash(~/.claude/skills/gremlins/gremlins.py:*)
 ---
 
@@ -20,7 +20,7 @@ The script produces a small table. Each row is one gremlin:
 - `KIND` — `local` (from `/localgremlin`) or `gh` (from `/ghgremlin`).
 - `ID` — short (6-hex) gremlin identifier. Use it with `close <id>` to mark a dead gremlin as closed (which hides it from future runs of this command).
 - `STAGE` — the gremlin's current stage name (e.g. `plan`, `implement`, `review-code`). For parallel reviewers, a parenthesized sub-stage shows each reviewer's state (e.g. `review-code (opus=done,sonnet=running)`).
-- `LIVENESS` — `running`, `stalled:<reason>`, or `dead:<reason>`.
+- `LIVENESS` — `running`, `stalled:<reason>`, `dead:<reason>`, or `dead:bailed:<bail-reason>` (set when `/gremlins rescue --headless` declined to proceed; see `rescue` below).
 - `AGE` — time since launch.
 - `DESCRIPTION` — the short human phrase captured at launch.
 
@@ -37,7 +37,17 @@ The script produces a small table. Each row is one gremlin:
 - `--watch [sec]`: refresh the view every `sec` seconds (default 2). Press Ctrl-C to stop cleanly. Mutually exclusive with the `<id-prefix>` positional argument. Composable with all listing flags and `--recent`.
 - `<id-prefix>`: substring to drill into a single gremlin — prints every field from `state.json` plus computed liveness, age, and local start time. Mutually exclusive with `--watch`.
 - `stop <id>`: send SIGTERM to a running (or stalled) gremlin's process group and wait up to 6 seconds for it to exit cleanly. If the process doesn't exit in time, marks it stopped manually. Use when you want to cancel an in-progress gremlin.
-- `rescue <id>`: two-phase diagnose-then-resume for a dead or stalled gremlin. **Phase A (foreground):** reads the failure log and existing artifacts, then spawns a `claude -p` agent **inline** in the gremlin's worktree to diagnose and fix the underlying issue. Ctrl-C to abort — state is preserved, no handoff happens. **Phase B (background):** on Phase A exit 0, invokes `~/.claude/skills/_bg/launch.sh --resume <id>` which relaunches the gremlin pipeline at the failed stage under the original gremlin id (visible again under `/gremlins`). The `LIVENESS` column is decorated with ` (rescue)` or ` (rescue x<N>)` so rescued gremlins are distinguishable at a glance. After the resumed gremlin finishes, run `/gremlins land <id>` to merge. If the gremlin is still running, `rescue` refuses and suggests `stop` first.
+- `rescue <id>` (interactive, default): two-phase diagnose-then-resume for a dead or stalled gremlin. **Phase A (foreground):** reads the failure log and existing artifacts, then spawns a `claude -p` agent **inline** in the gremlin's worktree to diagnose and fix the underlying issue. Ctrl-C to abort — state is preserved, no handoff happens. **Phase B (background):** on Phase A exit 0, invokes `~/.claude/skills/_bg/launch.sh --resume <id>` which relaunches the gremlin pipeline at the failed stage under the original gremlin id (visible again under `/gremlins`). The `LIVENESS` column is decorated with ` (rescue)` or ` (rescue x<N>)` so rescued gremlins are distinguishable at a glance. After the resumed gremlin finishes, run `/gremlins land <id>` to merge. If the gremlin is still running, `rescue` refuses and suggests `stop` first. If the gremlin has already been rescued ≥ 3 times, interactive rescue prints a warning and proceeds anyway (the cap is for unattended callers — see `--headless`).
+- `rescue --headless <id>`: same two-phase flow, run end-to-end with no TTY and no user input — for unattended callers (humans walking away, future bossgremlin). Differences from interactive:
+  - **Excluded bail classes:** before running Phase A, reads `bail_class` from `state.json`. If it's `reviewer_requested_changes`, `security`, or `secrets`, refuses immediately, writes `bail_reason=excluded_class:<class>` and `bail_detail` to state.json, touches the `finished` marker, and exits non-zero. The gremlin's liveness becomes `dead:bailed:excluded_class:<class>`.
+  - **Attempt cap:** before running Phase A, checks `rescue_count` (the same field interactive rescue increments via `launch.sh --resume`). At ≥ 3, hard-refuses with `bail_reason=attempts_exhausted` and exits non-zero.
+  - **Phase A contract:** runs `claude -p --permission-mode bypassPermissions --output-format text` with stdin closed and a wall-clock timeout (default 1800s, override via `HEADLESS_RESCUE_TIMEOUT_SECS`). The headless prompt instructs the agent to write a marker JSON file at `<state-dir>/artifacts/rescue-<ts>.done` containing `{"status": "fixed" | "transient" | "unsalvageable", "summary": "..."}`. The wrapper reads the marker:
+    - `fixed` / `transient` → proceed to Phase B as normal (a `transient` status is a relaunch-only attempt for flaky tool/network failures).
+    - `unsalvageable` → write `bail_reason=unsalvageable`, exit non-zero.
+    - timeout / non-zero claude exit / missing marker / unparseable marker → write a corresponding `phase_a_*` `bail_reason`, exit non-zero.
+  - **Bail visibility:** every bail path writes `bail_reason` (machine-readable) and `bail_detail` (human-readable) to `state.json` and marks the gremlin terminal so listings make clear it isn't coming back. Use the drill-in view (`/gremlins <id>`) to inspect both fields plus any upstream `bail_class`.
+
+  The bail-class vocabulary the upstream stages may write is documented in `~/.claude/skills/_bg/set-bail.sh`. The current set is `reviewer_requested_changes`, `security`, `secrets`, `other` — only `other` is attempted by headless rescue.
 - `rm <id>`: delete a dead or finished gremlin's state directory from disk (the log, plan, reviews, and `state.json`). Refuses with an error if the gremlin is still running or stalled — use `stop` first, then `rm`. This is permanent; use when you want to fully clean up a gremlin rather than just hide it with `close`.
 - `close <id>`: mark a dead or finished gremlin as closed (hides it from the default list view). Artifacts, logs, state directory, and branch remain on disk until `rm` is run. If the gremlin is still running or stalled, `close` will refuse and suggest using `stop` first.
 - `land <id>`: land a finished gremlin onto its target branch, then clean up. Behavior depends on gremlin kind:

--- a/skills/gremlins/SKILL.md
+++ b/skills/gremlins/SKILL.md
@@ -20,7 +20,7 @@ The script produces a small table. Each row is one gremlin:
 - `KIND` — `local` (from `/localgremlin`) or `gh` (from `/ghgremlin`).
 - `ID` — short (6-hex) gremlin identifier. Use it with `close <id>` to mark a dead gremlin as closed (which hides it from future runs of this command).
 - `STAGE` — the gremlin's current stage name (e.g. `plan`, `implement`, `review-code`). For parallel reviewers, a parenthesized sub-stage shows each reviewer's state (e.g. `review-code (opus=done,sonnet=running)`).
-- `LIVENESS` — `running`, `stalled:<reason>`, `dead:<reason>`, or `dead:bailed:<bail-reason>` (set when `/gremlins rescue --headless` declined to proceed; see `rescue` below).
+- `LIVENESS` — `running`, `stalled:<reason>`, `dead:<reason>`, or `dead:bailed:<bail-reason>` (set when `/gremlins rescue --headless` declined to proceed; see `rescue` below). An upstream stage writing `bail_class` (via `set-bail.sh`) halts the pipeline but surfaces here as `dead:exit <N>` — drill in with `/gremlins <id>` to see the `bail:` block explaining which class fired and why.
 - `AGE` — time since launch.
 - `DESCRIPTION` — the short human phrase captured at launch.
 

--- a/skills/gremlins/gremlins.py
+++ b/skills/gremlins/gremlins.py
@@ -37,9 +37,14 @@ FMT = "%-5s  %-47s  %-22s  %-28s  %-5s  %s"
 # while headless hard-refuses. The wall-clock timeout bounds Phase A so a
 # stuck `claude -p` doesn't hang an unattended caller indefinitely.
 RESCUE_CAP = 3
-HEADLESS_PHASE_A_TIMEOUT_SECS = int(
-    os.environ.get("HEADLESS_RESCUE_TIMEOUT_SECS") or 1800
-)
+try:
+    HEADLESS_PHASE_A_TIMEOUT_SECS = int(
+        os.environ.get("HEADLESS_RESCUE_TIMEOUT_SECS") or 1800
+    )
+except (ValueError, TypeError):
+    # A misconfigured env var must not break the rest of /gremlins (listing,
+    # stop, rm, close, land). Fall back silently to the default.
+    HEADLESS_PHASE_A_TIMEOUT_SECS = 1800
 
 # Bail classes the upstream stages may write into state.json.bail_class.
 # The first three are excluded from headless rescue: the spec is explicit
@@ -510,7 +515,10 @@ def _atomic_patch_state(sf: str, patch: dict) -> bool:
     except Exception:
         return False
     state.update(patch)
-    tmp = sf + ".bail.tmp"
+    # Unique temp path (pid-scoped) so two concurrent bail-patchers can't
+    # clobber each other's in-flight write. Matches the `$$`-suffixed
+    # pattern used by set-stage.sh / set-bail.sh.
+    tmp = f"{sf}.bail.tmp.{os.getpid()}"
     try:
         with open(tmp, "w", encoding="utf-8") as fh:
             json.dump(state, fh, indent=2)
@@ -572,11 +580,15 @@ def _run_headless_phase_a(workdir: str, prompt: str, marker_path: str):
         prompt,
     ]
     try:
+        # Discard stdout — the agent's reply can be large and we don't read
+        # it (results come from the marker file, not the process output).
+        # Keep stderr for the failure-path snippet.
         result = subprocess.run(
             cmd,
             cwd=workdir,
             stdin=subprocess.DEVNULL,
-            capture_output=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             text=True,
             timeout=HEADLESS_PHASE_A_TIMEOUT_SECS,
             env=env,

--- a/skills/gremlins/gremlins.py
+++ b/skills/gremlins/gremlins.py
@@ -32,6 +32,21 @@ STATE_ROOT = os.path.join(
 
 FMT = "%-5s  %-47s  %-22s  %-28s  %-5s  %s"
 
+# Headless rescue caps. The attempt cap is shared across interactive and
+# headless rescues — both check `rescue_count`, but interactive only warns
+# while headless hard-refuses. The wall-clock timeout bounds Phase A so a
+# stuck `claude -p` doesn't hang an unattended caller indefinitely.
+RESCUE_CAP = 3
+HEADLESS_PHASE_A_TIMEOUT_SECS = int(
+    os.environ.get("HEADLESS_RESCUE_TIMEOUT_SECS") or 1800
+)
+
+# Bail classes the upstream stages may write into state.json.bail_class.
+# The first three are excluded from headless rescue: the spec is explicit
+# that interpreting reviewer-blocking changes, security findings, or
+# secrets-touching diffs autonomously is not safe. `other` is attempted.
+EXCLUDED_BAIL_CLASSES = ("reviewer_requested_changes", "security", "secrets")
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -101,9 +116,15 @@ def liveness_of_state_file(sf: str, state=None) -> str:
     gr_status = state.get("status")
     gr_pid = state.get("pid")
     gr_exit_code = state.get("exit_code")
+    gr_bail_reason = state.get("bail_reason")
 
-    # Terminal: finish.sh ran → `finished` marker exists.
+    # Terminal: finish.sh (or headless rescue's bail path) wrote the
+    # `finished` marker. A bail_reason takes precedence over the generic
+    # exit code so listings show *why* rescue gave up rather than just
+    # "dead:exit 2".
     if os.path.isfile(os.path.join(wdir, "finished")):
+        if gr_bail_reason:
+            return f"dead:bailed:{gr_bail_reason}"
         if gr_exit_code is not None and gr_exit_code != 0 and gr_exit_code != "null":
             return f"dead:exit {gr_exit_code}"
         return "dead:finished"
@@ -383,7 +404,8 @@ def do_stop(target: str) -> bool:
     return True
 
 
-def build_rescue_prompt(state, wdir, log_tail, artifact_paths):
+def build_rescue_prompt(state, wdir, log_tail, artifact_paths,
+                        *, headless=False, marker_path=None):
     kind = state.get("kind", "localgremlin")
     stage = state.get("stage") or "unknown"
     instructions = state.get("instructions") or "(not recorded)"
@@ -405,7 +427,7 @@ def build_rescue_prompt(state, wdir, log_tail, artifact_paths):
     rescue_note_path = os.path.join(wdir, "artifacts", f"rescue-{timestamp}.md")
     log_tail_safe = log_tail.replace("```", "` ` `")
 
-    return f"""You are diagnosing a failed background gremlin so it can resume.
+    head = f"""You are diagnosing a failed background gremlin so it can resume.
 
 ## Original task
 
@@ -426,7 +448,43 @@ Stage order for {kind}: {' → '.join(stages)}
 ```
 {log_tail_safe}
 ```
+"""
 
+    if headless:
+        return head + f"""
+## What to do (headless mode — no human is watching)
+
+1. Diagnose the failure from the log above.
+2. Decide which of these applies and act accordingly:
+   - **fixable**: edit code or clean up partial state in this worktree (working directory: {workdir}) so rerunning the failed stage ({stage}) will succeed.
+   - **transient**: the failure was a flake (network, tool timeout, retriable infra). No code change needed; rerunning the same stage as-is should succeed.
+   - **unsalvageable**: the failure cannot be fixed without human input. Do NOT make speculative changes.
+3. Write a brief rescue note to `{rescue_note_path}` describing what failed and what (if anything) you did.
+4. Write a marker file to **exactly** this path:
+
+       {marker_path}
+
+   The marker MUST be a single JSON object with these fields:
+   - `"status"`: one of `"fixed"`, `"transient"`, or `"unsalvageable"` (mapping to the cases above).
+   - `"summary"` (optional): a one-line string explaining your decision.
+
+   Example:
+
+   ```json
+   {{"status": "fixed", "summary": "removed stale lockfile blocking the build"}}
+   ```
+
+5. Stop. Do NOT re-run the failed stage or any remaining stages yourself — the wrapper reads the marker and (on `fixed`/`transient`) hands off to a background resume that relaunches the pipeline starting at {stage}. On `unsalvageable`, the wrapper writes a bail reason and the gremlin stays terminal.
+
+Constraints for headless mode:
+- Do NOT prompt for input; there is no TTY.
+- Do NOT call `exit` or otherwise abort — finish normally so the wrapper can read the marker.
+- If you cannot write the marker file, the wrapper will treat that as an unsalvageable failure.
+
+Work directly in the current directory. Do not re-invoke the gremlin script.
+"""
+
+    return head + f"""
 ## What to do
 
 1. Diagnose the failure from the log above.
@@ -438,7 +496,123 @@ Work directly in the current directory. Do not re-invoke the gremlin script.
 """
 
 
-def do_rescue(target: str) -> bool:
+def _atomic_patch_state(sf: str, patch: dict) -> bool:
+    """Merge `patch` into state.json atomically. Returns True on success.
+
+    Used by headless rescue's bail paths so a partial write can't leave
+    state.json corrupt mid-bail. Stages that need to write a single field
+    (bail_class, stage) should still go through their dedicated jq-based
+    helper scripts for parity with the non-Python callers.
+    """
+    try:
+        with open(sf, encoding="utf-8") as fh:
+            state = json.load(fh)
+    except Exception:
+        return False
+    state.update(patch)
+    tmp = sf + ".bail.tmp"
+    try:
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(state, fh, indent=2)
+        os.replace(tmp, sf)
+        return True
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        return False
+
+
+def _write_bail(sf: str, wdir: str, bail_reason: str, bail_detail: str = "") -> None:
+    """Mark a gremlin as bailed by headless rescue.
+
+    Writes bail_reason/bail_detail/status/exit_code/ended_at into state.json
+    and touches the `finished` marker so liveness classifies the gremlin as
+    terminal (`dead:bailed:<reason>`). Best-effort throughout — failing to
+    write either piece leaves the gremlin in its prior state, which is no
+    worse than before headless rescue ran.
+    """
+    now_iso = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    _atomic_patch_state(sf, {
+        "bail_reason": bail_reason,
+        "bail_detail": bail_detail,
+        "status": "bailed",
+        "exit_code": 2,
+        "ended_at": now_iso,
+    })
+    try:
+        pathlib.Path(os.path.join(wdir, "finished")).touch()
+    except OSError:
+        pass
+
+
+def _run_headless_phase_a(workdir: str, prompt: str, marker_path: str):
+    """Run Phase A non-interactively. Returns (status, error_msg).
+
+    status ∈ {"fixed", "transient", "unsalvageable"} → handled by caller
+    status ∈ {"timeout", "claude_exit", "no_marker", "bad_marker"} →
+        Phase A failure modes that should write a bail_reason.
+
+    error_msg is empty for the success-shaped statuses ("fixed",
+    "transient") and populated for the failure-shaped ones (including
+    "unsalvageable", which carries the agent's summary if provided).
+    """
+    env = os.environ.copy()
+    # Same rationale as _run_claude_p_text below — keep the session-summary
+    # hook from prepending its block to the agent's output, which would
+    # otherwise corrupt anything the agent prints to its final reply (we
+    # don't actually read the reply here, but the hook also slows things
+    # down materially when scanning state).
+    env["GREMLIN_SKIP_SUMMARY"] = "1"
+    cmd = [
+        "claude", "-p",
+        "--permission-mode", "bypassPermissions",
+        "--output-format", "text",
+        prompt,
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=workdir,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=HEADLESS_PHASE_A_TIMEOUT_SECS,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        return "timeout", f"claude -p exceeded {HEADLESS_PHASE_A_TIMEOUT_SECS}s"
+    except FileNotFoundError:
+        return "claude_exit", "'claude' CLI not found in PATH"
+
+    if result.returncode != 0:
+        stderr_snip = (result.stderr or "").strip().splitlines()[-1:] or [""]
+        return "claude_exit", f"claude -p exited {result.returncode}: {stderr_snip[0]}"
+
+    if not os.path.isfile(marker_path):
+        return "no_marker", f"agent did not write marker file at {marker_path}"
+
+    try:
+        with open(marker_path, encoding="utf-8") as fh:
+            marker = json.load(fh)
+    except Exception as exc:
+        return "bad_marker", f"marker file unreadable: {exc}"
+
+    if not isinstance(marker, dict):
+        return "bad_marker", "marker file is not a JSON object"
+
+    status = marker.get("status")
+    summary = marker.get("summary") or ""
+    if status not in ("fixed", "transient", "unsalvageable"):
+        return "bad_marker", f"marker has invalid status: {status!r}"
+
+    if status == "unsalvageable":
+        return status, summary or "agent declared failure unsalvageable"
+    return status, ""
+
+
+def do_rescue(target: str, headless: bool = False) -> bool:
     match = resolve_gremlin(target)
     if match is None:
         return False
@@ -462,11 +636,51 @@ def do_rescue(target: str) -> bool:
         if not do_stop(target):
             print("error: could not stop the stalled gremlin — aborting rescue")
             return False
+        # Reload state — do_stop wrote ended_at / status / exit_code via the
+        # finished-marker fallback, and we want the fresh values for the
+        # bail-class and rescue_count checks below.
+        state = load_state(sf) or state
 
     workdir = state.get("workdir")
     if not workdir:
         print(f"error: no workdir recorded in state for {gr_id} — cannot rescue")
         return False
+
+    rescue_count_raw = state.get("rescue_count") or 0
+    try:
+        rescue_count = int(rescue_count_raw)
+    except (ValueError, TypeError):
+        rescue_count = 0
+
+    bail_class = state.get("bail_class") or ""
+
+    # Headless: hard-refuse on excluded class or exhausted attempts. Both
+    # paths write a fresh bail_reason (overwriting any prior one) so the
+    # most recent decision is what /gremlins listings show.
+    if headless:
+        if bail_class in EXCLUDED_BAIL_CLASSES:
+            reason = f"excluded_class:{bail_class}"
+            detail = state.get("bail_detail") \
+                or f"upstream stage bailed with bail_class={bail_class}"
+            _write_bail(sf, wdir, reason, detail)
+            print(f"headless rescue refused: {reason}")
+            return False
+        if rescue_count >= RESCUE_CAP:
+            reason = "attempts_exhausted"
+            detail = f"rescue_count={rescue_count} reached cap of {RESCUE_CAP}"
+            _write_bail(sf, wdir, reason, detail)
+            print(f"headless rescue refused: {reason}")
+            return False
+    else:
+        # Interactive: warn but let the human override. The cap is
+        # primarily a guardrail for autonomous callers; a person watching
+        # Phase A can decide for themselves whether attempt #4 is worth it.
+        if rescue_count >= RESCUE_CAP:
+            print(
+                f"warning: gremlin has been rescued {rescue_count} times "
+                f"(cap is {RESCUE_CAP}); proceeding because this is interactive — "
+                f"Ctrl-C to abort."
+            )
 
     stage = state.get("stage") or "unknown"
 
@@ -488,39 +702,87 @@ def do_rescue(target: str) -> bool:
             if os.path.isfile(fpath):
                 artifact_paths.append(fpath)
 
-    prompt = build_rescue_prompt(state, wdir, log_tail, artifact_paths)
+    marker_path = None
+    if headless:
+        # The marker file is the contract between the headless agent and
+        # this wrapper. We pre-create the artifacts dir so the agent doesn't
+        # need to mkdir it themselves — one less thing to get wrong.
+        try:
+            os.makedirs(artifacts_dir, exist_ok=True)
+        except OSError:
+            pass
+        ts = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+        marker_path = os.path.join(artifacts_dir, f"rescue-{ts}.done")
+
+    prompt = build_rescue_prompt(state, wdir, log_tail, artifact_paths,
+                                 headless=headless, marker_path=marker_path)
 
     print(f"Rescuing gremlin {gr_id} (stage: {stage}, liveness: {live})")
     print(f"Working directory: {workdir}")
-    print("Phase A: running diagnosis agent inline — Ctrl-C to abort.")
-    print()
 
-    try:
-        result = subprocess.run(["claude", "-p", prompt], cwd=workdir)
-    except FileNotFoundError:
-        print("error: 'claude' CLI not found in PATH")
-        return False
-    except KeyboardInterrupt:
-        print("\nRescue aborted by user. Gremlin state preserved — rerun /gremlins rescue, rm, or close.")
-        return False
+    if headless:
+        print(
+            f"Phase A (headless): running diagnosis agent "
+            f"(timeout: {HEADLESS_PHASE_A_TIMEOUT_SECS}s, marker: {marker_path})..."
+        )
+        status, err_msg = _run_headless_phase_a(workdir, prompt, marker_path)
 
-    if result.returncode != 0:
+        if status == "timeout":
+            _write_bail(sf, wdir, "phase_a_timeout", err_msg)
+            print(f"Phase A timed out: {err_msg}")
+            return False
+        if status == "claude_exit":
+            _write_bail(sf, wdir, "phase_a_claude_error", err_msg)
+            print(f"Phase A claude error: {err_msg}")
+            return False
+        if status == "no_marker":
+            _write_bail(sf, wdir, "phase_a_no_marker", err_msg)
+            print(f"Phase A produced no marker file: {err_msg}")
+            return False
+        if status == "bad_marker":
+            _write_bail(sf, wdir, "phase_a_bad_marker", err_msg)
+            print(f"Phase A marker file invalid: {err_msg}")
+            return False
+        if status == "unsalvageable":
+            _write_bail(sf, wdir, "unsalvageable", err_msg)
+            print(f"Phase A: agent declared the failure unsalvageable ({err_msg})")
+            return False
+        # status == "fixed" or "transient" → proceed to Phase B. Both count
+        # as a rescue attempt; the launcher increments rescue_count when it
+        # actually relaunches.
+        print(f"Phase A complete (status: {status}); handing off to Phase B...")
+    else:
+        print("Phase A: running diagnosis agent inline — Ctrl-C to abort.")
         print()
-        print(f"Rescue agent exited with code {result.returncode}.")
-        print("Gremlin state preserved — rerun /gremlins rescue, rm, or close.")
-        print(f"Inspect the log at {log_path} and worktree at {workdir} for details.")
-        return False
+        try:
+            result = subprocess.run(["claude", "-p", prompt], cwd=workdir)
+        except FileNotFoundError:
+            print("error: 'claude' CLI not found in PATH")
+            return False
+        except KeyboardInterrupt:
+            print("\nRescue aborted by user. Gremlin state preserved — rerun /gremlins rescue, rm, or close.")
+            return False
+
+        if result.returncode != 0:
+            print()
+            print(f"Rescue agent exited with code {result.returncode}.")
+            print("Gremlin state preserved — rerun /gremlins rescue, rm, or close.")
+            print(f"Inspect the log at {log_path} and worktree at {workdir} for details.")
+            return False
 
     # Phase B: hand off to launch.sh --resume so the remaining stages run in the
     # background under the same GR_ID. launch.sh patches state.json, clears the
-    # finished/summarized markers, and relaunches the pipeline with
-    # --resume-from <stage>.
+    # finished/summarized markers, increments rescue_count, and relaunches the
+    # pipeline with --resume-from <stage>.
     launcher = os.path.expanduser("~/.claude/skills/_bg/launch.sh")
     # os.access(..., X_OK) rather than os.path.isfile: an un-chmod'd launcher
     # (e.g. after a manual edit) would pass the existence check and then fail
     # with a PermissionError inside subprocess.run, which isn't caught by the
     # FileNotFoundError handler below.
     if not os.access(launcher, os.X_OK):
+        if headless:
+            _write_bail(sf, wdir, "phase_b_launcher_missing",
+                        f"launcher not executable at {launcher}")
         print(f"error: launcher not executable at {launcher} — cannot resume in background")
         return False
 
@@ -532,10 +794,16 @@ def do_rescue(target: str) -> bool:
             cwd=workdir,
         )
     except FileNotFoundError:
+        if headless:
+            _write_bail(sf, wdir, "phase_b_launcher_missing",
+                        f"could not exec launcher at {launcher}")
         print(f"error: could not exec launcher at {launcher}")
         return False
 
     if resume_result.returncode != 0:
+        if headless:
+            _write_bail(sf, wdir, "phase_b_relaunch_failed",
+                        f"launcher exit {resume_result.returncode}")
         print(f"error: background resume failed (launcher exit {resume_result.returncode})")
         return False
 
@@ -1276,6 +1544,23 @@ def do_drill_in(target: str):
     print(f"  age      : {age}")
     if local_start:
         print(f"  started  : {local_start}")
+
+    # Surface bail markers (if any) above the raw state dump so they're
+    # immediately visible. bail_class is upstream-set by review/address
+    # stages; bail_reason/bail_detail are headless-rescue-set when it
+    # declined to proceed.
+    bail_class = state.get("bail_class")
+    bail_reason = state.get("bail_reason")
+    bail_detail = state.get("bail_detail")
+    if bail_class or bail_reason:
+        print("  bail:")
+        if bail_class:
+            print(f"    class  : {bail_class}")
+        if bail_reason:
+            print(f"    reason : {bail_reason}")
+        if bail_detail:
+            print(f"    detail : {bail_detail}")
+
     print("  state.json fields:")
     for key, val in state.items():
         print(f"    {key}: {json.dumps(val)}")
@@ -1313,6 +1598,9 @@ def parse_args(argv=None):
             "Subcommands (positional, before flags):\n"
             "  stop <id>     Send SIGTERM to a running gremlin and wait for it to exit.\n"
             "  rescue <id>   Diagnose and resume a dead or stalled gremlin inline.\n"
+            "                Pass --headless to run end-to-end with no TTY: refuses\n"
+            "                excluded bail classes, caps at 3 attempts, writes a\n"
+            "                bail_reason to state.json on bail.\n"
             "  rm <id>       Delete a dead/finished gremlin's state directory, worktree, and branch.\n"
             "  close <id>    Mark a dead/finished gremlin as closed (hides it from the default view).\n"
             "  land <id>     Land a finished gremlin: squash-merge locally (local) or merge the PR (gh).\n"
@@ -1414,7 +1702,8 @@ def _dispatch_subcommand():
         force = "--force" in raw
         ok = do_land(target, force=force)
     else:
-        ok = do_rescue(target)
+        headless = "--headless" in raw
+        ok = do_rescue(target, headless=headless)
     return True, ok
 
 

--- a/skills/localgremlin/localgremlin.py
+++ b/skills/localgremlin/localgremlin.py
@@ -36,6 +36,7 @@ from typing import List, Optional, Tuple
 
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 SET_STAGE_SH = pathlib.Path.home() / ".claude" / "skills" / "_bg" / "set-stage.sh"
+SET_BAIL_SH = pathlib.Path.home() / ".claude" / "skills" / "_bg" / "set-bail.sh"
 MODEL_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 GR_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
@@ -135,6 +136,32 @@ def set_stage(stage: str, sub_stage=None) -> None:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             check=False,
+        )
+    except Exception:
+        pass
+
+
+def emit_bail(bail_class: str, bail_detail: str = "") -> None:
+    """Shell out to set-bail.sh to record a bail_class (and optional detail)
+    on the running gremlin's state.json. Read by /gremlins rescue --headless
+    to decide whether to attempt automated recovery. No-op without GR_ID or
+    when the helper is missing — never raises, the stage is already failing
+    and bail bookkeeping must not mask the underlying error."""
+    gr_id = os.environ.get("GR_ID")
+    if not gr_id:
+        return
+    try:
+        if not SET_BAIL_SH.exists() or not os.access(str(SET_BAIL_SH), os.X_OK):
+            return
+    except Exception:
+        return
+    try:
+        subprocess.run(
+            [str(SET_BAIL_SH), gr_id, bail_class, bail_detail],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=5,
         )
     except Exception:
         pass
@@ -748,14 +775,23 @@ Task: {instructions}"""
         code_review_context = (
             f"The plan for this change is:\n\n{plan_text}\n\n{code_scope}"
         )
-        run_triple_review(
-            context=code_review_context,
-            focuses=(focus_a, focus_b, focus_c),
-            out_files=(review_code_a, review_code_b, review_code_c),
-            models=(args.holistic, args.detail, args.scope),
-            where_field="**File:** `path/to/file.ext:<line>`",
-            session_dir=session_dir,
-        )
+        # Wrap so any infrastructure failure (claude -p crash, missing
+        # output file, etc.) records bail_class=other before the SystemExit
+        # propagates. Headless rescue can attempt the `other` class — but
+        # at least the bail field tells callers *something* failed during
+        # review-code rather than leaving them to grep the log.
+        try:
+            run_triple_review(
+                context=code_review_context,
+                focuses=(focus_a, focus_b, focus_c),
+                out_files=(review_code_a, review_code_b, review_code_c),
+                models=(args.holistic, args.detail, args.scope),
+                where_field="**File:** `path/to/file.ext:<line>`",
+                session_dir=session_dir,
+            )
+        except (SystemExit, Exception) as exc:
+            emit_bail("other", f"review-code stage failed: {exc}"[:200])
+            raise
         print(f"    holistic code review ({args.holistic}): {review_code_a}", flush=True)
         print(f"    detail code review   ({args.detail}): {review_code_b}", flush=True)
         print(f"    scope code review    ({args.scope}): {review_code_c}", flush=True)
@@ -774,6 +810,18 @@ Task: {instructions}"""
         text_a = review_code_a.read_text(encoding="utf-8")
         text_b = review_code_b.read_text(encoding="utf-8")
         text_c = review_code_c.read_text(encoding="utf-8")
+        # Only attached when running under a gremlin so direct invocations
+        # (no GR_ID) don't see prompt instructions for a helper they can't
+        # usefully invoke.
+        bail_section = ""
+        if os.environ.get("GR_ID"):
+            bail_section = """
+
+If a finding asks you to change something that touches secrets/credentials, or you decline to address one or more findings for any other reason that should halt automated recovery, run the bail helper before finishing:
+  - `~/.claude/skills/_bg/set-bail.sh "$GR_ID" secrets "<one-line reason>"` if the blocked finding touches secrets.
+  - `~/.claude/skills/_bg/set-bail.sh "$GR_ID" other "<one-line reason>"` for any other reason you cannot proceed.
+Do not call this helper if you successfully addressed every actionable finding.
+"""
         address_prompt = f"""Three independent code reviews of the most recent implementation follow. The reviewers have different lenses by design, so their findings will mostly be complementary rather than overlapping — still deduplicate where they do overlap. For every actionable finding you agree with, make the fix in the code. For findings you disagree with or choose to skip, note them briefly in your final summary with a reason.
 
 ---
@@ -793,13 +841,17 @@ Task: {instructions}"""
 
 ---
 
-{address_commit_instr}
+{address_commit_instr}{bail_section}
 
 End with a short summary (to stdout) of: what you addressed, what you skipped and why."""
-        run_claude(
-            args.address, address_prompt, "address-code",
-            session_dir / "stream-address.jsonl",
-        )
+        try:
+            run_claude(
+                args.address, address_prompt, "address-code",
+                session_dir / "stream-address.jsonl",
+            )
+        except (SystemExit, Exception) as exc:
+            emit_bail("other", f"address-code stage failed: {exc}"[:200])
+            raise
 
     print("", flush=True)
     print(f"done. session artifacts in: {session_dir}", flush=True)


### PR DESCRIPTION
## Summary

`/gremlins rescue --headless <id>` runs the existing two-phase diagnose-then-resume flow end-to-end with no TTY and no user input — for unattended callers (humans walking away, future bossgremlin) that need to recover a failed gremlin without human presence. Default (interactive) rescue is unchanged.

### Headless flow

- **Pre-flight refusals.** Reads `bail_class` from `state.json`. If it's `reviewer_requested_changes`, `security`, or `secrets`, hard-refuses, writes `bail_reason=excluded_class:<class>` plus `bail_detail`, touches the `finished` marker, exits non-zero.
- **Attempt cap.** Shares `rescue_count` with interactive rescue; at ≥ 3, hard-refuses with `bail_reason=attempts_exhausted`. Interactive warns and proceeds.
- **Phase A contract.** `claude -p` with stdin closed, `bypassPermissions`, `--output-format text`, wall-clock timeout (default 1800s, override via `HEADLESS_RESCUE_TIMEOUT_SECS`). Agent writes `artifacts/rescue-<ts>.done` containing `{"status": "fixed" | "transient" | "unsalvageable", "summary": "..."}`. The wrapper reads it deterministically — no log scraping.
- **Bail visibility.** Every refusal/failure writes `bail_reason` (machine) and `bail_detail` (human) to state.json; liveness gains `dead:bailed:<reason>` (both Python and shell paths); the drill-in view surfaces a dedicated `bail:` block above the raw state dump.

### Upstream bail markers

- New `skills/_bg/set-bail.sh` — atomic helper for stages to write `bail_class` + `bail_detail`. Vocabulary: `reviewer_requested_changes`, `security`, `secrets`, `other`. Only `other` is attempted by headless rescue.
- `/ghreview` and `/ghaddress` get gremlin-only bail sections in their SKILL.md (gated on `$GR_ID` so direct human invocations are unchanged).
- `ghgremlin.sh` runs `check_bail` after `/ghreview` and `/ghaddress` so a bail marker halts the pipeline cleanly.
- `localgremlin.py` adds an `emit_bail` helper and wraps the review-code/address-code stages so claude -p crashes record `bail_class=other` before the SystemExit propagates; the address-code prompt grows a gremlin-only bail-instructions section.

### Open-question decisions taken

- Phase A failures don't increment `rescue_count` — only successful Phase B relaunches do (preserves `launch.sh`'s existing semantics; users aren't penalized for a broken rescue agent).
- Marker file (not stdout JSON) — robust against truncation, doesn't need parser drift across model versions.
- Interactive rescue at cap warns and proceeds; headless hard-refuses.
- New terminal liveness `dead:bailed:<reason>` rather than overloading `dead:finished`.
- Bossgremlin is out of scope (it's the user, not the deliverable).

Closes #35

## Test plan

- [x] `gremlins.py rescue --headless <bogus-id>` → "no gremlin matched", exit 1
- [x] state.json with `bail_class=reviewer_requested_changes` → headless refuses, writes `bail_reason=excluded_class:reviewer_requested_changes`, exits non-zero
- [x] state.json with `rescue_count=3` → headless refuses, writes `bail_reason=attempts_exhausted`, exits non-zero
- [x] Drill-in view shows the `bail:` block with class/reason/detail above the raw state dump
- [x] Default listing shows `dead:bailed:<reason>` in the LIVENESS column
- [x] `set-bail.sh` writes/updates `bail_class` and `bail_detail` atomically (with and without detail)
- [x] All shell scripts pass `bash -n`; both Python files pass `ast.parse`
- [ ] End-to-end: run a real failing gremlin, invoke headless rescue from a script with stdin closed, confirm Phase A → marker → Phase B handoff (deferred — needs a real gremlin pipeline)