### PR TITLE
Split /localreview and /localaddress out of /localgremlin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,11 +29,15 @@ The `ghgremlin` skill invokes [`skills/ghgremlin/ghgremlin.sh`](skills/ghgremlin
 
 The `localgremlin` skill runs plan → implement → three parallel reviewers (holistic, detail, scope) → address-code locally via [`skills/localgremlin/localgremlin.py`](skills/localgremlin/localgremlin.py). All artifacts land in `~/.local/state/claude-gremlins/<id>/artifacts/` off the product branch.
 
+The review-code and address-code stage bodies live in [`skills/localgremlin/_core.py`](skills/localgremlin/_core.py) alongside the orchestrator, so the standalone `/localreview` and `/localaddress` skills execute the same code as the gremlin's review and address stages.
+
 Both `/ghgremlin` and `/localgremlin` accept `--design` as a first flag to invoke `/design` before the gremlin, running an interactive spec conversation and handing off automatically when the user is ready.
 
 ## Additional skills
 
 - [`/gremlins`](skills/gremlins/SKILL.md) — on-demand status of all background gremlins on this machine. Key subcommands: `stop <id>` (SIGTERM), `rescue <id>` (Phase A: inline `claude -p` diagnoses and fixes the failure in the foreground; Phase B: `launch.sh --resume` relaunches the pipeline at the failed stage in the background under the original gremlin id, with a `(rescue)` liveness marker), `rm <id>` (delete state directory, worktree directory, and branch), `close <id>` (mark finished gremlin closed), `land <id>` (squash-land a local gremlin or merge a gh PR and clean up). Use `--here` to filter to the current repo.
+- [`/localreview`](skills/localreview/SKILL.md) — foreground: run the triple-lens parallel code review over local changes, writing `review-code-*.md` files to `--dir` (cwd by default). No planning, no implementation, no background gremlin.
+- [`/localaddress`](skills/localaddress/SKILL.md) — foreground: read the three `review-code-*.md` files from `--dir` and address actionable findings. In a git repo, creates a single `Address review feedback` commit (no push).
 
 ## Not tracked
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ skills/
   ghgremlin/          # /ghgremlin: run the full gremlin in the background via skills/_bg/launch.sh
   ghreview/           # /ghreview: review a PR and post inline comments
   ghaddress/          # /ghaddress: address review comments on a PR
-  localgremlin/       # /localgremlin: full local gremlin via skills/_bg/launch.sh; sibling lens-*.md files hold reviewer prompts
+  localgremlin/       # /localgremlin: full local gremlin via skills/_bg/launch.sh; sibling lens-*.md files hold reviewer prompts; _core.py holds the shared review/address stage bodies
+  localreview/        # /localreview: standalone triple-lens code review over local changes (foreground)
+  localaddress/       # /localaddress: standalone address-code stage over existing review files (foreground)
   gremlins/           # /gremlins: on-demand status of background gremlins; supports stop/rescue/rm/close/land subcommands
 agents/
   pragmatic-developer.md
@@ -50,7 +52,9 @@ The skills cluster into a GitHub-issue-driven gremlin and a local gremlin (`/loc
 - [`/ghgremlin`](skills/ghgremlin/SKILL.md) — run the full gremlin run end-to-end via [`skills/ghgremlin/ghgremlin.sh`](skills/ghgremlin/ghgremlin.sh).
 - [`/ghreview`](skills/ghreview/SKILL.md) — review a PR and post inline comments.
 - [`/ghaddress`](skills/ghaddress/SKILL.md) — address review comments on a PR and reply to each thread.
-- [`/localgremlin`](skills/localgremlin/SKILL.md) — local (no-GitHub) counterpart to `/ghgremlin`: runs plan → implement → three parallel reviewers (holistic, detail, scope) → address-code locally via [`skills/localgremlin/localgremlin.py`](skills/localgremlin/localgremlin.py), with all artifacts written to `~/.local/state/claude-gremlins/<id>/artifacts/` (off the product branch). Accepts `--design` to invoke `/design` first.
+- [`/localgremlin`](skills/localgremlin/SKILL.md) — local (no-GitHub) counterpart to `/ghgremlin`: runs plan → implement → three parallel reviewers (holistic, detail, scope) → address-code locally via [`skills/localgremlin/localgremlin.py`](skills/localgremlin/localgremlin.py), with all artifacts written to `~/.local/state/claude-gremlins/<id>/artifacts/` (off the product branch). Accepts `--design` to invoke `/design` first. Review-code and address-code stage bodies live in [`skills/localgremlin/_core.py`](skills/localgremlin/_core.py) and are shared with the standalone skills below.
+- [`/localreview`](skills/localreview/SKILL.md) — standalone triple-lens code review (holistic, detail, scope) over local changes, foreground. Writes `review-code-*.md` files to `--dir` (defaults to cwd).
+- [`/localaddress`](skills/localaddress/SKILL.md) — standalone address-code stage that reads `review-code-*.md` files from `--dir` and applies actionable findings. Foreground. In a git repo, creates one `Address review feedback` commit (no push).
 - [`/gremlins`](skills/gremlins/SKILL.md) — on-demand status of background gremlins. Subcommands: `stop <id>`, `rescue <id>`, `rm <id>`, `close <id>`, `land <id>` (squash-land a local gremlin or merge a gh PR). Flags include `--here`, `--running`, `--dead`, `--stalled`, `--kind`, `--since`, `--recent`, `--watch`.
 
 `skills/ghgremlin/ghgremlin.sh` chains them: `/ghplan` → implement → `/ghreview` (Copilot + Claude in parallel with a scope reviewer) → `/ghaddress`, producing a merged-ready PR from a single instruction.

--- a/skills/localaddress/SKILL.md
+++ b/skills/localaddress/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: localaddress
+description: Address findings from a set of `review-code-{holistic,detail,scope}-*.md` files in --dir, deduping overlaps and fixing actionable items. In a git repo, creates a single 'Address review feedback' commit (no push). Foreground, not backgrounded.
+argument-hint: [--dir <path>] [-x <address-model>]
+allowed-tools: Bash(~/.claude/skills/localgremlin/localaddress.py:*)
+---
+
+Read the three `review-code-{holistic,detail,scope}-*.md` review files from `--dir` and fix the actionable findings in the local code, using the same prompt and behavior as `/localgremlin`'s address-code stage.
+
+This skill runs **in the foreground** — it blocks until the fixes are made. It does not spawn a background gremlin, does not create a worktree, and does not push.
+
+## Inputs
+
+`--dir` must contain exactly one file matching each of:
+
+- `review-code-holistic-*.md`
+- `review-code-detail-*.md`
+- `review-code-scope-*.md`
+
+If any lens glob has zero or more than one match, the script errors naming which lens is missing or ambiguous.
+
+## Output
+
+- Edits in the working tree corresponding to findings the address stage agreed with.
+- In a git repo: a single `Address review feedback` commit whose body references all three review files. No push.
+- Outside a git repo: no commit — the changes are left in the working tree.
+- A short stdout summary of what was addressed and what was skipped (and why).
+
+## Arguments
+
+$ARGUMENTS
+
+Forward them verbatim to the script:
+
+```
+~/.claude/skills/localgremlin/localaddress.py $ARGUMENTS
+```
+
+Flags:
+
+- `--dir <path>` — directory containing the three review files. Must already exist. Defaults to cwd.
+- `-x <model>` — model used to apply the fixes. Defaults to `sonnet`.
+
+After the script exits, report the summary and, in a git repo, the new commit.

--- a/skills/localgremlin/_core.py
+++ b/skills/localgremlin/_core.py
@@ -526,10 +526,34 @@ def run_review_code_stage(
     """Execute the review-code stage: load lenses, fan out three reviewers,
     and return the three output paths. Emits bail_class=other on failure
     when running under a gremlin (no-op otherwise). Shared by the
-    orchestrator and /localreview."""
+    orchestrator and /localreview.
+
+    Passing ``plan_text=""`` (empty string, not None) intentionally omits
+    the plan block from the review prompt entirely — this is the contract
+    that lets standalone ``/localreview`` callers run without ``--plan``.
+    Any non-empty ``plan_text`` (even whitespace-only) takes the with-plan
+    branch and is rendered verbatim into the prompt.
+
+    Stale ``review-code-<lens>-*.md`` files for each lens are unlinked
+    before spawning the reviewers so a ``--resume-from review-code`` with
+    different ``-a/-b/-c`` models cannot leave the directory with two
+    files for the same lens (which would later confuse
+    ``run_address_code_stage``'s glob-based discovery).
+    """
     review_code_a = session_dir / f"review-code-holistic-{holistic}.md"
     review_code_b = session_dir / f"review-code-detail-{detail}.md"
     review_code_c = session_dir / f"review-code-scope-{scope}.md"
+
+    # Clean up stale per-lens review files from a previous run with
+    # different reviewer models. Without this, --resume-from review-code
+    # with changed -a/-b/-c would leave two files for the same lens and
+    # break run_address_code_stage's uniqueness check.
+    for lens in ("holistic", "detail", "scope"):
+        for stale in session_dir.glob(f"review-code-{lens}-*.md"):
+            try:
+                stale.unlink()
+            except OSError:
+                pass
 
     focus_a, focus_b, focus_c = load_lenses()
 
@@ -582,51 +606,68 @@ def run_address_code_stage(
 ) -> None:
     """Execute the address-code stage: glob for the three review files,
     build the address prompt, and invoke claude. Emits bail_class=other
-    on failure when running under a gremlin (no-op otherwise). Shared by
+    on failure when running under a gremlin (no-op otherwise) — including
+    failures during glob/validation before claude is spawned. Shared by
     the orchestrator and /localaddress."""
-    review_files = {}
-    for lens in ("holistic", "detail", "scope"):
-        matches = sorted(glob.glob(str(session_dir / f"review-code-{lens}-*.md")))
-        if not matches:
-            die(f"no review-code-{lens}-*.md file found in {session_dir}")
-        if len(matches) > 1:
-            die(
-                f"multiple review-code-{lens}-*.md files in {session_dir}: "
-                f"{', '.join(matches)}"
+    # Outer try/except so *any* stage failure (missing or ambiguous review
+    # files, invalid model in a filename, read errors, or the claude -p
+    # subprocess itself) records a bail marker before SystemExit
+    # propagates. Without this wrapping the pre-claude failure paths would
+    # exit via die() without ever calling emit_bail, and headless rescue
+    # would have no bail_class to act on.
+    try:
+        review_files = {}
+        for lens in ("holistic", "detail", "scope"):
+            matches = sorted(glob.glob(str(session_dir / f"review-code-{lens}-*.md")))
+            if not matches:
+                die(f"no review-code-{lens}-*.md file found in {session_dir}")
+            if len(matches) > 1:
+                die(
+                    f"multiple review-code-{lens}-*.md files in {session_dir}: "
+                    f"{', '.join(matches)}"
+                )
+            review_files[lens] = pathlib.Path(matches[0])
+
+        # Model names are embedded in the filenames as the suffix between
+        # the lens tag and the `.md` extension. Extracting them here keeps
+        # the address prompt's per-lens model labels in sync with the files
+        # that were actually produced, for both orchestrator and standalone
+        # callers. Validate against MODEL_RE so a malformed filename (e.g.
+        # review-code-holistic-.md, or one with unexpected characters)
+        # fails loudly instead of producing an empty/garbled prompt label.
+        def _model_from(path: pathlib.Path, lens: str) -> str:
+            stem = path.stem  # review-code-<lens>-<model>
+            prefix = f"review-code-{lens}-"
+            model = stem[len(prefix):] if stem.startswith(prefix) else ""
+            if not model or not MODEL_RE.match(model):
+                die(
+                    f"cannot extract a valid model name from review file: "
+                    f"{path.name}"
+                )
+            return model
+
+        model_a = _model_from(review_files["holistic"], "holistic")
+        model_b = _model_from(review_files["detail"], "detail")
+        model_c = _model_from(review_files["scope"], "scope")
+
+        text_a = review_files["holistic"].read_text(encoding="utf-8")
+        text_b = review_files["detail"].read_text(encoding="utf-8")
+        text_c = review_files["scope"].read_text(encoding="utf-8")
+
+        address_commit_instr = ""
+        if is_git:
+            address_commit_instr = (
+                "After making all fixes, stage the changed files by name and "
+                "create a single git commit titled 'Address review feedback' whose "
+                "body references all three review files. Do not push."
             )
-        review_files[lens] = pathlib.Path(matches[0])
 
-    # Model names are embedded in the filenames as the suffix between the
-    # lens tag and the `.md` extension. Extracting them here keeps the
-    # address prompt's per-lens model labels in sync with the files that
-    # were actually produced, for both orchestrator and standalone callers.
-    def _model_from(path: pathlib.Path, lens: str) -> str:
-        stem = path.stem  # review-code-<lens>-<model>
-        prefix = f"review-code-{lens}-"
-        return stem[len(prefix):] if stem.startswith(prefix) else stem
-
-    model_a = _model_from(review_files["holistic"], "holistic")
-    model_b = _model_from(review_files["detail"], "detail")
-    model_c = _model_from(review_files["scope"], "scope")
-
-    text_a = review_files["holistic"].read_text(encoding="utf-8")
-    text_b = review_files["detail"].read_text(encoding="utf-8")
-    text_c = review_files["scope"].read_text(encoding="utf-8")
-
-    address_commit_instr = ""
-    if is_git:
-        address_commit_instr = (
-            "After making all fixes, stage the changed files by name and "
-            "create a single git commit titled 'Address review feedback' whose "
-            "body references all three review files. Do not push."
-        )
-
-    # Only attached when running under a gremlin so direct invocations
-    # (no GR_ID) don't see prompt instructions for a helper they can't
-    # usefully invoke.
-    bail_section = ""
-    if os.environ.get("GR_ID"):
-        bail_section = """
+        # Only attached when running under a gremlin so direct invocations
+        # (no GR_ID) don't see prompt instructions for a helper they can't
+        # usefully invoke.
+        bail_section = ""
+        if os.environ.get("GR_ID"):
+            bail_section = """
 
 If a finding asks you to change something that touches secrets/credentials, or you decline to address one or more findings for any other reason that should halt automated recovery, run the bail helper before finishing:
   - `~/.claude/skills/_bg/set-bail.sh "$GR_ID" secrets "<one-line reason>"` if the blocked finding touches secrets.
@@ -634,7 +675,7 @@ If a finding asks you to change something that touches secrets/credentials, or y
 Do not call this helper if you successfully addressed every actionable finding.
 """
 
-    address_prompt = f"""Three independent code reviews of the most recent implementation follow. The reviewers have different lenses by design, so their findings will mostly be complementary rather than overlapping — still deduplicate where they do overlap. For every actionable finding you agree with, make the fix in the code. For findings you disagree with or choose to skip, note them briefly in your final summary with a reason.
+        address_prompt = f"""Three independent code reviews of the most recent implementation follow. The reviewers have different lenses by design, so their findings will mostly be complementary rather than overlapping — still deduplicate where they do overlap. For every actionable finding you agree with, make the fix in the code. For findings you disagree with or choose to skip, note them briefly in your final summary with a reason.
 
 ---
 **Holistic reviewer** (model: {model_a}):
@@ -656,7 +697,6 @@ Do not call this helper if you successfully addressed every actionable finding.
 {address_commit_instr}{bail_section}
 
 End with a short summary (to stdout) of: what you addressed, what you skipped and why."""
-    try:
         run_claude(
             address_model, address_prompt, "address-code",
             session_dir / "stream-address.jsonl",

--- a/skills/localgremlin/_core.py
+++ b/skills/localgremlin/_core.py
@@ -1,0 +1,666 @@
+"""Shared primitives for the /localgremlin, /localreview, and /localaddress
+skills.
+
+The orchestrator (`localgremlin.py`) and the two standalone CLIs
+(`localreview.py`, `localaddress.py`) share identical review-code and
+address-code stage logic; this module is the single source of truth for
+that code.
+
+Gremlin bookkeeping helpers (`set_stage`, `emit_bail`) are no-ops outside a
+gremlin context (no `GR_ID`), so standalone invocations of the CLIs use the
+same code paths without trying to patch a state.json that does not exist.
+"""
+
+import datetime
+import glob
+import json
+import os
+import pathlib
+import re
+import secrets
+import signal
+import subprocess
+import sys
+import threading
+import time
+from typing import List, Optional, Tuple
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+SET_STAGE_SH = pathlib.Path.home() / ".claude" / "skills" / "_bg" / "set-stage.sh"
+SET_BAIL_SH = pathlib.Path.home() / ".claude" / "skills" / "_bg" / "set-bail.sh"
+MODEL_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+GR_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+CLAUDE_FLAGS = [
+    "--permission-mode", "bypassPermissions",
+    "--output-format", "stream-json",
+    "--verbose",
+]
+
+
+# ---------------------------------------------------------------------------
+# Child-process tracking
+# ---------------------------------------------------------------------------
+# Reviewer threads spawn their own `claude -p` subprocesses in parallel. On
+# SIGINT/SIGTERM we need to terminate every live child so a Ctrl-C'd run
+# doesn't leave orphaned claude processes burning tokens (the bash equivalent
+# was `trap 'kill -- -$$'`). We keep a module-level list of Popens under a
+# reentrant lock — signal handlers run on the main thread and may land while
+# _track/_untrack already hold it, which would deadlock a plain Lock in that
+# narrow window. Children are added on spawn and removed on wait().
+_children_lock = threading.RLock()
+_children: List[subprocess.Popen] = []
+
+
+def _track(p: subprocess.Popen) -> None:
+    with _children_lock:
+        _children.append(p)
+
+
+def _untrack(p: subprocess.Popen) -> None:
+    with _children_lock:
+        try:
+            _children.remove(p)
+        except ValueError:
+            pass
+
+
+def _reap_all() -> None:
+    with _children_lock:
+        procs = list(_children)
+    for p in procs:
+        try:
+            p.terminate()
+        except Exception:
+            pass
+    deadline = time.time() + 2.0
+    for p in procs:
+        remaining = max(0.0, deadline - time.time())
+        try:
+            p.wait(timeout=remaining)
+        except Exception:
+            pass
+    for p in procs:
+        if p.poll() is None:
+            try:
+                p.kill()
+            except Exception:
+                pass
+
+
+def _signal_handler(signum, frame):
+    _reap_all()
+    sys.exit(130)
+
+
+def install_signal_handlers() -> None:
+    signal.signal(signal.SIGINT, _signal_handler)
+    signal.signal(signal.SIGTERM, _signal_handler)
+
+
+def die(msg: str) -> None:
+    sys.stderr.write(f"error: {msg}\n")
+    sys.stderr.flush()
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Stage bookkeeping
+# ---------------------------------------------------------------------------
+
+def set_stage(stage: str, sub_stage=None) -> None:
+    """Shell out to set-stage.sh. No-op without GR_ID or when the helper is
+    missing/non-executable. Never raises — stage bookkeeping must not break
+    a running gremlin."""
+    gr_id = os.environ.get("GR_ID")
+    if not gr_id:
+        return
+    try:
+        if not SET_STAGE_SH.exists() or not os.access(str(SET_STAGE_SH), os.X_OK):
+            return
+    except Exception:
+        return
+    args = [str(SET_STAGE_SH), gr_id, stage]
+    if sub_stage is not None:
+        try:
+            args.append(json.dumps(sub_stage))
+        except Exception:
+            return
+    try:
+        subprocess.run(
+            args,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except Exception:
+        pass
+
+
+def emit_bail(bail_class: str, bail_detail: str = "") -> None:
+    """Shell out to set-bail.sh to record a bail_class (and optional detail)
+    on the running gremlin's state.json. Read by /gremlins rescue --headless
+    to decide whether to attempt automated recovery. No-op without GR_ID or
+    when the helper is missing — never raises, the stage is already failing
+    and bail bookkeeping must not mask the underlying error."""
+    gr_id = os.environ.get("GR_ID")
+    if not gr_id:
+        return
+    try:
+        if not SET_BAIL_SH.exists() or not os.access(str(SET_BAIL_SH), os.X_OK):
+            return
+    except Exception:
+        return
+    try:
+        subprocess.run(
+            [str(SET_BAIL_SH), gr_id, bail_class, bail_detail],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=5,
+        )
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Stream-JSON logger
+# ---------------------------------------------------------------------------
+
+def _trunc(s, n: int = 200) -> str:
+    if s is None:
+        return ""
+    if not isinstance(s, str):
+        s = str(s)
+    s = s.replace("\n", " ")
+    return s[:n] + "..." if len(s) > n else s
+
+
+def _emit_event(prefix: str, evt: dict) -> None:
+    t = evt.get("type")
+    out = sys.stderr
+    if t == "system":
+        if evt.get("subtype") != "init":
+            return
+        out.write(
+            f"{prefix}init session={evt.get('session_id', '?')} "
+            f"model={evt.get('model', '?')} cwd={evt.get('cwd', '?')}\n"
+        )
+    elif t == "assistant":
+        content = (evt.get("message") or {}).get("content") or []
+        for c in content:
+            if not isinstance(c, dict):
+                continue
+            ct = c.get("type")
+            if ct == "text":
+                out.write(f"{prefix}text: {_trunc(c.get('text', ''))}\n")
+            elif ct == "tool_use":
+                inp = c.get("input") or {}
+                arg = ""
+                if isinstance(inp, dict):
+                    for k in ("file_path", "command", "pattern", "url", "output_file"):
+                        v = inp.get(k)
+                        if v:
+                            arg = v
+                            break
+                out.write(f"{prefix}tool: {c.get('name', '?')} {_trunc(str(arg))}\n")
+    elif t == "user":
+        content = (evt.get("message") or {}).get("content") or []
+        for c in content:
+            if not isinstance(c, dict) or c.get("type") != "tool_result":
+                continue
+            err = " ERROR" if c.get("is_error") is True else ""
+            body = c.get("content")
+            if isinstance(body, list):
+                body_s = " ".join(
+                    (p.get("text") or "") for p in body if isinstance(p, dict)
+                )
+            elif isinstance(body, str):
+                body_s = body
+            elif body is None:
+                body_s = ""
+            else:
+                body_s = str(body)
+            out.write(f"{prefix}result{err}: {_trunc(body_s)}\n")
+    elif t == "result":
+        cost = evt.get("total_cost_usd", evt.get("cost_usd", "?"))
+        out.write(
+            f"{prefix}final: subtype={evt.get('subtype', '?')} "
+            f"turns={evt.get('num_turns', '?')} cost={cost}\n"
+        )
+    out.flush()
+
+
+def log_stream(label: str, raw_path: pathlib.Path, stdout) -> None:
+    """Tee raw stream-json lines from `stdout` to `raw_path` and emit a
+    human-readable trace to stderr. Malformed lines are skipped silently
+    (parity with the bash `jq ... || true` — a truncated JSON line from a
+    crashing `claude -p` must not abort the stage)."""
+    prefix = f"[{label}] " if label else ""
+    with open(raw_path, "ab") as raw:
+        for line in stdout:
+            raw.write(line)
+            raw.flush()
+            try:
+                evt = json.loads(line.decode("utf-8", errors="replace"))
+            except Exception:
+                continue
+            if not isinstance(evt, dict):
+                continue
+            try:
+                _emit_event(prefix, evt)
+            except Exception:
+                continue
+
+
+# ---------------------------------------------------------------------------
+# Claude invocation
+# ---------------------------------------------------------------------------
+
+def run_claude(model: str, prompt: str, label: str, raw_path: pathlib.Path) -> None:
+    """Spawn `claude -p`, stream its stdout through log_stream, and raise
+    RuntimeError on non-zero exit."""
+    cmd = ["claude", "-p", "--model", model, *CLAUDE_FLAGS, prompt]
+    # Default bufsize (-1) gives a BufferedReader with 8 KiB reads, so
+    # readline() scans for '\n' in-buffer instead of doing one os.read() per
+    # byte. Streaming latency is preserved (readline returns on '\n' or EOF,
+    # it doesn't block for the buffer to fill) and throughput on the big
+    # implement-stage stream-json traces jumps by orders of magnitude.
+    p = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=None,
+        start_new_session=False,
+    )
+    _track(p)
+    try:
+        assert p.stdout is not None
+        log_stream(label, raw_path, p.stdout)
+        p.stdout.close()
+        rc = p.wait()
+    finally:
+        _untrack(p)
+    if rc != 0:
+        raise RuntimeError(f"claude -p (model={model}, label={label}) exited {rc}")
+
+
+def run_review(
+    model: str,
+    out_file: pathlib.Path,
+    focus: str,
+    context: str,
+    where_field: str,
+    label: str,
+    raw_path: pathlib.Path,
+) -> None:
+    """Generic reviewer runner. CONTEXT describes what is being reviewed;
+    FOCUS is the lens prose; WHERE_FIELD is the field label used to cite
+    findings (e.g. `**File:** path:line` for code reviews)."""
+    prompt = f"""Read surrounding code as needed — don't review in isolation.
+
+{context}
+
+Structure your review as markdown:
+
+# Review ({model})
+
+## Summary
+2-4 sentences overall.
+
+## Findings
+For each actionable finding:
+### <short title>
+- {where_field}
+- **Severity:** blocker | major | minor | nit
+- **What:** what's wrong
+- **Fix:** concrete suggestion
+
+If there are no issues worth raising, write a Findings section that says so explicitly.
+
+Do NOT make any code changes — only write the review file.
+
+{focus}
+
+`{out_file}` is the canonical and required location for your review output in every case, including any short-circuit one-liner the lens tells you to emit. Do not emit the verdict only to chat; write it to `{out_file}` and then stop."""
+    run_claude(model, prompt, label, raw_path)
+
+
+# ---------------------------------------------------------------------------
+# Triple-reviewer fan-out
+# ---------------------------------------------------------------------------
+
+class ReviewWorker(threading.Thread):
+    """Runs one lens's reviewer in its own thread. Exceptions are captured
+    on `self.error` so the main thread can decide whether to die()."""
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        out_file: pathlib.Path,
+        focus: str,
+        context: str,
+        where_field: str,
+        label: str,
+        raw_path: pathlib.Path,
+    ) -> None:
+        super().__init__(daemon=True)
+        self.model = model
+        self.out_file = out_file
+        self.focus = focus
+        self.context = context
+        self.where_field = where_field
+        self.label = label
+        self.raw_path = raw_path
+        self.error: Optional[Exception] = None
+
+    def run(self) -> None:
+        try:
+            run_review(
+                self.model,
+                self.out_file,
+                self.focus,
+                self.context,
+                self.where_field,
+                self.label,
+                self.raw_path,
+            )
+        except Exception as e:  # noqa: BLE001
+            self.error = e
+            sys.stderr.write(f"review {self.model} failed: {e}\n")
+            sys.stderr.flush()
+
+
+def run_triple_review(
+    context: str,
+    focuses: Tuple[str, str, str],
+    out_files: Tuple[pathlib.Path, pathlib.Path, pathlib.Path],
+    models: Tuple[str, str, str],
+    where_field: str,
+    session_dir: pathlib.Path,
+) -> None:
+    """Spawn three reviewer threads, emit sub_stage updates as each finishes,
+    and die() if any worker failed or produced an empty output file."""
+    model_a, model_b, model_c = models
+    out_a, out_b, out_c = out_files
+    focus_a, focus_b, focus_c = focuses
+
+    # Stable lens labels (not model names) as sub_stage keys so the shape is
+    # unambiguous when two lenses share a model. Model name is embedded in
+    # the value so status output can show it. The lens key also goes into
+    # each raw-trace filename so three reviewers sharing a model (the default
+    # sonnet×3 case) don't concurrently append to the same .jsonl.
+    lens_keys = ("holistic", "detail", "scope")
+
+    workers = [
+        ReviewWorker(
+            model=model_a, out_file=out_a, focus=focus_a, context=context,
+            where_field=where_field, label=f"review-code:{model_a}",
+            raw_path=session_dir / f"stream-review-code-{lens_keys[0]}-{model_a}.jsonl",
+        ),
+        ReviewWorker(
+            model=model_b, out_file=out_b, focus=focus_b, context=context,
+            where_field=where_field, label=f"review-code:{model_b}",
+            raw_path=session_dir / f"stream-review-code-{lens_keys[1]}-{model_b}.jsonl",
+        ),
+        ReviewWorker(
+            model=model_c, out_file=out_c, focus=focus_c, context=context,
+            where_field=where_field, label=f"review-code:{model_c}",
+            raw_path=session_dir / f"stream-review-code-{lens_keys[2]}-{model_c}.jsonl",
+        ),
+    ]
+    statuses = ["running", "running", "running"]
+
+    def emit_sub_stage() -> None:
+        sub = {
+            lens_keys[i]: f"{statuses[i]} ({workers[i].model})"
+            for i in range(3)
+        }
+        set_stage("review-code", sub)
+
+    for w in workers:
+        w.start()
+    emit_sub_stage()
+
+    while any(s == "running" for s in statuses):
+        changed = False
+        for i, w in enumerate(workers):
+            if statuses[i] == "running" and not w.is_alive():
+                w.join()
+                statuses[i] = "done"
+                changed = True
+        if changed:
+            emit_sub_stage()
+        if any(s == "running" for s in statuses):
+            time.sleep(2)
+
+    failures = [w.model for w in workers if w.error is not None]
+    if failures:
+        die("one or more reviews failed")
+    for w, out in zip(workers, out_files):
+        if not out.exists() or out.stat().st_size == 0:
+            die(f"review {w.model} did not produce {out}")
+
+
+# ---------------------------------------------------------------------------
+# Session dir + git helpers
+# ---------------------------------------------------------------------------
+
+def resolve_session_dir() -> pathlib.Path:
+    state_root = pathlib.Path(
+        os.environ.get("XDG_STATE_HOME")
+        or os.path.join(os.path.expanduser("~"), ".local", "state")
+    ) / "claude-gremlins"
+    gr_id = os.environ.get("GR_ID", "")
+    if gr_id:
+        if not GR_ID_RE.match(gr_id):
+            die(f"invalid GR_ID: {gr_id}")
+        session_dir = state_root / gr_id / "artifacts"
+    else:
+        ts = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        rand = secrets.token_hex(3)  # 6 hex chars
+        session_dir = state_root / "direct" / f"{ts}-{rand}" / "artifacts"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    return session_dir
+
+
+def in_git_repo() -> bool:
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def git_head() -> str:
+    r = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=False,
+    )
+    return r.stdout.strip() if r.returncode == 0 else ""
+
+
+# ---------------------------------------------------------------------------
+# Lens loading
+# ---------------------------------------------------------------------------
+
+def load_lenses() -> Tuple[str, str, str]:
+    """Return (holistic, detail, scope) lens prose from the sibling
+    lens-*-code.md files. Die if any is missing or empty — the gremlin
+    can't review without all three lenses."""
+    lens_files = {
+        "holistic": SCRIPT_DIR / "lens-holistic-code.md",
+        "detail": SCRIPT_DIR / "lens-detail-code.md",
+        "scope": SCRIPT_DIR / "lens-scope-code.md",
+    }
+    for _name, path in lens_files.items():
+        if not path.exists() or path.stat().st_size == 0:
+            die(f"missing or empty lens file: {path}")
+    # Explicit utf-8 — lens files contain em-dashes and other non-ASCII, so
+    # relying on the process default encoding would crash under a non-UTF-8
+    # locale (e.g. a minimal container with LANG=C).
+    return (
+        lens_files["holistic"].read_text(encoding="utf-8"),
+        lens_files["detail"].read_text(encoding="utf-8"),
+        lens_files["scope"].read_text(encoding="utf-8"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage-level helpers: review-code and address-code
+# ---------------------------------------------------------------------------
+
+def run_review_code_stage(
+    session_dir: pathlib.Path,
+    plan_text: str,
+    holistic: str,
+    detail: str,
+    scope: str,
+    is_git: bool,
+) -> Tuple[pathlib.Path, pathlib.Path, pathlib.Path]:
+    """Execute the review-code stage: load lenses, fan out three reviewers,
+    and return the three output paths. Emits bail_class=other on failure
+    when running under a gremlin (no-op otherwise). Shared by the
+    orchestrator and /localreview."""
+    review_code_a = session_dir / f"review-code-holistic-{holistic}.md"
+    review_code_b = session_dir / f"review-code-detail-{detail}.md"
+    review_code_c = session_dir / f"review-code-scope-{scope}.md"
+
+    focus_a, focus_b, focus_c = load_lenses()
+
+    if is_git:
+        code_scope = (
+            "Review the changes introduced by the most recent commit "
+            "(HEAD vs HEAD~1) plus any uncommitted working-tree changes. "
+            "Use `git diff HEAD~1 HEAD` and `git diff` to see the scope."
+        )
+    else:
+        code_scope = (
+            "Review the uncommitted changes in this directory (`git diff` if "
+            "available, otherwise inspect recently modified files)."
+        )
+    # Omit the plan block entirely when no plan was supplied (standalone
+    # /localreview without --plan); sending a bare "The plan for this change
+    # is:" header with empty body would confuse the reviewer.
+    if plan_text:
+        code_review_context = (
+            f"The plan for this change is:\n\n{plan_text}\n\n{code_scope}"
+        )
+    else:
+        code_review_context = code_scope
+
+    # Wrap so any infrastructure failure (claude -p crash, missing output
+    # file, etc.) records bail_class=other before the SystemExit propagates.
+    # Headless rescue can attempt the `other` class — but at least the bail
+    # field tells callers *something* failed during review-code rather than
+    # leaving them to grep the log.
+    try:
+        run_triple_review(
+            context=code_review_context,
+            focuses=(focus_a, focus_b, focus_c),
+            out_files=(review_code_a, review_code_b, review_code_c),
+            models=(holistic, detail, scope),
+            where_field="**File:** `path/to/file.ext:<line>`",
+            session_dir=session_dir,
+        )
+    except (SystemExit, Exception) as exc:
+        emit_bail("other", f"review-code stage failed: {exc}"[:200])
+        raise
+
+    return review_code_a, review_code_b, review_code_c
+
+
+def run_address_code_stage(
+    session_dir: pathlib.Path,
+    address_model: str,
+    is_git: bool,
+) -> None:
+    """Execute the address-code stage: glob for the three review files,
+    build the address prompt, and invoke claude. Emits bail_class=other
+    on failure when running under a gremlin (no-op otherwise). Shared by
+    the orchestrator and /localaddress."""
+    review_files = {}
+    for lens in ("holistic", "detail", "scope"):
+        matches = sorted(glob.glob(str(session_dir / f"review-code-{lens}-*.md")))
+        if not matches:
+            die(f"no review-code-{lens}-*.md file found in {session_dir}")
+        if len(matches) > 1:
+            die(
+                f"multiple review-code-{lens}-*.md files in {session_dir}: "
+                f"{', '.join(matches)}"
+            )
+        review_files[lens] = pathlib.Path(matches[0])
+
+    # Model names are embedded in the filenames as the suffix between the
+    # lens tag and the `.md` extension. Extracting them here keeps the
+    # address prompt's per-lens model labels in sync with the files that
+    # were actually produced, for both orchestrator and standalone callers.
+    def _model_from(path: pathlib.Path, lens: str) -> str:
+        stem = path.stem  # review-code-<lens>-<model>
+        prefix = f"review-code-{lens}-"
+        return stem[len(prefix):] if stem.startswith(prefix) else stem
+
+    model_a = _model_from(review_files["holistic"], "holistic")
+    model_b = _model_from(review_files["detail"], "detail")
+    model_c = _model_from(review_files["scope"], "scope")
+
+    text_a = review_files["holistic"].read_text(encoding="utf-8")
+    text_b = review_files["detail"].read_text(encoding="utf-8")
+    text_c = review_files["scope"].read_text(encoding="utf-8")
+
+    address_commit_instr = ""
+    if is_git:
+        address_commit_instr = (
+            "After making all fixes, stage the changed files by name and "
+            "create a single git commit titled 'Address review feedback' whose "
+            "body references all three review files. Do not push."
+        )
+
+    # Only attached when running under a gremlin so direct invocations
+    # (no GR_ID) don't see prompt instructions for a helper they can't
+    # usefully invoke.
+    bail_section = ""
+    if os.environ.get("GR_ID"):
+        bail_section = """
+
+If a finding asks you to change something that touches secrets/credentials, or you decline to address one or more findings for any other reason that should halt automated recovery, run the bail helper before finishing:
+  - `~/.claude/skills/_bg/set-bail.sh "$GR_ID" secrets "<one-line reason>"` if the blocked finding touches secrets.
+  - `~/.claude/skills/_bg/set-bail.sh "$GR_ID" other "<one-line reason>"` for any other reason you cannot proceed.
+Do not call this helper if you successfully addressed every actionable finding.
+"""
+
+    address_prompt = f"""Three independent code reviews of the most recent implementation follow. The reviewers have different lenses by design, so their findings will mostly be complementary rather than overlapping — still deduplicate where they do overlap. For every actionable finding you agree with, make the fix in the code. For findings you disagree with or choose to skip, note them briefly in your final summary with a reason.
+
+---
+**Holistic reviewer** (model: {model_a}):
+
+{text_a}
+
+---
+**Detail reviewer** (model: {model_b}):
+
+{text_b}
+
+---
+**Scope reviewer** (model: {model_c}):
+
+{text_c}
+
+---
+
+{address_commit_instr}{bail_section}
+
+End with a short summary (to stdout) of: what you addressed, what you skipped and why."""
+    try:
+        run_claude(
+            address_model, address_prompt, "address-code",
+            session_dir / "stream-address.jsonl",
+        )
+    except (SystemExit, Exception) as exc:
+        emit_bail("other", f"address-code stage failed: {exc}"[:200])
+        raise

--- a/skills/localgremlin/localaddress.py
+++ b/skills/localgremlin/localaddress.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Standalone address-code stage for the /localaddress skill.
+
+Reads the three review-code-*.md files produced by /localreview (or
+/localgremlin) from --dir and addresses their findings. In a git repo,
+creates one 'Address review feedback' commit. No push.
+
+Entry point for the sibling _core.py `run_address_code_stage` helper,
+which is the single source of truth shared with localgremlin.py.
+"""
+
+import argparse
+import pathlib
+import shutil
+import sys
+from typing import List
+
+from _core import (
+    MODEL_RE,
+    die,
+    in_git_repo,
+    install_signal_handlers,
+    run_address_code_stage,
+)
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    usage = "usage: localaddress.py [--dir <path>] [-x <address-model>]"
+    parser = argparse.ArgumentParser(add_help=False, usage=usage)
+    parser.add_argument("--dir", dest="dir", default=".")
+    parser.add_argument("-x", dest="address", default="sonnet")
+    args = parser.parse_args(argv)
+    if not MODEL_RE.match(args.address):
+        die(f"invalid model: {args.address}")
+    return args
+
+
+def main(argv: List[str]) -> int:
+    install_signal_handlers()
+    args = parse_args(argv)
+
+    if shutil.which("claude") is None:
+        die("claude CLI not found")
+
+    session_dir = pathlib.Path(args.dir).resolve()
+    if not session_dir.is_dir():
+        die(f"--dir does not exist: {session_dir}")
+
+    is_git = in_git_repo()
+
+    print(f"==> addressing code reviews (model: {args.address})", flush=True)
+    run_address_code_stage(
+        session_dir=session_dir,
+        address_model=args.address,
+        is_git=is_git,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/localgremlin/localgremlin.py
+++ b/skills/localgremlin/localgremlin.py
@@ -17,476 +17,32 @@ The gremlin shells out to ~/.claude/skills/_bg/set-stage.sh at each boundary
 so `/gremlins` and the session-summary hook can see where it is; sub_stage
 for review-code is a {holistic, detail, scope} dict that flips running→done
 as each reviewer thread finishes.
+
+Review-code and address-code stage bodies live in `_core.py` so the
+standalone /localreview and /localaddress skills execute the same code.
 """
 
 import argparse
-import datetime
-import json
 import os
 import pathlib
-import re
-import secrets
 import shutil
-import signal
 import subprocess
 import sys
-import threading
-import time
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
-SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
-SET_STAGE_SH = pathlib.Path.home() / ".claude" / "skills" / "_bg" / "set-stage.sh"
-SET_BAIL_SH = pathlib.Path.home() / ".claude" / "skills" / "_bg" / "set-bail.sh"
-MODEL_RE = re.compile(r"^[A-Za-z0-9._-]+$")
-GR_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
-
-CLAUDE_FLAGS = [
-    "--permission-mode", "bypassPermissions",
-    "--output-format", "stream-json",
-    "--verbose",
-]
-
-
-# ---------------------------------------------------------------------------
-# Child-process tracking
-# ---------------------------------------------------------------------------
-# Reviewer threads spawn their own `claude -p` subprocesses in parallel. On
-# SIGINT/SIGTERM we need to terminate every live child so a Ctrl-C'd run
-# doesn't leave orphaned claude processes burning tokens (the bash equivalent
-# was `trap 'kill -- -$$'`). We keep a module-level list of Popens under a
-# reentrant lock — signal handlers run on the main thread and may land while
-# _track/_untrack already hold it, which would deadlock a plain Lock in that
-# narrow window. Children are added on spawn and removed on wait().
-_children_lock = threading.RLock()
-_children: List[subprocess.Popen] = []
-
-
-def _track(p: subprocess.Popen) -> None:
-    with _children_lock:
-        _children.append(p)
-
-
-def _untrack(p: subprocess.Popen) -> None:
-    with _children_lock:
-        try:
-            _children.remove(p)
-        except ValueError:
-            pass
-
-
-def _reap_all() -> None:
-    with _children_lock:
-        procs = list(_children)
-    for p in procs:
-        try:
-            p.terminate()
-        except Exception:
-            pass
-    deadline = time.time() + 2.0
-    for p in procs:
-        remaining = max(0.0, deadline - time.time())
-        try:
-            p.wait(timeout=remaining)
-        except Exception:
-            pass
-    for p in procs:
-        if p.poll() is None:
-            try:
-                p.kill()
-            except Exception:
-                pass
-
-
-def _signal_handler(signum, frame):
-    _reap_all()
-    sys.exit(130)
-
-
-def die(msg: str) -> None:
-    sys.stderr.write(f"error: {msg}\n")
-    sys.stderr.flush()
-    sys.exit(1)
-
-
-# ---------------------------------------------------------------------------
-# Stage bookkeeping
-# ---------------------------------------------------------------------------
-
-def set_stage(stage: str, sub_stage=None) -> None:
-    """Shell out to set-stage.sh. No-op without GR_ID or when the helper is
-    missing/non-executable. Never raises — stage bookkeeping must not break
-    a running gremlin."""
-    gr_id = os.environ.get("GR_ID")
-    if not gr_id:
-        return
-    try:
-        if not SET_STAGE_SH.exists() or not os.access(str(SET_STAGE_SH), os.X_OK):
-            return
-    except Exception:
-        return
-    args = [str(SET_STAGE_SH), gr_id, stage]
-    if sub_stage is not None:
-        try:
-            args.append(json.dumps(sub_stage))
-        except Exception:
-            return
-    try:
-        subprocess.run(
-            args,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=False,
-        )
-    except Exception:
-        pass
-
-
-def emit_bail(bail_class: str, bail_detail: str = "") -> None:
-    """Shell out to set-bail.sh to record a bail_class (and optional detail)
-    on the running gremlin's state.json. Read by /gremlins rescue --headless
-    to decide whether to attempt automated recovery. No-op without GR_ID or
-    when the helper is missing — never raises, the stage is already failing
-    and bail bookkeeping must not mask the underlying error."""
-    gr_id = os.environ.get("GR_ID")
-    if not gr_id:
-        return
-    try:
-        if not SET_BAIL_SH.exists() or not os.access(str(SET_BAIL_SH), os.X_OK):
-            return
-    except Exception:
-        return
-    try:
-        subprocess.run(
-            [str(SET_BAIL_SH), gr_id, bail_class, bail_detail],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=False,
-            timeout=5,
-        )
-    except Exception:
-        pass
-
-
-# ---------------------------------------------------------------------------
-# Stream-JSON logger
-# ---------------------------------------------------------------------------
-
-def _trunc(s, n: int = 200) -> str:
-    if s is None:
-        return ""
-    if not isinstance(s, str):
-        s = str(s)
-    s = s.replace("\n", " ")
-    return s[:n] + "..." if len(s) > n else s
-
-
-def _emit_event(prefix: str, evt: dict) -> None:
-    t = evt.get("type")
-    out = sys.stderr
-    if t == "system":
-        if evt.get("subtype") != "init":
-            return
-        out.write(
-            f"{prefix}init session={evt.get('session_id', '?')} "
-            f"model={evt.get('model', '?')} cwd={evt.get('cwd', '?')}\n"
-        )
-    elif t == "assistant":
-        content = (evt.get("message") or {}).get("content") or []
-        for c in content:
-            if not isinstance(c, dict):
-                continue
-            ct = c.get("type")
-            if ct == "text":
-                out.write(f"{prefix}text: {_trunc(c.get('text', ''))}\n")
-            elif ct == "tool_use":
-                inp = c.get("input") or {}
-                arg = ""
-                if isinstance(inp, dict):
-                    for k in ("file_path", "command", "pattern", "url", "output_file"):
-                        v = inp.get(k)
-                        if v:
-                            arg = v
-                            break
-                out.write(f"{prefix}tool: {c.get('name', '?')} {_trunc(str(arg))}\n")
-    elif t == "user":
-        content = (evt.get("message") or {}).get("content") or []
-        for c in content:
-            if not isinstance(c, dict) or c.get("type") != "tool_result":
-                continue
-            err = " ERROR" if c.get("is_error") is True else ""
-            body = c.get("content")
-            if isinstance(body, list):
-                body_s = " ".join(
-                    (p.get("text") or "") for p in body if isinstance(p, dict)
-                )
-            elif isinstance(body, str):
-                body_s = body
-            elif body is None:
-                body_s = ""
-            else:
-                body_s = str(body)
-            out.write(f"{prefix}result{err}: {_trunc(body_s)}\n")
-    elif t == "result":
-        cost = evt.get("total_cost_usd", evt.get("cost_usd", "?"))
-        out.write(
-            f"{prefix}final: subtype={evt.get('subtype', '?')} "
-            f"turns={evt.get('num_turns', '?')} cost={cost}\n"
-        )
-    out.flush()
-
-
-def log_stream(label: str, raw_path: pathlib.Path, stdout) -> None:
-    """Tee raw stream-json lines from `stdout` to `raw_path` and emit a
-    human-readable trace to stderr. Malformed lines are skipped silently
-    (parity with the bash `jq ... || true` — a truncated JSON line from a
-    crashing `claude -p` must not abort the stage)."""
-    prefix = f"[{label}] " if label else ""
-    with open(raw_path, "ab") as raw:
-        for line in stdout:
-            raw.write(line)
-            raw.flush()
-            try:
-                evt = json.loads(line.decode("utf-8", errors="replace"))
-            except Exception:
-                continue
-            if not isinstance(evt, dict):
-                continue
-            try:
-                _emit_event(prefix, evt)
-            except Exception:
-                continue
-
-
-# ---------------------------------------------------------------------------
-# Claude invocation
-# ---------------------------------------------------------------------------
-
-def run_claude(model: str, prompt: str, label: str, raw_path: pathlib.Path) -> None:
-    """Spawn `claude -p`, stream its stdout through log_stream, and raise
-    RuntimeError on non-zero exit."""
-    cmd = ["claude", "-p", "--model", model, *CLAUDE_FLAGS, prompt]
-    # Default bufsize (-1) gives a BufferedReader with 8 KiB reads, so
-    # readline() scans for '\n' in-buffer instead of doing one os.read() per
-    # byte. Streaming latency is preserved (readline returns on '\n' or EOF,
-    # it doesn't block for the buffer to fill) and throughput on the big
-    # implement-stage stream-json traces jumps by orders of magnitude.
-    p = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=None,
-        start_new_session=False,
-    )
-    _track(p)
-    try:
-        assert p.stdout is not None
-        log_stream(label, raw_path, p.stdout)
-        p.stdout.close()
-        rc = p.wait()
-    finally:
-        _untrack(p)
-    if rc != 0:
-        raise RuntimeError(f"claude -p (model={model}, label={label}) exited {rc}")
-
-
-def run_review(
-    model: str,
-    out_file: pathlib.Path,
-    focus: str,
-    context: str,
-    where_field: str,
-    label: str,
-    raw_path: pathlib.Path,
-) -> None:
-    """Generic reviewer runner. CONTEXT describes what is being reviewed;
-    FOCUS is the lens prose; WHERE_FIELD is the field label used to cite
-    findings (e.g. `**File:** path:line` for code reviews)."""
-    prompt = f"""Read surrounding code as needed — don't review in isolation.
-
-{context}
-
-Structure your review as markdown:
-
-# Review ({model})
-
-## Summary
-2-4 sentences overall.
-
-## Findings
-For each actionable finding:
-### <short title>
-- {where_field}
-- **Severity:** blocker | major | minor | nit
-- **What:** what's wrong
-- **Fix:** concrete suggestion
-
-If there are no issues worth raising, write a Findings section that says so explicitly.
-
-Do NOT make any code changes — only write the review file.
-
-{focus}
-
-`{out_file}` is the canonical and required location for your review output in every case, including any short-circuit one-liner the lens tells you to emit. Do not emit the verdict only to chat; write it to `{out_file}` and then stop."""
-    run_claude(model, prompt, label, raw_path)
-
-
-# ---------------------------------------------------------------------------
-# Triple-reviewer fan-out
-# ---------------------------------------------------------------------------
-
-class ReviewWorker(threading.Thread):
-    """Runs one lens's reviewer in its own thread. Exceptions are captured
-    on `self.error` so the main thread can decide whether to die()."""
-
-    def __init__(
-        self,
-        *,
-        model: str,
-        out_file: pathlib.Path,
-        focus: str,
-        context: str,
-        where_field: str,
-        label: str,
-        raw_path: pathlib.Path,
-    ) -> None:
-        super().__init__(daemon=True)
-        self.model = model
-        self.out_file = out_file
-        self.focus = focus
-        self.context = context
-        self.where_field = where_field
-        self.label = label
-        self.raw_path = raw_path
-        self.error: Optional[Exception] = None
-
-    def run(self) -> None:
-        try:
-            run_review(
-                self.model,
-                self.out_file,
-                self.focus,
-                self.context,
-                self.where_field,
-                self.label,
-                self.raw_path,
-            )
-        except Exception as e:  # noqa: BLE001
-            self.error = e
-            sys.stderr.write(f"review {self.model} failed: {e}\n")
-            sys.stderr.flush()
-
-
-def run_triple_review(
-    context: str,
-    focuses: Tuple[str, str, str],
-    out_files: Tuple[pathlib.Path, pathlib.Path, pathlib.Path],
-    models: Tuple[str, str, str],
-    where_field: str,
-    session_dir: pathlib.Path,
-) -> None:
-    """Spawn three reviewer threads, emit sub_stage updates as each finishes,
-    and die() if any worker failed or produced an empty output file."""
-    model_a, model_b, model_c = models
-    out_a, out_b, out_c = out_files
-    focus_a, focus_b, focus_c = focuses
-
-    # Stable lens labels (not model names) as sub_stage keys so the shape is
-    # unambiguous when two lenses share a model. Model name is embedded in
-    # the value so status output can show it. The lens key also goes into
-    # each raw-trace filename so three reviewers sharing a model (the default
-    # sonnet×3 case) don't concurrently append to the same .jsonl.
-    lens_keys = ("holistic", "detail", "scope")
-
-    workers = [
-        ReviewWorker(
-            model=model_a, out_file=out_a, focus=focus_a, context=context,
-            where_field=where_field, label=f"review-code:{model_a}",
-            raw_path=session_dir / f"stream-review-code-{lens_keys[0]}-{model_a}.jsonl",
-        ),
-        ReviewWorker(
-            model=model_b, out_file=out_b, focus=focus_b, context=context,
-            where_field=where_field, label=f"review-code:{model_b}",
-            raw_path=session_dir / f"stream-review-code-{lens_keys[1]}-{model_b}.jsonl",
-        ),
-        ReviewWorker(
-            model=model_c, out_file=out_c, focus=focus_c, context=context,
-            where_field=where_field, label=f"review-code:{model_c}",
-            raw_path=session_dir / f"stream-review-code-{lens_keys[2]}-{model_c}.jsonl",
-        ),
-    ]
-    statuses = ["running", "running", "running"]
-
-    def emit_sub_stage() -> None:
-        sub = {
-            lens_keys[i]: f"{statuses[i]} ({workers[i].model})"
-            for i in range(3)
-        }
-        set_stage("review-code", sub)
-
-    for w in workers:
-        w.start()
-    emit_sub_stage()
-
-    while any(s == "running" for s in statuses):
-        changed = False
-        for i, w in enumerate(workers):
-            if statuses[i] == "running" and not w.is_alive():
-                w.join()
-                statuses[i] = "done"
-                changed = True
-        if changed:
-            emit_sub_stage()
-        if any(s == "running" for s in statuses):
-            time.sleep(2)
-
-    failures = [w.model for w in workers if w.error is not None]
-    if failures:
-        die("one or more reviews failed")
-    for w, out in zip(workers, out_files):
-        if not out.exists() or out.stat().st_size == 0:
-            die(f"review {w.model} did not produce {out}")
-
-
-# ---------------------------------------------------------------------------
-# Session dir + implementation-change detection
-# ---------------------------------------------------------------------------
-
-def resolve_session_dir() -> pathlib.Path:
-    state_root = pathlib.Path(
-        os.environ.get("XDG_STATE_HOME")
-        or os.path.join(os.path.expanduser("~"), ".local", "state")
-    ) / "claude-gremlins"
-    gr_id = os.environ.get("GR_ID", "")
-    if gr_id:
-        if not GR_ID_RE.match(gr_id):
-            die(f"invalid GR_ID: {gr_id}")
-        session_dir = state_root / gr_id / "artifacts"
-    else:
-        ts = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-        rand = secrets.token_hex(3)  # 6 hex chars
-        session_dir = state_root / "direct" / f"{ts}-{rand}" / "artifacts"
-    session_dir.mkdir(parents=True, exist_ok=True)
-    return session_dir
-
-
-def in_git_repo() -> bool:
-    try:
-        r = subprocess.run(
-            ["git", "rev-parse", "--git-dir"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=False,
-        )
-        return r.returncode == 0
-    except Exception:
-        return False
-
-
-def git_head() -> str:
-    r = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        capture_output=True, text=True, check=False,
-    )
-    return r.stdout.strip() if r.returncode == 0 else ""
+from _core import (
+    MODEL_RE,
+    SCRIPT_DIR,
+    die,
+    git_head,
+    in_git_repo,
+    install_signal_handlers,
+    resolve_session_dir,
+    run_address_code_stage,
+    run_claude,
+    run_review_code_stage,
+    set_stage,
+)
 
 
 def changes_outside_git(sentinel: pathlib.Path, session_dir: pathlib.Path) -> bool:
@@ -561,8 +117,7 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
 
 
 def main(argv: List[str]) -> int:
-    signal.signal(signal.SIGINT, _signal_handler)
-    signal.signal(signal.SIGTERM, _signal_handler)
+    install_signal_handlers()
 
     args = parse_args(argv)
     instructions = " ".join(args.instructions)
@@ -579,23 +134,6 @@ def main(argv: List[str]) -> int:
     print(f"==> session: {session_dir}", flush=True)
 
     is_git = in_git_repo()
-
-    # Reviewer focuses. Two complementary lenses (holistic / detail) are told
-    # to stay out of each other's lane so the reviews are complementary.
-    lens_files = {
-        "holistic": SCRIPT_DIR / "lens-holistic-code.md",
-        "detail": SCRIPT_DIR / "lens-detail-code.md",
-        "scope": SCRIPT_DIR / "lens-scope-code.md",
-    }
-    for name, path in lens_files.items():
-        if not path.exists() or path.stat().st_size == 0:
-            die(f"missing or empty lens file: {path}")
-    # Explicit utf-8 — lens files contain em-dashes and other non-ASCII, so
-    # relying on the process default encoding would crash under a non-UTF-8
-    # locale (e.g. a minimal container with LANG=C).
-    focus_a = lens_files["holistic"].read_text(encoding="utf-8")
-    focus_b = lens_files["detail"].read_text(encoding="utf-8")
-    focus_c = lens_files["scope"].read_text(encoding="utf-8")
 
     pragmatic_dev_file = (SCRIPT_DIR / "../../agents/pragmatic-developer.md").resolve()
     if not pragmatic_dev_file.exists():
@@ -761,37 +299,14 @@ Task: {instructions}"""
             f"(models: {args.holistic}, {args.detail}, {args.scope})",
             flush=True,
         )
-        if is_git:
-            code_scope = (
-                "Review the changes introduced by the most recent commit "
-                "(HEAD vs HEAD~1) plus any uncommitted working-tree changes. "
-                "Use `git diff HEAD~1 HEAD` and `git diff` to see the scope."
-            )
-        else:
-            code_scope = (
-                "Review the uncommitted changes in this directory (`git diff` if "
-                "available, otherwise inspect recently modified files)."
-            )
-        code_review_context = (
-            f"The plan for this change is:\n\n{plan_text}\n\n{code_scope}"
+        review_code_a, review_code_b, review_code_c = run_review_code_stage(
+            session_dir=session_dir,
+            plan_text=plan_text,
+            holistic=args.holistic,
+            detail=args.detail,
+            scope=args.scope,
+            is_git=is_git,
         )
-        # Wrap so any infrastructure failure (claude -p crash, missing
-        # output file, etc.) records bail_class=other before the SystemExit
-        # propagates. Headless rescue can attempt the `other` class — but
-        # at least the bail field tells callers *something* failed during
-        # review-code rather than leaving them to grep the log.
-        try:
-            run_triple_review(
-                context=code_review_context,
-                focuses=(focus_a, focus_b, focus_c),
-                out_files=(review_code_a, review_code_b, review_code_c),
-                models=(args.holistic, args.detail, args.scope),
-                where_field="**File:** `path/to/file.ext:<line>`",
-                session_dir=session_dir,
-            )
-        except (SystemExit, Exception) as exc:
-            emit_bail("other", f"review-code stage failed: {exc}"[:200])
-            raise
         print(f"    holistic code review ({args.holistic}): {review_code_a}", flush=True)
         print(f"    detail code review   ({args.detail}): {review_code_b}", flush=True)
         print(f"    scope code review    ({args.scope}): {review_code_c}", flush=True)
@@ -800,58 +315,11 @@ Task: {instructions}"""
     if start_idx <= VALID_RESUME_STAGES.index("address-code"):
         set_stage("address-code")
         print(f"==> [4/4] addressing code reviews (model: {args.address})", flush=True)
-        address_commit_instr = ""
-        if is_git:
-            address_commit_instr = (
-                "After making all fixes, stage the changed files by name and "
-                "create a single git commit titled 'Address review feedback' whose "
-                "body references all three review files. Do not push."
-            )
-        text_a = review_code_a.read_text(encoding="utf-8")
-        text_b = review_code_b.read_text(encoding="utf-8")
-        text_c = review_code_c.read_text(encoding="utf-8")
-        # Only attached when running under a gremlin so direct invocations
-        # (no GR_ID) don't see prompt instructions for a helper they can't
-        # usefully invoke.
-        bail_section = ""
-        if os.environ.get("GR_ID"):
-            bail_section = """
-
-If a finding asks you to change something that touches secrets/credentials, or you decline to address one or more findings for any other reason that should halt automated recovery, run the bail helper before finishing:
-  - `~/.claude/skills/_bg/set-bail.sh "$GR_ID" secrets "<one-line reason>"` if the blocked finding touches secrets.
-  - `~/.claude/skills/_bg/set-bail.sh "$GR_ID" other "<one-line reason>"` for any other reason you cannot proceed.
-Do not call this helper if you successfully addressed every actionable finding.
-"""
-        address_prompt = f"""Three independent code reviews of the most recent implementation follow. The reviewers have different lenses by design, so their findings will mostly be complementary rather than overlapping — still deduplicate where they do overlap. For every actionable finding you agree with, make the fix in the code. For findings you disagree with or choose to skip, note them briefly in your final summary with a reason.
-
----
-**Holistic reviewer** (model: {args.holistic}):
-
-{text_a}
-
----
-**Detail reviewer** (model: {args.detail}):
-
-{text_b}
-
----
-**Scope reviewer** (model: {args.scope}):
-
-{text_c}
-
----
-
-{address_commit_instr}{bail_section}
-
-End with a short summary (to stdout) of: what you addressed, what you skipped and why."""
-        try:
-            run_claude(
-                args.address, address_prompt, "address-code",
-                session_dir / "stream-address.jsonl",
-            )
-        except (SystemExit, Exception) as exc:
-            emit_bail("other", f"address-code stage failed: {exc}"[:200])
-            raise
+        run_address_code_stage(
+            session_dir=session_dir,
+            address_model=args.address,
+            is_git=is_git,
+        )
 
     print("", flush=True)
     print(f"done. session artifacts in: {session_dir}", flush=True)

--- a/skills/localgremlin/localreview.py
+++ b/skills/localgremlin/localreview.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Standalone review-code stage for the /localreview skill.
+
+Runs the same triple-lens parallel reviewer fan-out as the review-code
+stage of /localgremlin, but against arbitrary local changes rather than
+a gremlin-managed worktree. No GR_ID, no gremlin state dir — review files
+are written straight to --dir (defaulting to cwd).
+
+Entry point for the sibling _core.py `run_review_code_stage` helper, which
+is the single source of truth shared with localgremlin.py.
+"""
+
+import argparse
+import pathlib
+import shutil
+import subprocess
+import sys
+from typing import List
+
+from _core import (
+    MODEL_RE,
+    die,
+    in_git_repo,
+    install_signal_handlers,
+    run_review_code_stage,
+)
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    usage = (
+        "usage: localreview.py [--dir <path>] [--plan <path>] "
+        "[-a <holistic-model>] [-b <detail-model>] [-c <scope-model>]"
+    )
+    parser = argparse.ArgumentParser(add_help=False, usage=usage)
+    parser.add_argument("--dir", dest="dir", default=".")
+    parser.add_argument("--plan", dest="plan", default=None)
+    parser.add_argument("-a", dest="holistic", default="sonnet")
+    parser.add_argument("-b", dest="detail", default="sonnet")
+    parser.add_argument("-c", dest="scope", default="sonnet")
+    args = parser.parse_args(argv)
+    for m in (args.holistic, args.detail, args.scope):
+        if not MODEL_RE.match(m):
+            die(f"invalid model: {m}")
+    return args
+
+
+def main(argv: List[str]) -> int:
+    install_signal_handlers()
+    args = parse_args(argv)
+
+    if shutil.which("claude") is None:
+        die("claude CLI not found")
+
+    session_dir = pathlib.Path(args.dir).resolve()
+    if not session_dir.is_dir():
+        die(f"--dir does not exist: {session_dir}")
+
+    plan_text = ""
+    if args.plan is not None:
+        plan_path = pathlib.Path(args.plan)
+        if not plan_path.exists():
+            die(f"--plan does not exist: {plan_path}")
+        if plan_path.stat().st_size == 0:
+            die(f"--plan is empty: {plan_path}")
+        plan_text = plan_path.read_text(encoding="utf-8")
+
+    is_git = in_git_repo()
+    if is_git:
+        # Refuse to spawn three reviewers on an empty diff. HEAD~1 may not
+        # exist (initial commit); in that case we require dirty tree to have
+        # something worth reviewing.
+        head1_exists = subprocess.run(
+            ["git", "rev-parse", "--verify", "HEAD~1"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False,
+        ).returncode == 0
+        has_commit_diff = False
+        if head1_exists:
+            has_commit_diff = subprocess.run(
+                ["git", "diff", "--quiet", "HEAD~1", "HEAD"],
+                check=False,
+            ).returncode != 0
+        has_dirty = bool(subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True, text=True, check=False,
+        ).stdout.strip())
+        if not has_commit_diff and not has_dirty:
+            die("nothing to review: HEAD~1..HEAD has no changes and working tree is clean")
+
+    print(f"==> reviewing code in parallel (models: {args.holistic}, {args.detail}, {args.scope})", flush=True)
+    review_a, review_b, review_c = run_review_code_stage(
+        session_dir=session_dir,
+        plan_text=plan_text,
+        holistic=args.holistic,
+        detail=args.detail,
+        scope=args.scope,
+        is_git=is_git,
+    )
+    print(f"    holistic code review ({args.holistic}): {review_a}", flush=True)
+    print(f"    detail code review   ({args.detail}): {review_b}", flush=True)
+    print(f"    scope code review    ({args.scope}): {review_c}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/localgremlin/localreview.py
+++ b/skills/localgremlin/localreview.py
@@ -60,9 +60,16 @@ def main(argv: List[str]) -> int:
         plan_path = pathlib.Path(args.plan)
         if not plan_path.exists():
             die(f"--plan does not exist: {plan_path}")
+        if not plan_path.is_file():
+            die(f"--plan is not a file: {plan_path}")
         if plan_path.stat().st_size == 0:
             die(f"--plan is empty: {plan_path}")
-        plan_text = plan_path.read_text(encoding="utf-8")
+        try:
+            plan_text = plan_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            die(f"--plan is not valid UTF-8 text: {plan_path}")
+        except OSError as exc:
+            die(f"failed to read --plan {plan_path}: {exc}")
 
     is_git = in_git_repo()
     if is_git:
@@ -84,6 +91,8 @@ def main(argv: List[str]) -> int:
             capture_output=True, text=True, check=False,
         ).stdout.strip())
         if not has_commit_diff and not has_dirty:
+            if not head1_exists:
+                die("nothing to review: no commit history beyond HEAD and working tree is clean")
             die("nothing to review: HEAD~1..HEAD has no changes and working tree is clean")
 
     print(f"==> reviewing code in parallel (models: {args.holistic}, {args.detail}, {args.scope})", flush=True)

--- a/skills/localreview/SKILL.md
+++ b/skills/localreview/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: localreview
+description: Run the three parallel code-review lenses (holistic, detail, scope) over local changes without the full gremlin pipeline. Writes review-code-*.md files into --dir (cwd by default). Foreground, not backgrounded.
+argument-hint: [--dir <path>] [--plan <path>] [-a <holistic-model>] [-b <detail-model>] [-c <scope-model>]
+allowed-tools: Bash(~/.claude/skills/localgremlin/localreview.py:*)
+---
+
+Run a code review on the current local changes using the same triple-lens parallel reviewer fan-out as `/localgremlin`'s review-code stage, without planning or implementing anything.
+
+This skill runs **in the foreground** — it blocks until the three reviews finish. It does not spawn a background gremlin, does not create a worktree, and does not write to `~/.local/state/claude-gremlins/`.
+
+## What it reviews
+
+- In a git repo: the most recent commit (`HEAD~1..HEAD`) plus any uncommitted working-tree changes. If both are empty, it errors rather than run reviewers on nothing.
+- Outside a git repo: uncommitted/recently-modified files in the directory (the reviewer is told to run `git diff` if available, otherwise inspect recent files).
+
+## Output
+
+Three markdown files are written into `--dir` (default: cwd):
+
+- `review-code-holistic-<model>.md`
+- `review-code-detail-<model>.md`
+- `review-code-scope-<model>.md`
+
+Filenames match `/localgremlin`'s review-code stage exactly, so the resulting files can be fed straight into `/localaddress` (point its `--dir` at the same path).
+
+## Arguments
+
+$ARGUMENTS
+
+Forward them verbatim to the script:
+
+```
+~/.claude/skills/localgremlin/localreview.py $ARGUMENTS
+```
+
+Flags:
+
+- `--dir <path>` — destination directory for the three review files. Must already exist (no silent mkdir). Defaults to cwd.
+- `--plan <path>` — optional path to an implementation plan; its contents are passed to the reviewers as context. Errors if the path is missing or empty.
+- `-a <model>` / `-b <model>` / `-c <model>` — models for the holistic / detail / scope lenses. Each defaults to `sonnet`.
+
+After the script exits, report the three output filenames to the user.


### PR DESCRIPTION
## Summary

- Factor review-code and address-code stage bodies out of `skills/localgremlin/localgremlin.py` into a sibling `_core.py`, sharing them with two new standalone skills.
- Add `/localreview` (foreground triple-lens parallel review over local changes) and `/localaddress` (foreground address-stage over existing `review-code-*.md` files).
- `/localgremlin` keeps its end-to-end behavior by calling the shared `run_review_code_stage` / `run_address_code_stage` helpers directly — no subprocess hop, byte-identical artifacts/stdout/sub_stage emissions for the with-plan case.

## Behavior notes

- Standalone invocations have no `GR_ID`, so `set_stage` / `emit_bail` stay no-ops outside a gremlin.
- Filenames, lens prompts, and review structure are unchanged.
- When `/localreview` is run without `--plan`, the plan block is omitted from the review prompt (vs. rendering an empty plan section). The orchestrator path always has a plan, so it is unaffected.
- `/localaddress` extracts model names from the `review-code-<lens>-<model>.md` filenames, so the address prompt's per-lens model labels match the files that were actually produced (for both orchestrator and standalone callers).

## Test plan

- [ ] `/localreview` against a one-commit-ahead worktree produces the same three filenames + content shape as a same-models `/localgremlin` review-code stage.
- [ ] `/localaddress --dir <path>` against those three files produces the same fixes + `Address review feedback` commit as `/localgremlin`'s address-code stage.
- [ ] `/localgremlin` end-to-end still produces identical artifacts, `state.json` sub_stage transitions, bail-class plumbing, and `--resume-from` behavior.
- [ ] `/gremlins rescue` of a failed `/localgremlin` (force a failure in review-code or address-code) still succeeds.
- [ ] Post-merge: run `scripts/sync.sh push` from the main checkout so `~/.claude/skills/{localreview,localaddress}/` mirror the repo.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)