### PR TITLE
Add --print-id flag to launch.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Both `/ghgremlin` and `/localgremlin` accept `--design` as a first flag to invok
 - [`/gremlins`](skills/gremlins/SKILL.md) — on-demand status of all background gremlins on this machine. Key subcommands: `stop <id>` (SIGTERM), `rescue <id>` (Phase A: inline `claude -p` diagnoses and fixes the failure in the foreground; Phase B: `launch.sh --resume` relaunches the pipeline at the failed stage in the background under the original gremlin id, with a `(rescue)` liveness marker), `rm <id>` (delete state directory, worktree directory, and branch), `close <id>` (mark finished gremlin closed), `land <id>` (squash-land a local gremlin or merge a gh PR and clean up). Use `--here` to filter to the current repo.
 - [`/localreview`](skills/localreview/SKILL.md) — foreground: run the triple-lens parallel code review over local changes, writing `review-code-*.md` files to `--dir` (cwd by default). No planning, no implementation, no background gremlin.
 - [`/localaddress`](skills/localaddress/SKILL.md) — foreground: read the three `review-code-*.md` files from `--dir` and address actionable findings. In a git repo, creates a single `Address review feedback` commit (no push).
-- [`/handoff`](skills/handoff/SKILL.md) — foreground: reads the current plan and landed diff, decides `next-plan` / `chain-done` / `bail`, and writes an updated plan plus a child plan for the next gremlin. Accepts `--plan <path> [--out <path>] [--base <ref>] [--model <model>]`.
+- [`/handoff`](skills/handoff/SKILL.md) — foreground: reads the current plan and landed diff, decides `next-plan` / `chain-done` / `bail`, and writes an updated plan plus a child plan for the next gremlin. Accepts `--plan <path> [--out <path>] [--base <ref>] [--model <model>] [--timeout <secs>]`.
 
 ## Not tracked
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ Both `/ghgremlin` and `/localgremlin` accept `--design` as a first flag to invok
 - [`/gremlins`](skills/gremlins/SKILL.md) — on-demand status of all background gremlins on this machine. Key subcommands: `stop <id>` (SIGTERM), `rescue <id>` (Phase A: inline `claude -p` diagnoses and fixes the failure in the foreground; Phase B: `launch.sh --resume` relaunches the pipeline at the failed stage in the background under the original gremlin id, with a `(rescue)` liveness marker), `rm <id>` (delete state directory, worktree directory, and branch), `close <id>` (mark finished gremlin closed), `land <id>` (squash-land a local gremlin or merge a gh PR and clean up). Use `--here` to filter to the current repo.
 - [`/localreview`](skills/localreview/SKILL.md) — foreground: run the triple-lens parallel code review over local changes, writing `review-code-*.md` files to `--dir` (cwd by default). No planning, no implementation, no background gremlin.
 - [`/localaddress`](skills/localaddress/SKILL.md) — foreground: read the three `review-code-*.md` files from `--dir` and address actionable findings. In a git repo, creates a single `Address review feedback` commit (no push).
+- [`/handoff`](skills/handoff/SKILL.md) — foreground: reads the current plan and landed diff, decides `next-plan` / `chain-done` / `bail`, and writes an updated plan plus a child plan for the next gremlin. Accepts `--plan <path> [--out <path>] [--base <ref>] [--model <model>]`.
 
 ## Not tracked
 

--- a/skills/_bg/launch.sh
+++ b/skills/_bg/launch.sh
@@ -244,20 +244,7 @@ if [[ -n "$RESUME_GR_ID" ]]; then
             && mv "$STATE_TMP" "$STATE_FILE"
     fi
 
-    if [[ $PRINT_ID -eq 1 ]]; then
-        cat >&2 <<EOF
-resumed gremlin: $RESUME_GR_ID
-from stage:      $STAGE
-workdir:         $WORKDIR
-log:             $STATE_DIR/log
-state file:      $STATE_FILE
-pid:             ${PID:-unknown}
-
-The $RESUME_KIND gremlin is running in the background. You'll be notified in a
-future Claude session for this project when it finishes.
-EOF
-        printf '%s\n' "$RESUME_GR_ID"
-    else
+    {
         cat <<EOF
 resumed gremlin: $RESUME_GR_ID
 from stage:      $STAGE
@@ -269,7 +256,8 @@ pid:             ${PID:-unknown}
 The $RESUME_KIND gremlin is running in the background. You'll be notified in a
 future Claude session for this project when it finishes.
 EOF
-    fi
+    } >&$( [[ $PRINT_ID -eq 1 ]] && echo 2 || echo 1 )
+    [[ $PRINT_ID -eq 1 ]] && printf '%s\n' "$RESUME_GR_ID"
     exit 0
 fi
 
@@ -583,19 +571,7 @@ if [[ -n "$PID" ]]; then
         && mv "$STATE_TMP" "$STATE_FILE"
 fi
 
-if [[ $PRINT_ID -eq 1 ]]; then
-    cat >&2 <<EOF
-gremlin id:  $GR_ID
-workdir:     $WORKDIR
-log:         $STATE_DIR/log
-state file:  $STATE_FILE
-pid:         ${PID:-unknown}
-
-The $KIND gremlin is running in the background. You'll be notified in a future
-Claude session for this project when it finishes.
-EOF
-    printf '%s\n' "$GR_ID"
-else
+{
     cat <<EOF
 gremlin id:  $GR_ID
 workdir:     $WORKDIR
@@ -606,4 +582,5 @@ pid:         ${PID:-unknown}
 The $KIND gremlin is running in the background. You'll be notified in a future
 Claude session for this project when it finishes.
 EOF
-fi
+} >&$( [[ $PRINT_ID -eq 1 ]] && echo 2 || echo 1 )
+[[ $PRINT_ID -eq 1 ]] && printf '%s\n' "$GR_ID"

--- a/skills/_bg/launch.sh
+++ b/skills/_bg/launch.sh
@@ -9,9 +9,10 @@ die() { echo "error: $*" >&2; exit 1; }
 
 usage() {
     cat >&2 <<'EOF'
-usage: launch.sh [--description <phrase>] [--parent <boss-id>] <kind> [pipeline-args...]
-       launch.sh --resume <gremlin-id>
+usage: launch.sh [--description <phrase>] [--parent <boss-id>] [--print-id] <kind> [pipeline-args...]
+       launch.sh --resume <gremlin-id> [--print-id]
        kind ∈ {ghgremlin, localgremlin}
+       --print-id: write only the gremlin ID to stdout; all other output goes to stderr
 EOF
     exit 1
 }
@@ -44,6 +45,7 @@ DESCRIPTION=""
 DESCRIPTION_EXPLICIT=0
 RESUME_GR_ID=""
 PARENT_ID=""
+PRINT_ID=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --description)
@@ -62,6 +64,7 @@ while [[ $# -gt 0 ]]; do
             PARENT_ID="$2"
             shift 2
             ;;
+        --print-id) PRINT_ID=1; shift ;;
         --) shift; break ;;
         -*) die "unknown flag: $1" ;;
         *)  break ;;
@@ -241,7 +244,8 @@ if [[ -n "$RESUME_GR_ID" ]]; then
             && mv "$STATE_TMP" "$STATE_FILE"
     fi
 
-    cat <<EOF
+    if [[ $PRINT_ID -eq 1 ]]; then
+        cat >&2 <<EOF
 resumed gremlin: $RESUME_GR_ID
 from stage:      $STAGE
 workdir:         $WORKDIR
@@ -252,6 +256,20 @@ pid:             ${PID:-unknown}
 The $RESUME_KIND gremlin is running in the background. You'll be notified in a
 future Claude session for this project when it finishes.
 EOF
+        printf '%s\n' "$RESUME_GR_ID"
+    else
+        cat <<EOF
+resumed gremlin: $RESUME_GR_ID
+from stage:      $STAGE
+workdir:         $WORKDIR
+log:             $STATE_DIR/log
+state file:      $STATE_FILE
+pid:             ${PID:-unknown}
+
+The $RESUME_KIND gremlin is running in the background. You'll be notified in a
+future Claude session for this project when it finishes.
+EOF
+    fi
     exit 0
 fi
 
@@ -565,7 +583,8 @@ if [[ -n "$PID" ]]; then
         && mv "$STATE_TMP" "$STATE_FILE"
 fi
 
-cat <<EOF
+if [[ $PRINT_ID -eq 1 ]]; then
+    cat >&2 <<EOF
 gremlin id:  $GR_ID
 workdir:     $WORKDIR
 log:         $STATE_DIR/log
@@ -575,3 +594,16 @@ pid:         ${PID:-unknown}
 The $KIND gremlin is running in the background. You'll be notified in a future
 Claude session for this project when it finishes.
 EOF
+    printf '%s\n' "$GR_ID"
+else
+    cat <<EOF
+gremlin id:  $GR_ID
+workdir:     $WORKDIR
+log:         $STATE_DIR/log
+state file:  $STATE_FILE
+pid:         ${PID:-unknown}
+
+The $KIND gremlin is running in the background. You'll be notified in a future
+Claude session for this project when it finishes.
+EOF
+fi

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: handoff
 description: Reads the current plan document and the diff accumulated on the branch, decides whether the chain is complete or a next step is needed, and writes an updated plan plus (on next-plan) a child plan suitable for launch.sh --plan. Foreground, not backgrounded.
-argument-hint: --plan <path> [--out <path>] [--base <ref>] [--model <model>]
+argument-hint: --plan <path> [--out <path>] [--base <ref>] [--model <model>] [--timeout <secs>]
 allowed-tools: Bash(~/.claude/skills/handoff/handoff.py:*)
 ---
 
@@ -42,5 +42,6 @@ Flags:
 - `--out <path>` — path for the updated plan output. Auto-named from `--plan` if omitted (e.g. `plan.md` → `plan-001.md`, `plan-001.md` → `plan-002.md`).
 - `--base <ref>` — git ref to use as the chain-start point for diff/log collection. Defaults to `main`.
 - `--model <model>` — model for the inner agent. Defaults to `sonnet`.
+- `--timeout <secs>` — timeout in seconds for the inner agent. No timeout by default.
 
 After the script exits, report the exit state, updated plan path, and child plan path (if applicable) to the user.

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: handoff
+description: Reads the current plan document and the diff accumulated on the branch, decides whether the chain is complete or a next step is needed, and writes an updated plan plus (on next-plan) a child plan suitable for launch.sh --plan. Foreground, not backgrounded.
+argument-hint: --plan <path> [--out <path>] [--base <ref>] [--model <model>]
+allowed-tools: Bash(~/.claude/skills/handoff/handoff.py:*)
+---
+
+You are running the `handoff` chain-step decision agent. It reads the current plan, compares it against the diff that has landed on the branch since the chain started, and decides what to do next.
+
+This skill runs **in the foreground** — it blocks until the inner agent finishes. It does not spawn a background gremlin, does not create a worktree, and does not push.
+
+## What it does
+
+1. Reads the input plan from `--plan`.
+2. Collects the git log and diff since the branch diverged from `--base` (default: `main`).
+3. Runs an inner `claude -p` agent to compare landed work against the plan and determine the exit state.
+4. Writes an updated plan to `--out` (auto-named if omitted).
+5. If exit state is `next-plan`, also writes a child plan to `<out-stem>-child.md`.
+6. Writes a machine-readable signal file to `<out-stem>.state.json`.
+
+## Exit states
+
+- **`next-plan`**: work remains; a child plan has been written for the next gremlin.
+- **`chain-done`**: all tasks are implemented; the chain is complete.
+- **`bail`**: something prevents safe continuation; reason is in the signal file and updated plan.
+
+Script exit code 0 on any recognized outcome; 1 on infrastructure failure (read the signal file to distinguish outcomes).
+
+## Arguments
+
+$ARGUMENTS
+
+Forward them verbatim to the script:
+
+```
+~/.claude/skills/handoff/handoff.py $ARGUMENTS
+```
+
+Flags:
+
+- `--plan <path>` — (required) path to the current plan document.
+- `--out <path>` — path for the updated plan output. Auto-named from `--plan` if omitted (e.g. `plan.md` → `plan-001.md`, `plan-001.md` → `plan-002.md`).
+- `--base <ref>` — git ref to use as the chain-start point for diff/log collection. Defaults to `main`.
+- `--model <model>` — model for the inner agent. Defaults to `sonnet`.
+
+After the script exits, report the exit state, updated plan path, and child plan path (if applicable) to the user.

--- a/skills/handoff/handoff.py
+++ b/skills/handoff/handoff.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""handoff.py — per-step planner for chained gremlin workflows.
+
+Reads the current plan document, inspects the diff accumulated on the branch
+since the chain started, decides whether there is more work to do, and writes
+an updated plan document plus (on next-plan) a child plan suitable for
+`launch.sh --plan`.
+
+Exit codes:
+  0  — one of the three recognized outcomes; read signal file to distinguish
+  1  — infrastructure failure (bad args, missing claude, agent crash, etc.)
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+from typing import List, Optional, Tuple
+
+
+CLAUDE_FLAGS = [
+    "--permission-mode", "bypassPermissions",
+    "--output-format", "text",
+]
+
+
+def die(msg: str) -> None:
+    sys.stderr.write(f"error: {msg}\n")
+    sys.stderr.flush()
+    sys.exit(1)
+
+
+def run_git(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git"] + list(args),
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def auto_name_out(plan_path: pathlib.Path) -> pathlib.Path:
+    """Given plan.md → plan-001.md; given plan-001.md → plan-002.md, etc."""
+    # Strip trailing -NNN so plan-001.md produces plan-002.md, not plan-001-001.md
+    base = re.sub(r"-\d{3}$", "", plan_path.stem) or plan_path.stem
+    parent = plan_path.parent
+    n = 1
+    while True:
+        candidate = parent / f"{base}-{n:03d}.md"
+        if not candidate.exists():
+            return candidate
+        n += 1
+
+
+def collect_git_context(base_ref: Optional[str]) -> Tuple[str, str, str]:
+    """Return (branch_name, git_log, git_diff) since merge-base with base_ref."""
+    target = base_ref or "main"
+
+    # Validate target ref exists early so we get a clear error message
+    result = run_git("rev-parse", "--verify", target, check=False)
+    if result.returncode != 0:
+        die(f"--base ref not found in repo: {target!r}")
+
+    result = run_git("rev-parse", "--abbrev-ref", "HEAD")
+    branch = result.stdout.strip()
+
+    result = run_git("merge-base", "HEAD", target, check=False)
+    if result.returncode != 0:
+        die(f"could not compute merge-base between HEAD and {target!r}")
+    merge_base = result.stdout.strip()
+
+    result = run_git("log", f"{merge_base}..HEAD", "--oneline")
+    git_log = result.stdout.strip()
+
+    result = run_git("diff", f"{merge_base}..HEAD")
+    git_diff = result.stdout
+
+    return branch, git_log, git_diff
+
+
+def build_prompt(
+    plan_text: str,
+    branch: str,
+    git_log: str,
+    git_diff: str,
+    out_path: pathlib.Path,
+    child_plan_path: pathlib.Path,
+    signal_path: pathlib.Path,
+) -> str:
+    diff_body = git_diff[:50000] if git_diff else "(empty — no changes yet)"
+    diff_trunc = f"\n(diff truncated to 50000 chars; {len(git_diff)} chars total)" if len(git_diff) > 50000 else ""
+    log_body = git_log if git_log else "(no commits yet — branch just started)"
+
+    return f"""You are a chain-manager agent. Inspect the plan document and the work that has landed on the current branch, then decide whether the chain is complete or a next step is needed.
+
+## Input plan
+
+~~~~
+{plan_text}
+~~~~
+
+## Branch context
+
+Branch: {branch}
+
+Git log since chain start:
+```
+{log_body}
+```
+
+Git diff since chain start:
+```diff
+{diff_body}
+```{diff_trunc}
+
+## Your task
+
+1. Read the plan. Identify every task listed under `## Tasks`.
+2. Compare each task against the landed diff and git log to determine whether it has been implemented.
+3. Decide the exit state:
+   - **`chain-done`**: all tasks in the plan are implemented and landed.
+   - **`next-plan`**: some tasks remain unimplemented; the next gremlin should tackle them.
+   - **`bail`**: something prevents safe continuation (broken state, incoherent plan, security issue, etc.).
+
+4. Write an **updated plan document** to: `{out_path}`
+   - Free-form markdown. A human reading it must be able to see what is done and what remains.
+   - Mark completed tasks (e.g. `[x]`) and leave remaining tasks as `[ ]`.
+   - If `bail`, record the bail reason prominently at the top.
+
+5. If exit state is **`next-plan`**, write a **child plan** to: `{child_plan_path}`
+   - Use the standard localgremlin plan structure exactly:
+
+     ```
+     ## Context
+     <brief description of what this child gremlin should implement>
+
+     ## Approach
+     <implementation approach for the remaining work>
+
+     ## Tasks
+     - [ ] Task N: ...
+     <only the tasks that are not yet done>
+
+     ## Open questions
+     <risks or open questions, or "(none)" if there are none>
+     ```
+   - The child plan must be self-contained — a fresh gremlin with only this file must know exactly what to implement.
+
+6. Write the **signal marker** to: `{signal_path}`
+   - Valid JSON, exactly this structure:
+     ```json
+     {{"exit_state": "next-plan|chain-done|bail", "child_plan": "<absolute path or null>", "reason": "<bail reason or null>"}}
+     ```
+   - `child_plan`: `{child_plan_path}` (as a string) if exit state is `next-plan`, otherwise `null`.
+   - `reason`: a short human-readable explanation if exit state is `bail`, otherwise `null`.
+
+Write all required files before finishing. Do not explain your reasoning in stdout — the files are the output."""
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    usage = "usage: handoff.py --plan <path> [--out <path>] [--base <ref>] [--model <model>]"
+    parser = argparse.ArgumentParser(add_help=False, usage=usage)
+    parser.add_argument("--plan", dest="plan", required=True)
+    parser.add_argument("--out", dest="out", default=None)
+    parser.add_argument("--base", dest="base", default=None)
+    parser.add_argument("--model", dest="model", default="sonnet")
+    parser.add_argument("--timeout", dest="timeout", type=int, default=None,
+                        help="timeout in seconds for the inner claude agent (default: no timeout)")
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str]) -> int:
+    args = parse_args(argv)
+
+    if shutil.which("claude") is None:
+        die("claude CLI not found")
+
+    plan_path = pathlib.Path(args.plan).resolve()
+    if not plan_path.exists():
+        die(f"--plan does not exist: {plan_path}")
+    if not plan_path.is_file():
+        die(f"--plan is not a file: {plan_path}")
+    if plan_path.stat().st_size == 0:
+        die(f"--plan is empty: {plan_path}")
+    try:
+        plan_text = plan_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        die(f"--plan is not valid UTF-8: {plan_path}")
+    except OSError as exc:
+        die(f"failed to read --plan {plan_path}: {exc}")
+
+    if args.out:
+        out_path = pathlib.Path(args.out).resolve()
+    else:
+        out_path = auto_name_out(plan_path)
+
+    child_plan_path = out_path.parent / (out_path.stem + "-child" + out_path.suffix)
+    signal_path = out_path.parent / (out_path.stem + ".state.json")
+
+    try:
+        branch, git_log, git_diff = collect_git_context(args.base)
+    except SystemExit:
+        raise
+    except Exception as exc:
+        die(f"git context collection failed: {exc}")
+
+    prompt = build_prompt(
+        plan_text=plan_text,
+        branch=branch,
+        git_log=git_log,
+        git_diff=git_diff,
+        out_path=out_path,
+        child_plan_path=child_plan_path,
+        signal_path=signal_path,
+    )
+
+    cmd = ["claude", "-p", "--model", args.model, *CLAUDE_FLAGS, prompt]
+    print(f"==> running handoff agent (model: {args.model})", flush=True)
+    try:
+        result = subprocess.run(cmd, timeout=args.timeout)
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(f"error: handoff agent timed out after {args.timeout}s\n")
+        return 1
+    if result.returncode != 0:
+        sys.stderr.write(f"error: claude -p exited {result.returncode}\n")
+        return 1
+
+    if not signal_path.exists():
+        sys.stderr.write(f"error: signal file not written by agent: {signal_path}\n")
+        return 1
+
+    try:
+        state = json.loads(signal_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        sys.stderr.write(f"error: could not parse signal file {signal_path}: {exc}\n")
+        return 1
+
+    exit_state = state.get("exit_state")
+    if exit_state not in ("next-plan", "chain-done", "bail"):
+        sys.stderr.write(f"error: signal file has unrecognized exit_state: {exit_state!r}\n")
+        return 1
+
+    print(f"==> handoff complete: {exit_state}", flush=True)
+    if exit_state == "next-plan":
+        child_plan = state.get("child_plan")
+        if not child_plan:
+            sys.stderr.write("warning: signal file exit_state is next-plan but child_plan is null\n")
+        elif not pathlib.Path(child_plan).exists():
+            sys.stderr.write(f"error: child plan path in signal file does not exist: {child_plan}\n")
+            return 1
+        print(f"    updated plan: {out_path}", flush=True)
+        print(f"    child plan:   {child_plan or '(missing)'}", flush=True)
+        print(f"    signal file:  {signal_path}", flush=True)
+    elif exit_state == "chain-done":
+        print(f"    updated plan: {out_path}", flush=True)
+        print(f"    signal file:  {signal_path}", flush=True)
+    elif exit_state == "bail":
+        reason = state.get("reason") or "(no reason given)"
+        print(f"    bail reason:  {reason}", flush=True)
+        print(f"    updated plan: {out_path}", flush=True)
+        print(f"    signal file:  {signal_path}", flush=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/handoff/handoff.py
+++ b/skills/handoff/handoff.py
@@ -114,7 +114,8 @@ Git log since chain start:
 Git diff since chain start:
 ```diff
 {diff_body}
-```{diff_trunc}
+```
+{diff_trunc}
 
 ## Your task
 
@@ -161,7 +162,7 @@ Write all required files before finishing. Do not explain your reasoning in stdo
 
 
 def parse_args(argv: List[str]) -> argparse.Namespace:
-    usage = "usage: handoff.py --plan <path> [--out <path>] [--base <ref>] [--model <model>]"
+    usage = "usage: handoff.py --plan <path> [--out <path>] [--base <ref>] [--model <model>] [--timeout <secs>]"
     parser = argparse.ArgumentParser(add_help=False, usage=usage)
     parser.add_argument("--plan", dest="plan", required=True)
     parser.add_argument("--out", dest="out", default=None)
@@ -194,6 +195,10 @@ def main(argv: List[str]) -> int:
 
     if args.out:
         out_path = pathlib.Path(args.out).resolve()
+        if not out_path.parent.exists():
+            die(f"--out parent directory does not exist: {out_path.parent}")
+        if not out_path.parent.is_dir():
+            die(f"--out parent path is not a directory: {out_path.parent}")
     else:
         out_path = auto_name_out(plan_path)
 
@@ -247,12 +252,13 @@ def main(argv: List[str]) -> int:
     if exit_state == "next-plan":
         child_plan = state.get("child_plan")
         if not child_plan:
-            sys.stderr.write("warning: signal file exit_state is next-plan but child_plan is null\n")
-        elif not pathlib.Path(child_plan).exists():
+            sys.stderr.write("error: signal file exit_state is next-plan but child_plan is null\n")
+            return 1
+        if not pathlib.Path(child_plan).exists():
             sys.stderr.write(f"error: child plan path in signal file does not exist: {child_plan}\n")
             return 1
         print(f"    updated plan: {out_path}", flush=True)
-        print(f"    child plan:   {child_plan or '(missing)'}", flush=True)
+        print(f"    child plan:   {child_plan}", flush=True)
         print(f"    signal file:  {signal_path}", flush=True)
     elif exit_state == "chain-done":
         print(f"    updated plan: {out_path}", flush=True)


### PR DESCRIPTION
## Summary

- Adds a `--print-id` flag to `launch.sh` that makes gremlin ID capture machine-readable
- When set, stdout contains only `$GR_ID\n`; all human-readable summary output moves to stderr
- Works on both the normal launch path and the `--resume` path
- Without `--print-id`, output is byte-for-byte identical to before

## Usage

```bash
id=$(launch.sh --print-id localgremlin --plan /tmp/foo.md)
id=$(launch.sh --print-id --resume <gremlin-id>)
```

## Test plan

- [ ] `id=$(launch.sh --print-id localgremlin --plan /tmp/foo.md)` captures only the ID with no extra whitespace
- [ ] `launch.sh --print-id --resume <id>` outputs only the gremlin ID to stdout
- [ ] Without `--print-id`, output is unchanged from before
- [ ] `launch.sh --help` (usage block) shows the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)