### PR TITLE
Add --plan flag to skip the planning stage in both gremlins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,11 +23,11 @@ Create the file under the corresponding repo directory (`skills/<name>/SKILL.md`
 
 ## The `gh*` gremlin
 
-The `ghgremlin` skill invokes [`skills/ghgremlin/ghgremlin.sh`](skills/ghgremlin/ghgremlin.sh) to run an end-to-end GitHub-issue-driven workflow: `/ghplan`, an implementation + PR creation stage, `/ghreview` (with a scope reviewer running in parallel), and `/ghaddress`.
+The `ghgremlin` skill invokes [`skills/ghgremlin/ghgremlin.sh`](skills/ghgremlin/ghgremlin.sh) to run an end-to-end GitHub-issue-driven workflow: `/ghplan`, an implementation + PR creation stage, `/ghreview` (with a scope reviewer running in parallel), and `/ghaddress`. `--plan <path|issue-ref>` skips the `/ghplan` stage and uses the supplied file or existing issue as the plan instead.
 
 ## The local gremlin
 
-The `localgremlin` skill runs plan → implement → three parallel reviewers (holistic, detail, scope) → address-code locally via [`skills/localgremlin/localgremlin.py`](skills/localgremlin/localgremlin.py). All artifacts land in `~/.local/state/claude-gremlins/<id>/artifacts/` off the product branch.
+The `localgremlin` skill runs plan → implement → three parallel reviewers (holistic, detail, scope) → address-code locally via [`skills/localgremlin/localgremlin.py`](skills/localgremlin/localgremlin.py). All artifacts land in `~/.local/state/claude-gremlins/<id>/artifacts/` off the product branch. `--plan <path>` skips the plan stage and uses the supplied file as the plan.
 
 The review-code and address-code stage bodies live in [`skills/localgremlin/_core.py`](skills/localgremlin/_core.py) alongside the orchestrator, so the standalone `/localreview` and `/localaddress` skills execute the same code as the gremlin's review and address stages.
 

--- a/skills/_bg/launch.sh
+++ b/skills/_bg/launch.sh
@@ -200,9 +200,16 @@ if [[ -n "$RESUME_GR_ID" ]]; then
     # sidecar INSTRUCTIONS is just flag-echo garbage. Appending it as a
     # positional on resume would make the gremlin re-parse flag text as
     # prose — omit the trailing positional in that case.
+    # Note: this matches both the space-separated form (`--plan <value>`, our
+    # only caller shape today) and the `--plan=<value>` form, so a
+    # hand-crafted resume that packs them together still takes the no-trailing-
+    # positional branch.
     _has_plan=0
     for _pa in "${PIPELINE_ARGS[@]}"; do
-        [[ "$_pa" == "--plan" ]] && { _has_plan=1; break; }
+        if [[ "$_pa" == "--plan" || "$_pa" == --plan=* ]]; then
+            _has_plan=1
+            break
+        fi
     done
 
     (
@@ -317,6 +324,10 @@ done
 # both find the file. A relative --plan path would resolve relative to
 # $WORKDIR post-cd, not the original caller's cwd — breaking on first run.
 # Persisted pipeline_args picks up the normalized value via `set --` below.
+# Note: `cd "$(dirname …)" && pwd` follows symlinks, so the persisted path
+# is the resolved physical path. This is intentional — rescue is more
+# robust if the symlink is later moved or removed — but it means the
+# caller's original symlink path doesn't round-trip into state.json.
 _plan_abs=""
 if [[ -n "$_plan_arg" && -f "$_plan_arg" ]]; then
     _plan_abs=$(cd "$(dirname "$_plan_arg")" 2>/dev/null && printf '%s/%s' "$(pwd)" "$(basename "$_plan_arg")") || _plan_abs=""
@@ -325,6 +336,20 @@ if [[ -n "$_plan_arg" && -f "$_plan_arg" ]]; then
         # Rebuild $@ so the initial dispatch at the bottom of this script
         # uses the same normalized arg list as the persisted pipeline_args.
         set -- "${_args[@]}"
+    fi
+fi
+
+# Early validation for localgremlin --plan <path>: the arg is always a local
+# file path (localgremlin has no issue-ref form), so we can fail fast here
+# (before state dir creation) on missing/empty files instead of deferring to
+# localgremlin.py. ghgremlin's --plan accepts issue refs whose validity
+# depends on the network, so its validation stays inside ghgremlin.sh.
+if [[ "$KIND" == "localgremlin" && -n "$_plan_arg" ]]; then
+    if [[ ! -f "$_plan_arg" ]]; then
+        die "--plan: file not found: $_plan_arg"
+    fi
+    if [[ ! -s "$_plan_arg" ]]; then
+        die "--plan: file is empty: $_plan_arg"
     fi
 fi
 
@@ -403,10 +428,16 @@ SLUG=$(slugify "$SLUG_SOURCE")
 # launch.sh can't see the issue body, DESCRIPTION stays empty so ghgremlin.sh
 # can fill it in after resolving the issue (INSTR_RAW would be just the
 # flag echo "--plan 42" which is not a useful description).
+# The empty-description issue-ref branch is guarded to KIND=ghgremlin: only
+# ghgremlin has an issue-body fill-in step later in the pipeline, and its
+# --plan accepts non-file refs. localgremlin's --plan is always a file (and
+# the earlier early-validation block dies on a non-file value), so a
+# non-file _plan_arg reaching this block under localgremlin is structurally
+# impossible — but the guard makes the assumption explicit and future-proof.
 if [[ -z "$DESCRIPTION" ]]; then
     if [[ -n "$_plan_h1" ]]; then
         DESCRIPTION="${_plan_h1:0:60}"
-    elif [[ -n "$_plan_arg" ]]; then
+    elif [[ -n "$_plan_arg" && "$KIND" == "ghgremlin" ]]; then
         DESCRIPTION=""
     else
         DESCRIPTION="${INSTR_RAW:0:60}"

--- a/skills/_bg/launch.sh
+++ b/skills/_bg/launch.sh
@@ -40,12 +40,14 @@ slugify() {
 }
 
 DESCRIPTION=""
+DESCRIPTION_EXPLICIT=0
 RESUME_GR_ID=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --description)
             [[ $# -ge 2 ]] || usage
             DESCRIPTION="$2"
+            DESCRIPTION_EXPLICIT=1
             shift 2
             ;;
         --resume)
@@ -193,10 +195,25 @@ if [[ -n "$RESUME_GR_ID" ]]; then
         done < <(jq -r '.[]' <<<"$PIPELINE_ARGS_JSON")
     fi
 
+    # When --plan is in pipeline_args, the gremlin was launched without a
+    # positional instructions string (the two are mutually exclusive), so the
+    # sidecar INSTRUCTIONS is just flag-echo garbage. Appending it as a
+    # positional on resume would make the gremlin re-parse flag text as
+    # prose — omit the trailing positional in that case.
+    _has_plan=0
+    for _pa in "${PIPELINE_ARGS[@]}"; do
+        [[ "$_pa" == "--plan" ]] && { _has_plan=1; break; }
+    done
+
     (
         cd "$WORKDIR"
-        nohup bash -c '"$PIPELINE" "$@"; EC=$?; "$HOME/.claude/skills/_bg/finish.sh" "$GR_ID" "$EC"' \
-            -- "${PIPELINE_ARGS[@]}" --resume-from "$STAGE" "$INSTRUCTIONS" </dev/null >>"$STATE_DIR/log" 2>&1 &
+        if [[ $_has_plan -eq 1 ]]; then
+            nohup bash -c '"$PIPELINE" "$@"; EC=$?; "$HOME/.claude/skills/_bg/finish.sh" "$GR_ID" "$EC"' \
+                -- "${PIPELINE_ARGS[@]}" --resume-from "$STAGE" </dev/null >>"$STATE_DIR/log" 2>&1 &
+        else
+            nohup bash -c '"$PIPELINE" "$@"; EC=$?; "$HOME/.claude/skills/_bg/finish.sh" "$GR_ID" "$EC"' \
+                -- "${PIPELINE_ARGS[@]}" --resume-from "$STAGE" "$INSTRUCTIONS" </dev/null >>"$STATE_DIR/log" 2>&1 &
+        fi
         echo $! >"$STATE_DIR/pid"
     )
 
@@ -279,41 +296,94 @@ done
 _first_positional=""
 (( _i < ${#_args[@]} )) && _first_positional="${_args[_i]}"
 
+# Find --plan <arg> in the pipeline args so both the slug-source and
+# description fallback paths can peek at the plan file's H1. The arg
+# may be a file path (local plan source) or an issue reference (ghgremlin
+# only) — only file-path values are used here; non-files fall through to
+# the raw-arg fallback, and ghgremlin.sh overwrites .description after
+# resolving the issue body.
+_plan_arg=""
+_plan_arg_idx=-1
+for (( _k=0; _k<${#_args[@]}; _k++ )); do
+    if [[ "${_args[_k]}" == "--plan" && $((_k+1)) -lt ${#_args[@]} ]]; then
+        _plan_arg="${_args[_k+1]}"
+        _plan_arg_idx=$((_k+1))
+        break
+    fi
+done
+
+# Resolve --plan file path to absolute so the initial dispatch (which
+# cd's to $WORKDIR) and any later rescue (which also cd's to $WORKDIR)
+# both find the file. A relative --plan path would resolve relative to
+# $WORKDIR post-cd, not the original caller's cwd — breaking on first run.
+# Persisted pipeline_args picks up the normalized value via `set --` below.
+_plan_abs=""
+if [[ -n "$_plan_arg" && -f "$_plan_arg" ]]; then
+    _plan_abs=$(cd "$(dirname "$_plan_arg")" 2>/dev/null && printf '%s/%s' "$(pwd)" "$(basename "$_plan_arg")") || _plan_abs=""
+    if [[ -n "$_plan_abs" && $_plan_arg_idx -ge 0 ]]; then
+        _args[$_plan_arg_idx]="$_plan_abs"
+        # Rebuild $@ so the initial dispatch at the bottom of this script
+        # uses the same normalized arg list as the persisted pipeline_args.
+        set -- "${_args[@]}"
+    fi
+fi
+
+# Extract first `# heading` from --plan file once for reuse in slug + description.
+_plan_h1=""
+if [[ -n "$_plan_arg" && -f "$_plan_arg" ]]; then
+    _plan_h1=$(head -n 50 "$_plan_arg" 2>/dev/null \
+               | sed -nE '/^#+[[:space:]]+.+/{s/^#+[[:space:]]+//p;q;}' \
+               || true)
+fi
+
+# Mutex: --plan and a positional instructions string cannot both be supplied.
+# Checked here (before any state dir creation) so the error path leaves no
+# litter behind. The gremlin scripts separately validate plan-source content
+# (file existence / issue-ref shape / non-empty body), which happens after
+# state dir creation.
+if [[ -n "$_plan_arg" && -n "$_first_positional" ]]; then
+    die "--plan and positional instructions are mutually exclusive"
+fi
+
 # Slug source resolution, in priority order. This runs *before* the
 # DESCRIPTION-from-INSTR_RAW fallback so the file-path branch isn't
 # shadowed by the fallback (which would feed the slugifier a path like
 # `/tmp/test-spec-slug.md` and produce `tmp-test-spec-slug-md`).
 #   1. Explicit --description (SKILL.md callers compose a clean ≤60-char phrase).
-#   2. If the first positional argument is a readable file, use its first
-#      `# heading` line, or fall back to its basename without extension.
-#   3. The raw instructions with leading flags stripped, first 80 chars.
-#   4. Literal "gremlin" last-resort (applied after slugify if result empty).
+#   2. --plan <file>: use the file's H1, or its basename without extension.
+#   3. First positional argument that is a readable file: same logic.
+#   4. --plan <non-file-arg>: use the raw arg (issue ref like "42" or "owner/repo#42").
+#   5. The raw instructions with leading flags stripped, first 80 chars.
+#   6. Literal "gremlin" last-resort (applied after slugify if result empty).
 SLUG_SOURCE=""
 if [[ -n "$DESCRIPTION" ]]; then
     SLUG_SOURCE="$DESCRIPTION"
-else
-    if [[ -n "$_first_positional" && -f "$_first_positional" ]]; then
-        # Quit on first `# …` line — BSD sed doesn't accept a line-range
-        # with a nested {…} block, so we use a plain pattern with `q` and
-        # cap the scan to 50 lines by piping through head (sed stops reading
-        # once `q` fires, so this is only a safety bound).
-        _title=$(head -n 50 "$_first_positional" 2>/dev/null \
-                 | sed -nE '/^#+[[:space:]]+.+/{s/^#+[[:space:]]+//p;q;}' \
-                 || true)
-        if [[ -n "$_title" ]]; then
-            SLUG_SOURCE="$_title"
-        else
-            _base="${_first_positional##*/}"
-            SLUG_SOURCE="${_base%.*}"
-        fi
+elif [[ -n "$_plan_arg" && -f "$_plan_arg" ]]; then
+    if [[ -n "$_plan_h1" ]]; then
+        SLUG_SOURCE="$_plan_h1"
     else
-        _rem=""
-        for (( _j=_i; _j<${#_args[@]}; _j++ )); do
-            _rem+="${_args[_j]} "
-        done
-        SLUG_SOURCE="${_rem% }"
-        SLUG_SOURCE="${SLUG_SOURCE:0:80}"
+        _base="${_plan_arg##*/}"
+        SLUG_SOURCE="${_base%.*}"
     fi
+elif [[ -n "$_first_positional" && -f "$_first_positional" ]]; then
+    _title=$(head -n 50 "$_first_positional" 2>/dev/null \
+             | sed -nE '/^#+[[:space:]]+.+/{s/^#+[[:space:]]+//p;q;}' \
+             || true)
+    if [[ -n "$_title" ]]; then
+        SLUG_SOURCE="$_title"
+    else
+        _base="${_first_positional##*/}"
+        SLUG_SOURCE="${_base%.*}"
+    fi
+elif [[ -n "$_plan_arg" ]]; then
+    SLUG_SOURCE="$_plan_arg"
+else
+    _rem=""
+    for (( _j=_i; _j<${#_args[@]}; _j++ )); do
+        _rem+="${_args[_j]} "
+    done
+    SLUG_SOURCE="${_rem% }"
+    SLUG_SOURCE="${SLUG_SOURCE:0:80}"
 fi
 
 # If the first positional arg is a readable file (e.g. a spec from /design),
@@ -327,11 +397,20 @@ fi
 SLUG=$(slugify "$SLUG_SOURCE")
 [[ -z "$SLUG" ]] && SLUG="gremlin"
 
-# Description fallback: explicit --description wins; otherwise fall back to
-# a truncated slice of the raw instructions so the status views always have
-# something to print.
+# Description fallback: explicit --description wins; otherwise prefer the
+# --plan file's H1 (when the plan arg is a local file), and finally fall back
+# to a truncated slice of the raw instructions. For a --plan issue-ref where
+# launch.sh can't see the issue body, DESCRIPTION stays empty so ghgremlin.sh
+# can fill it in after resolving the issue (INSTR_RAW would be just the
+# flag echo "--plan 42" which is not a useful description).
 if [[ -z "$DESCRIPTION" ]]; then
-    DESCRIPTION="${INSTR_RAW:0:60}"
+    if [[ -n "$_plan_h1" ]]; then
+        DESCRIPTION="${_plan_h1:0:60}"
+    elif [[ -n "$_plan_arg" ]]; then
+        DESCRIPTION=""
+    else
+        DESCRIPTION="${INSTR_RAW:0:60}"
+    fi
 fi
 
 RANDHEX=$(LC_ALL=C tr -dc 'a-f0-9' </dev/urandom 2>/dev/null | head -c 6 || true)
@@ -394,23 +473,29 @@ fi
 
 STATE_FILE="$STATE_DIR/state.json"
 STATE_TMP="$STATE_FILE.tmp"
+if [[ $DESCRIPTION_EXPLICIT -eq 1 ]]; then
+    DESC_EXPLICIT_JSON=true
+else
+    DESC_EXPLICIT_JSON=false
+fi
 jq -n \
-    --arg     id            "$GR_ID" \
-    --arg     kind          "$KIND" \
-    --arg     project_root  "$PROJECT_ROOT" \
-    --arg     workdir       "$WORKDIR" \
-    --arg     setup_kind    "$SETUP_KIND" \
-    --arg     branch        "$BRANCH" \
-    --arg     status        "running" \
-    --arg     started_at    "$NOW_ISO" \
-    --arg     instructions  "$INSTR_SUMMARY" \
-    --arg     description   "$DESCRIPTION" \
-    --argjson pipeline_args "$PIPELINE_ARGS_JSON" \
+    --arg     id                   "$GR_ID" \
+    --arg     kind                 "$KIND" \
+    --arg     project_root         "$PROJECT_ROOT" \
+    --arg     workdir              "$WORKDIR" \
+    --arg     setup_kind           "$SETUP_KIND" \
+    --arg     branch               "$BRANCH" \
+    --arg     status               "running" \
+    --arg     started_at           "$NOW_ISO" \
+    --arg     instructions         "$INSTR_SUMMARY" \
+    --arg     description          "$DESCRIPTION" \
+    --argjson description_explicit "$DESC_EXPLICIT_JSON" \
+    --argjson pipeline_args        "$PIPELINE_ARGS_JSON" \
     '{id: $id, kind: $kind, project_root: $project_root, workdir: $workdir,
       setup_kind: $setup_kind, branch: $branch, status: $status,
       started_at: $started_at, instructions: $instructions,
-      description: $description, pipeline_args: $pipeline_args,
-      stage: "starting", pid: null}' \
+      description: $description, description_explicit: $description_explicit,
+      pipeline_args: $pipeline_args, stage: "starting", pid: null}' \
     > "$STATE_TMP" || die "failed to write initial state"
 mv "$STATE_TMP" "$STATE_FILE"
 

--- a/skills/ghgremlin/SKILL.md
+++ b/skills/ghgremlin/SKILL.md
@@ -74,15 +74,22 @@ gremlin's session as `plan.md` and fed to the implement stage. Four forms:
   without a `Closes` link (to avoid auto-closing an unrelated issue in the
   PR's target repo).
 - **Full URL `https://github.com/owner/repo/issues/42`** — same cross-repo
-  semantics.
+  semantics. `github.com` only; GitHub Enterprise hosts are not recognized
+  as URLs — use the `owner/repo#42` form instead (which works for any host
+  `gh` is configured to reach).
 
 Rules:
 
 - Mutually exclusive with the positional `<instructions>`. Pass exactly one.
 - Files must be non-empty; issues must exist and have a non-empty body.
-- Errors (missing file, empty file, unreachable issue, unrecognized shape,
-  both forms supplied, neither supplied) are surfaced before the state
-  directory is created or cleaned up if the plan source turns out bad.
+- Failure modes split by where they fire:
+  - **Clean (no state dir):** mutex violations (`--plan` + positional, or
+    neither) and missing / empty local file are caught in `launch.sh`
+    before the state directory is created.
+  - **Dirty (failed state dir left behind):** issue-ref errors (unreachable
+    issue, unrecognized shape, empty issue body) fire in `ghgremlin.sh`
+    after the state dir has already been created. Use `/gremlins rm <id>`
+    to clean up.
 
 ## Do not
 

--- a/skills/ghgremlin/SKILL.md
+++ b/skills/ghgremlin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ghgremlin
 description: Run the end-to-end plan → implement → review → address workflow in the background by invoking ~/.claude/skills/_bg/launch.sh. Creates a GitHub issue, opens a PR implementing it, collects Copilot + Claude reviews, and addresses them. The launcher returns immediately; you'll be notified when the gremlin finishes.
-argument-hint: [--design] [-r <ref>] <instructions>
+argument-hint: [--design] [-r <ref>] [--plan <path|issue-ref> | <instructions>]
 allowed-tools: Bash(~/.claude/skills/_bg/launch.sh:*)
 ---
 
@@ -58,6 +58,31 @@ Report the gremlin id, workdir, and log path that it prints. Make clear to the u
 - The gremlin is running in the background — their session is free immediately.
 - They do **not** need to keep this Claude Code session open.
 - They will see a notification in a future session (any project-scoped session) once the gremlin finishes; the log path is where the final PR URL and per-stage output will be.
+
+## `--plan <source>`
+
+If the user already has a plan, pass `--plan <source>` to skip the `/ghplan`
+stage (no new GitHub issue is created). The plan body is copied into the
+gremlin's session as `plan.md` and fed to the implement stage. Four forms:
+
+- **Local file path** — the file contents become the plan. The PR is opened
+  with no `Closes #N` link since there's no issue to close.
+- **`42` or `#42`** — resolves to issue #42 in the current repo. The PR
+  includes `Closes #42`, same as a fresh `/ghplan` run.
+- **`owner/repo#42`** — resolves to issue #42 in a different repo. Uses the
+  issue body as plan content only; the PR is opened in the current repo
+  without a `Closes` link (to avoid auto-closing an unrelated issue in the
+  PR's target repo).
+- **Full URL `https://github.com/owner/repo/issues/42`** — same cross-repo
+  semantics.
+
+Rules:
+
+- Mutually exclusive with the positional `<instructions>`. Pass exactly one.
+- Files must be non-empty; issues must exist and have a non-empty body.
+- Errors (missing file, empty file, unreachable issue, unrecognized shape,
+  both forms supplied, neither supplied) are surfaced before the state
+  directory is created or cleaned up if the plan source turns out bad.
 
 ## Do not
 

--- a/skills/ghgremlin/ghgremlin.sh
+++ b/skills/ghgremlin/ghgremlin.sh
@@ -209,7 +209,11 @@ if [[ -n "$PLAN_SOURCE" ]]; then
         ISSUE_URL="$_resolved_url"
         ISSUE_NUM="$_resolved_num"
       fi
-      printf '%s' "$ISSUE_BODY" > "$PLAN_MD"
+      # Use `%s\n` (not `%s`) to match the `cp` semantics of the file-source
+      # branch above, which preserves the source file verbatim including a
+      # trailing newline. Keeps plan.md's on-disk shape consistent across
+      # both plan-source paths.
+      printf '%s\n' "$ISSUE_BODY" > "$PLAN_MD"
       echo "==> [1/6] plan supplied via --plan (issue ${_target_repo}#${_issue_ref})"
     fi
     patch_state '.issue_url = $url | .issue_num = $num' \

--- a/skills/ghgremlin/ghgremlin.sh
+++ b/skills/ghgremlin/ghgremlin.sh
@@ -25,7 +25,8 @@ progress_tee() {
 
 REF=""
 RESUME_FROM=""
-USAGE='usage: ghgremlin.sh [-r <ref>] [--resume-from <stage>] "<instructions>"'
+PLAN_SOURCE=""
+USAGE='usage: ghgremlin.sh [-r <ref>] [--resume-from <stage>] [--plan <path|issue-ref>] "<instructions>"'
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -r)
@@ -34,13 +35,25 @@ while [[ $# -gt 0 ]]; do
     --resume-from)
       [[ $# -ge 2 ]] || die "$USAGE"
       RESUME_FROM="$2"; shift 2 ;;
+    --plan)
+      [[ $# -ge 2 ]] || die "$USAGE"
+      PLAN_SOURCE="$2"; shift 2 ;;
     --) shift; break ;;
     -*) die "unknown flag: $1" ;;
     *) break ;;
   esac
 done
-[[ $# -ge 1 ]] || die "$USAGE"
-INSTRUCTIONS="$*"
+
+# --plan replaces the positional instructions: either one must be supplied,
+# never both. Launch.sh enforces the mutex earlier (before state dir
+# creation); this check catches direct invocations that bypass the launcher.
+if [[ -n "$PLAN_SOURCE" ]]; then
+  [[ $# -eq 0 ]] || die "--plan and positional instructions are mutually exclusive"
+  INSTRUCTIONS=""
+else
+  [[ $# -ge 1 ]] || die "$USAGE"
+  INSTRUCTIONS="$*"
+fi
 
 # Validate REF against a conservative git-ref charset. INSTRUCTIONS is
 # intentionally *not* sanitized: it is the prompt this tool exists to send.
@@ -127,6 +140,94 @@ command -v jq >/dev/null     || die "jq not found"
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner) \
   || die "not in a gh-recognized repo"
 
+# Artifacts dir (for plan.md snapshot + persisted plan cache). Falls back to
+# a mktemp dir for gremlin-less direct invocations — resume needs GR_ID/state
+# anyway, so that mode is single-shot only.
+ARTIFACTS_DIR=""
+if [[ -n "$STATE_FILE" ]]; then
+  ARTIFACTS_DIR="$(dirname "$STATE_FILE")/artifacts"
+  mkdir -p "$ARTIFACTS_DIR"
+else
+  ARTIFACTS_DIR=$(mktemp -d -t "ghgremlin-artifacts.XXXXXX")
+fi
+
+# Plan-source resolution: populate ISSUE_URL/ISSUE_NUM (empty for non-issue
+# sources so the commit-pr stage knows to omit `Closes #N`) and write the
+# canonical plan body into $ARTIFACTS_DIR/plan.md. On resume, the snapshot
+# is authoritative — don't re-read the source file or re-fetch the issue.
+ISSUE_URL=""
+ISSUE_NUM=""
+ISSUE_BODY=""
+PLAN_MD="$ARTIFACTS_DIR/plan.md"
+
+if [[ -n "$PLAN_SOURCE" ]]; then
+  if [[ -s "$PLAN_MD" ]]; then
+    # Resume path: reload from snapshot + persisted state fields.
+    ISSUE_URL=$(jq -r '.issue_url // ""' "$STATE_FILE" 2>/dev/null || true)
+    ISSUE_NUM=$(jq -r '.issue_num // ""' "$STATE_FILE" 2>/dev/null || true)
+    ISSUE_BODY=$(cat "$PLAN_MD")
+    echo "==> [1/6] plan resumed from snapshot: $PLAN_MD${ISSUE_NUM:+ (issue #$ISSUE_NUM)}"
+  else
+    # Fresh launch: classify source shape.
+    if [[ -f "$PLAN_SOURCE" ]]; then
+      # Local file source. No Closes link (no issue to close).
+      [[ -s "$PLAN_SOURCE" ]] || die "--plan: file is empty: $PLAN_SOURCE"
+      ISSUE_BODY=$(cat "$PLAN_SOURCE")
+      cp "$PLAN_SOURCE" "$PLAN_MD" || die "--plan: failed to copy to $PLAN_MD"
+      echo "==> [1/6] plan supplied via --plan (file): $PLAN_SOURCE"
+    else
+      # Issue reference. Accepted shapes:
+      #   42         → issue #42 in the current repo
+      #   #42        → same
+      #   owner/repo#42  → issue #42 in owner/repo (cross-repo)
+      #   https://github.com/owner/repo/issues/42[#fragment] → absolute URL
+      _issue_ref=""
+      _target_repo=""
+      if [[ "$PLAN_SOURCE" =~ ^#?([0-9]+)$ ]]; then
+        _issue_ref="${BASH_REMATCH[1]}"
+        _target_repo="$REPO"
+      elif [[ "$PLAN_SOURCE" =~ ^([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#([0-9]+)$ ]]; then
+        _target_repo="${BASH_REMATCH[1]}"
+        _issue_ref="${BASH_REMATCH[2]}"
+      elif [[ "$PLAN_SOURCE" =~ ^https://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/([0-9]+)(#.*)?$ ]]; then
+        _target_repo="${BASH_REMATCH[1]}"
+        _issue_ref="${BASH_REMATCH[2]}"
+      else
+        die "--plan: not a readable file or recognized issue reference: $PLAN_SOURCE"
+      fi
+      _issue_json=$(gh issue view "$_issue_ref" --repo "$_target_repo" --json number,url,body,repository 2>&1) \
+        || die "--plan: could not resolve issue $PLAN_SOURCE: $_issue_json"
+      ISSUE_BODY=$(jq -r '.body // ""' <<<"$_issue_json")
+      [[ -n "$ISSUE_BODY" ]] || die "--plan: issue $PLAN_SOURCE has an empty body"
+      _resolved_url=$(jq -r '.url // ""' <<<"$_issue_json")
+      _resolved_num=$(jq -r '.number // ""' <<<"$_issue_json")
+      _resolved_nwo=$(jq -r '.repository.nameWithOwner // empty' <<<"$_issue_json")
+      # Only set ISSUE_URL/ISSUE_NUM (which drive the `Closes #N` link) when
+      # the resolved issue's repo matches the PR's target repo. Cross-repo
+      # issue sources get the body as plan content but no auto-close link.
+      if [[ "$_resolved_nwo" == "$REPO" ]]; then
+        ISSUE_URL="$_resolved_url"
+        ISSUE_NUM="$_resolved_num"
+      fi
+      printf '%s' "$ISSUE_BODY" > "$PLAN_MD"
+      echo "==> [1/6] plan supplied via --plan (issue ${_target_repo}#${_issue_ref})"
+    fi
+    patch_state '.issue_url = $url | .issue_num = $num' \
+      --arg url "$ISSUE_URL" --arg num "$ISSUE_NUM"
+    # Fill in description from plan body's first H1, but only if the caller
+    # didn't pass --description explicitly (launch.sh records that).
+    _desc_explicit=$(jq -r '.description_explicit // false' "$STATE_FILE" 2>/dev/null || echo false)
+    if [[ "$_desc_explicit" != "true" ]]; then
+      _plan_h1=$(head -n 50 "$PLAN_MD" 2>/dev/null \
+                 | sed -nE '/^#+[[:space:]]+.+/{s/^#+[[:space:]]+//p;q;}' \
+                 || true)
+      if [[ -n "$_plan_h1" ]]; then
+        patch_state '.description = $d' --arg d "${_plan_h1:0:60}"
+      fi
+    fi
+  fi
+fi
+
 CLAUDE_FLAGS=(--permission-mode bypassPermissions --output-format stream-json --verbose)
 # Stages run sequentially; the wait-copilot sleep 20 loop should not be extended beyond ~5 min intervals or the Anthropic prompt cache TTL expires and cache benefits between the review and address stages are lost.
 
@@ -203,7 +304,7 @@ extract_session_id() {
   echo "$sid"
 }
 
-if run_stage plan; then
+if [[ -z "$PLAN_SOURCE" ]] && run_stage plan; then
   set_stage plan
   echo "==> [1/6] running /ghplan"
   # Stream the plan output to a persistent artifact as well as capturing it in
@@ -228,10 +329,13 @@ if run_stage plan; then
     "issue")
   ISSUE_NUM=$(basename "$ISSUE_URL")
   echo "    issue: $ISSUE_URL"
-  # Persist issue_url so --resume-from implement (or later) can rehydrate
-  # ISSUE_URL without re-running /ghplan.
-  patch_state '.issue_url = $url' --arg url "$ISSUE_URL"
-else
+  # Persist issue_url/issue_num so --resume-from implement (or later) can
+  # rehydrate without re-running /ghplan.
+  patch_state '.issue_url = $url | .issue_num = $num' \
+    --arg url "$ISSUE_URL" --arg num "$ISSUE_NUM"
+  ISSUE_BODY=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json body --jq .body)
+  [[ -n "$ISSUE_BODY" ]] || die "issue $ISSUE_NUM has an empty body"
+elif [[ -z "$PLAN_SOURCE" ]]; then
   [[ -n "$STATE_FILE" && -f "$STATE_FILE" ]] \
     || die "--resume-from $RESUME_FROM requires GR_ID and state.json"
   ISSUE_URL=$(jq -r '.issue_url // ""' "$STATE_FILE")
@@ -239,9 +343,11 @@ else
     || die "--resume-from $RESUME_FROM: no issue_url in state.json (rewind to plan?)"
   ISSUE_NUM=$(basename "$ISSUE_URL")
   echo "    resumed issue: $ISSUE_URL"
+  ISSUE_BODY=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json body --jq .body)
+  [[ -n "$ISSUE_BODY" ]] || die "issue $ISSUE_NUM has an empty body"
 fi
-ISSUE_BODY=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json body --jq .body)
-[[ -n "$ISSUE_BODY" ]] || die "issue $ISSUE_NUM has an empty body"
+# When PLAN_SOURCE is set, ISSUE_BODY was populated by the plan-source
+# resolution block above (from file contents or gh issue view at launch time).
 
 PRAGMATIC_DEV_FILE="$SCRIPT_DIR/../../agents/pragmatic-developer.md"
 [[ -f "$PRAGMATIC_DEV_FILE" ]] || die "missing agent file: $PRAGMATIC_DEV_FILE"
@@ -256,16 +362,23 @@ if run_stage implement; then
 
   set_stage implement
   echo "==> [2a/6] implementing plan"
+  if [[ -n "$ISSUE_NUM" ]]; then
+    _plan_source_label="from the GitHub issue"
+    _plan_location_note="The plan lives in the GitHub issue and reviews go to PR comments; the only changes in this working tree should be product code."
+  else
+    _plan_source_label="below"
+    _plan_location_note="Reviews go to PR comments; the only changes in this working tree should be product code."
+  fi
   IMPL_OUT=$(claude -p "${CLAUDE_FLAGS[@]}" \
     "When writing code, follow these principles:
 
 ${CORE_PRINCIPLES}
 
-The following is the implementation plan from the GitHub issue:
+The following is the implementation plan ${_plan_source_label}:
 
 ${ISSUE_BODY}
 
-Implement the plan above by making the code changes in this repo. Do not commit or push yet. Do NOT create any meta/scaffolding files in the repo — no \`.claude-workflow/\` directory, no \`plan.md\`, no review docs, no notes-to-self. The plan lives in the GitHub issue and reviews go to PR comments; the only changes in this working tree should be product code." \
+Implement the plan above by making the code changes in this repo. Do not commit or push yet. Do NOT create any meta/scaffolding files in the repo — no \`.claude-workflow/\` directory, no \`plan.md\`, no review docs, no notes-to-self. ${_plan_location_note}" \
     | progress_tee)
   IMPL_SESSION=$(extract_session_id "$IMPL_OUT")
 
@@ -283,11 +396,21 @@ fi
 if run_stage commit-pr; then
   set_stage commit-pr
   echo "==> [2b/6] committing + opening PR"
+  # With an issue to close, name the branch after it and include `Closes #N`
+  # in the commit + PR body. Without one (--plan from a file, or cross-repo
+  # issue ref), the branch name derives from the plan description and no
+  # Closes link is emitted — the PR would otherwise auto-close an unrelated
+  # issue in the target repo.
+  if [[ -n "$ISSUE_NUM" ]]; then
+    _pr_prompt="Create a new branch from the default branch, commit all changes with a descriptive message, push the branch, and open a PR with 'gh pr create'. Name the branch 'issue-${ISSUE_NUM}-<short-slug>', end the commit message with 'Closes #${ISSUE_NUM}', and include 'Closes #${ISSUE_NUM}' in the PR body. Print ONLY the PR URL on the final line of your response."
+  else
+    _pr_prompt="Create a new branch from the default branch, commit all changes with a descriptive message, push the branch, and open a PR with 'gh pr create'. Name the branch with a short descriptive slug derived from the plan title. Do NOT include any 'Closes #N' or 'Fixes #N' link in the commit message or PR body. Print ONLY the PR URL on the final line of your response."
+  fi
   # The --resume "$IMPL_SESSION" pairing means commit-pr only runs in the same
   # pipeline invocation as its implement stage. Resumes that start here are
   # rewound to implement above.
   PR_OUT=$(claude -p "${CLAUDE_FLAGS[@]}" --resume "$IMPL_SESSION" \
-    "Create a new branch from the default branch, commit all changes with a descriptive message, push the branch, and open a PR with 'gh pr create'. Name the branch 'issue-${ISSUE_NUM}-<short-slug>', end the commit message with 'Closes #${ISSUE_NUM}', and include 'Closes #${ISSUE_NUM}' in the PR body. Print ONLY the PR URL on the final line of your response." | progress_tee)
+    "$_pr_prompt" | progress_tee)
   PR_URL=$(extract_gh_url "$PR_OUT" \
     'https://github\.com/[^ )]+/pull/[0-9]+' \
     'gh pr create' \
@@ -329,7 +452,7 @@ if run_stage ghreview; then
 Lens:
 $SCOPE_LENS
 
-Implementation plan (from the GitHub issue):
+Implementation plan:
 
 $SCOPE_ISSUE_BODY
 

--- a/skills/localgremlin/SKILL.md
+++ b/skills/localgremlin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: localgremlin
 description: Run the end-to-end plan → implement → review-code → address-code workflow in the background by invoking ~/.claude/skills/_bg/launch.sh. Plan and code reviews land in `~/.local/state/claude-gremlins/<gremlin-id>/artifacts/` alongside the run log (kept off the product branch); the code review uses two different models in parallel. The launcher returns immediately; you'll be notified when the gremlin finishes.
-argument-hint: [--design] [-a <model>] [-b <model>] [-c <model>] <instructions>
+argument-hint: [--design] [-a <model>] [-b <model>] [-c <model>] [--plan <path> | <instructions>]
 allowed-tools: Bash(~/.claude/skills/_bg/launch.sh:*)
 ---
 
@@ -65,6 +65,19 @@ Report the gremlin id, workdir, and log path that it prints. Make clear to the u
 - The gremlin is running in the background — their session is free immediately.
 - They do **not** need to keep this Claude Code session open.
 - They will see a notification in a future session (any project-scoped session) once the gremlin finishes.
+
+## `--plan <path>`
+
+If the user already has an implementation plan, pass `--plan <path>` to skip
+the plan stage. The file's contents are copied into the gremlin's session as
+`plan.md` and the implement stage reads them as-is.
+
+- Mutually exclusive with the positional `<instructions>`. Pass exactly one.
+- The path must point to a readable, non-empty file.
+- The gremlin's description defaults to the first `# heading` in the plan
+  file unless `--description` is supplied explicitly.
+- Errors (file missing, file empty, both `--plan` and positional supplied,
+  neither supplied) are surfaced before the state directory is created.
 
 ## Do not
 

--- a/skills/localgremlin/SKILL.md
+++ b/skills/localgremlin/SKILL.md
@@ -77,7 +77,8 @@ the plan stage. The file's contents are copied into the gremlin's session as
 - The gremlin's description defaults to the first `# heading` in the plan
   file unless `--description` is supplied explicitly.
 - Errors (file missing, file empty, both `--plan` and positional supplied,
-  neither supplied) are surfaced before the state directory is created.
+  neither supplied) are surfaced in `launch.sh` before the state directory
+  is created, so a bad invocation leaves no state-dir litter behind.
 
 ## Do not
 

--- a/skills/localgremlin/localgremlin.py
+++ b/skills/localgremlin/localgremlin.py
@@ -83,18 +83,18 @@ VALID_RESUME_STAGES = ["plan", "implement", "review-code", "address-code"]
 
 
 def parse_args(argv: List[str]) -> argparse.Namespace:
-    # Short-only flags to preserve the bash `getopts "p:i:x:a:b:c:"` contract —
-    # no `--plan-model` etc. leak in via argparse's default long-form expansion.
-    # `--resume-from` is the sole long-form flag, added for the Phase B rescue
-    # path driven by launch.sh --resume.
+    # Short-only model flags to preserve the bash `getopts "p:i:x:a:b:c:"`
+    # contract — no `--plan-model` etc. leak in via argparse's default
+    # long-form expansion. Long-form flags: `--resume-from` (Phase B rescue)
+    # and `--plan` (skip the plan stage, read plan from a file instead).
     usage = (
         'usage: localgremlin.py [-p <plan-model>] [-i <impl-model>] '
         '[-x <address-model>] [-a <holistic-review-model>] '
         '[-b <detail-review-model>] [-c <scope-review-model>] '
-        '[--resume-from <stage>] "<instructions>"'
+        '[--resume-from <stage>] [--plan <path>] "<instructions>"'
     )
     parser = argparse.ArgumentParser(add_help=False, usage=usage)
-    parser.add_argument("-p", dest="plan", default="sonnet")
+    parser.add_argument("-p", dest="plan_model", default="sonnet")
     parser.add_argument("-i", dest="impl", default="sonnet")
     parser.add_argument("-x", dest="address", default="sonnet")
     parser.add_argument("-a", dest="holistic", default="sonnet")
@@ -102,15 +102,37 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     parser.add_argument("-c", dest="scope", default="sonnet")
     parser.add_argument("--resume-from", dest="resume_from", default=None,
                         choices=VALID_RESUME_STAGES)
+    parser.add_argument("--plan", dest="plan_path", default=None)
     parser.add_argument("instructions", nargs="*")
     # No try/except around parse_args: argparse already prints its own
     # `usage: …\nlocalgremlin.py: error: <specific>` to stderr before
     # raising SystemExit. Wrapping it would bury the specific error behind
     # a second copy of the usage line.
     args = parser.parse_args(argv)
-    if not args.instructions:
-        die(usage)
-    for m in (args.plan, args.impl, args.address, args.holistic, args.detail, args.scope):
+    # launch.sh resume may pass an empty-string positional when a --plan
+    # gremlin is resumed; treat that as "no positional supplied" rather than
+    # a literal empty-string instruction.
+    args.instructions = [s for s in args.instructions if s]
+    if args.plan_path:
+        if args.instructions:
+            die("--plan and positional instructions are mutually exclusive")
+        # Existing plan.md snapshot (resume path): don't re-validate the source
+        # file — it may have been deleted or edited since launch, and the
+        # snapshot in session_dir/plan.md is the durable record.
+        # Fresh launch: validate that the path is a readable, non-empty file.
+        # The snapshot check happens in main() against session_dir, so here
+        # we only do the fresh-launch validation. When resumed, main() skips
+        # re-copying, so a missing source file is tolerated there.
+        if not args.resume_from:
+            p = pathlib.Path(args.plan_path)
+            if not p.is_file():
+                die(f"--plan: file not found: {args.plan_path}")
+            if p.stat().st_size == 0:
+                die(f"--plan: file is empty: {args.plan_path}")
+    else:
+        if not args.instructions:
+            die(usage)
+    for m in (args.plan_model, args.impl, args.address, args.holistic, args.detail, args.scope):
         if not MODEL_RE.match(m):
             die(f"invalid model: {m}")
     return args
@@ -215,9 +237,21 @@ def main(argv: List[str]) -> int:
 
     # Stages run back-to-back; inserting sleeps >~5 min between them drops the Anthropic prompt cache TTL and loses inter-stage cache benefits.
     # ----- plan -----
-    if start_idx <= VALID_RESUME_STAGES.index("plan"):
+    # When --plan <path> is set, we short-circuit the plan stage: copy the
+    # user-supplied plan file into session_dir/plan.md and skip the planning
+    # agent entirely. An existing plan.md (resume path) is left alone — the
+    # snapshot captured at initial launch is authoritative, per the spec's
+    # rescue-determinism rule.
+    if args.plan_path:
+        if not plan_file.exists():
+            src = pathlib.Path(args.plan_path)
+            if not src.is_file() or src.stat().st_size == 0:
+                die(f"--plan: source file missing or empty at resume: {src}")
+            shutil.copyfile(src, plan_file)
+        print(f"==> [1/4] plan supplied via --plan -> {plan_file}", flush=True)
+    elif start_idx <= VALID_RESUME_STAGES.index("plan"):
         set_stage("plan")
-        print(f"==> [1/4] planning (model: {args.plan}) -> {plan_file}", flush=True)
+        print(f"==> [1/4] planning (model: {args.plan_model}) -> {plan_file}", flush=True)
         plan_prompt = f"""Create a detailed implementation plan for the following task and write it to the file `{plan_file}`. Use this structure:
 
 ## Context
@@ -236,7 +270,7 @@ Anything that needs discussion before implementation.
 Read any relevant code in the repo to inform the plan. Do NOT make any code changes yet — only write the plan file.
 
 Task: {instructions}"""
-        run_claude(args.plan, plan_prompt, "plan", session_dir / "stream-plan.jsonl")
+        run_claude(args.plan_model, plan_prompt, "plan", session_dir / "stream-plan.jsonl")
         if not plan_file.exists() or plan_file.stat().st_size == 0:
             die(f"plan stage did not produce {plan_file}")
     plan_text = plan_file.read_text(encoding="utf-8")

--- a/skills/localgremlin/localgremlin.py
+++ b/skills/localgremlin/localgremlin.py
@@ -111,24 +111,18 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     args = parser.parse_args(argv)
     # launch.sh resume may pass an empty-string positional when a --plan
     # gremlin is resumed; treat that as "no positional supplied" rather than
-    # a literal empty-string instruction.
-    args.instructions = [s for s in args.instructions if s]
+    # a literal empty-string instruction. Narrowed to the resume path so the
+    # fresh-launch mutex (`--plan foo.md ""`) still fires on a literal empty
+    # string passed alongside --plan.
+    if args.resume_from:
+        args.instructions = [s for s in args.instructions if s]
     if args.plan_path:
         if args.instructions:
             die("--plan and positional instructions are mutually exclusive")
-        # Existing plan.md snapshot (resume path): don't re-validate the source
-        # file — it may have been deleted or edited since launch, and the
-        # snapshot in session_dir/plan.md is the durable record.
-        # Fresh launch: validate that the path is a readable, non-empty file.
-        # The snapshot check happens in main() against session_dir, so here
-        # we only do the fresh-launch validation. When resumed, main() skips
-        # re-copying, so a missing source file is tolerated there.
-        if not args.resume_from:
-            p = pathlib.Path(args.plan_path)
-            if not p.is_file():
-                die(f"--plan: file not found: {args.plan_path}")
-            if p.stat().st_size == 0:
-                die(f"--plan: file is empty: {args.plan_path}")
+        # Source-file validation is deferred to main() so it can check the
+        # session_dir/plan.md snapshot first: on resume the snapshot is the
+        # durable record and the source may have been deleted or edited;
+        # only a fresh launch (no snapshot) actually needs the source file.
     else:
         if not args.instructions:
             die(usage)
@@ -154,6 +148,23 @@ def main(argv: List[str]) -> int:
     review_code_c = session_dir / f"review-code-scope-{args.scope}.md"
 
     print(f"==> session: {session_dir}", flush=True)
+
+    # --plan staging happens up front (before the --resume-from precondition
+    # checks below) so `--plan <path> --resume-from implement` works: the
+    # `implement` precondition requires plan.md to exist, and if we staged
+    # --plan afterwards the precondition would fire first on fresh + resume
+    # combos. On resume we skip re-copying — session_dir/plan.md is the
+    # durable snapshot per the spec's rescue-determinism rule — and only
+    # require the source file on a fresh launch (no snapshot yet).
+    plan_copied_from_source = False
+    if args.plan_path and not plan_file.exists():
+        src = pathlib.Path(args.plan_path)
+        if not src.is_file():
+            die(f"--plan: file not found: {args.plan_path}")
+        if src.stat().st_size == 0:
+            die(f"--plan: file is empty: {args.plan_path}")
+        shutil.copyfile(src, plan_file)
+        plan_copied_from_source = True
 
     is_git = in_git_repo()
 
@@ -237,18 +248,16 @@ def main(argv: List[str]) -> int:
 
     # Stages run back-to-back; inserting sleeps >~5 min between them drops the Anthropic prompt cache TTL and loses inter-stage cache benefits.
     # ----- plan -----
-    # When --plan <path> is set, we short-circuit the plan stage: copy the
-    # user-supplied plan file into session_dir/plan.md and skip the planning
-    # agent entirely. An existing plan.md (resume path) is left alone — the
-    # snapshot captured at initial launch is authoritative, per the spec's
+    # When --plan <path> is set, the plan stage is a no-op: the source file
+    # was copied into session_dir/plan.md earlier in main() (before the
+    # --resume-from precondition check), or plan.md already existed on a
+    # resume and the snapshot is authoritative per the spec's
     # rescue-determinism rule.
     if args.plan_path:
-        if not plan_file.exists():
-            src = pathlib.Path(args.plan_path)
-            if not src.is_file() or src.stat().st_size == 0:
-                die(f"--plan: source file missing or empty at resume: {src}")
-            shutil.copyfile(src, plan_file)
-        print(f"==> [1/4] plan supplied via --plan -> {plan_file}", flush=True)
+        if plan_copied_from_source:
+            print(f"==> [1/4] plan supplied via --plan (copied) -> {plan_file}", flush=True)
+        else:
+            print(f"==> [1/4] plan reused from snapshot -> {plan_file}", flush=True)
     elif start_idx <= VALID_RESUME_STAGES.index("plan"):
         set_stage("plan")
         print(f"==> [1/4] planning (model: {args.plan_model}) -> {plan_file}", flush=True)


### PR DESCRIPTION
## Summary

Adds `--plan <source>` to `/localgremlin` and `/ghgremlin` so users can hand
the gremlin a plan they already have (from `/design`, an earlier `/ghplan`,
an existing GitHub issue, or a hand-written markdown file) and skip the
redundant planning stage.

- `/localgremlin --plan <path>` — copy file into `session_dir/plan.md`,
  skip the plan agent, implement reads as-is.
- `/ghgremlin --plan <source>` — file / `42` / `#42` / `owner/repo#42` /
  full GitHub URL. No new issue is filed. `Closes #N` only when the
  resolved issue's repo matches the PR's target repo (so cross-repo
  issue-ref plans don't auto-close unrelated issues).
- Mutually exclusive with the positional `<instructions>`; errors fire
  in `launch.sh` before state dir creation.
- Rescue-safe: `plan.md` is captured at launch and treated as a snapshot;
  later edits or deletions of the original `--plan` source don't leak
  into resumed runs.

## Test plan

- [x] `bash -n` / `py_compile` — all three scripts parse cleanly.
- [x] `parse_args` for `localgremlin.py`: validates missing file, empty
      file, mutex, and neither-supplied cases.
- [x] `launch.sh` mutex: `--plan <path> "extra"` errors without creating
      a state dir.
- [ ] Manual: `/localgremlin --plan ./some-plan.md` produces artifacts
      identical to a normal run whose `plan.md` matches the source.
- [ ] Manual: `/ghgremlin --plan ./some-plan.md` opens a PR with no
      `Closes #N` and no new issue filed.
- [ ] Manual: `/ghgremlin --plan 42` resolves issue #42 in the current
      repo and opens a PR with `Closes #42`.
- [ ] Manual: `/ghgremlin --plan owner/other-repo#42` resolves the
      cross-repo issue body, opens a PR in the current repo, omits the
      `Closes` link.
- [ ] Manual: `/gremlins rescue` of a `--plan`-launched gremlin at the
      `implement` stage re-runs implement without re-running plan.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)