### PR TITLE
Add /bossgremlin for chained serial gremlin workflows

### DIFF
--- a/skills/_bg/launch.sh
+++ b/skills/_bg/launch.sh
@@ -11,7 +11,7 @@ usage() {
     cat >&2 <<'EOF'
 usage: launch.sh [--description <phrase>] [--parent <boss-id>] [--print-id] <kind> [pipeline-args...]
        launch.sh --resume <gremlin-id> [--print-id]
-       kind ∈ {ghgremlin, localgremlin}
+       kind ∈ {ghgremlin, localgremlin, bossgremlin}
        --print-id: write only the gremlin ID to stdout; all other output goes to stderr
 EOF
     exit 1
@@ -118,7 +118,7 @@ if [[ -n "$RESUME_GR_ID" ]]; then
     PIPELINE_ARGS_JSON=$(jq -c '.pipeline_args // []' "$STATE_FILE")
 
     case "$RESUME_KIND" in
-        ghgremlin|localgremlin) ;;
+        ghgremlin|localgremlin|bossgremlin) ;;
         *) die "invalid kind in state.json: $RESUME_KIND" ;;
     esac
     [[ -n "$WORKDIR" && -d "$WORKDIR" ]] || die "worktree missing: $WORKDIR"
@@ -266,8 +266,8 @@ KIND="$1"
 shift
 
 case "$KIND" in
-    ghgremlin|localgremlin) ;;
-    *) die "invalid kind: $KIND (allowed: ghgremlin, localgremlin)" ;;
+    ghgremlin|localgremlin|bossgremlin) ;;
+    *) die "invalid kind: $KIND (allowed: ghgremlin, localgremlin, bossgremlin)" ;;
 esac
 
 command -v jq     >/dev/null 2>&1 || die "jq not found"
@@ -361,7 +361,7 @@ fi
 # (before state dir creation) on missing/empty files instead of deferring to
 # localgremlin.py. ghgremlin's --plan accepts issue refs whose validity
 # depends on the network, so its validation stays inside ghgremlin.sh.
-if [[ "$KIND" == "localgremlin" && -n "$_plan_arg" ]]; then
+if [[ ( "$KIND" == "localgremlin" || "$KIND" == "bossgremlin" ) && -n "$_plan_arg" ]]; then
     if [[ ! -f "$_plan_arg" ]]; then
         die "--plan: file not found: $_plan_arg"
     fi

--- a/skills/bossgremlin/SKILL.md
+++ b/skills/bossgremlin/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: bossgremlin
+description: Run the end-to-end chained gremlin workflow in the background by invoking ~/.claude/skills/_bg/launch.sh. Chains multiple child gremlins serially: the handoff agent decides what to implement next, each child runs plan→implement→review→address, and the boss lands each one before proceeding. The launcher returns immediately; you'll be notified when the chain finishes.
+argument-hint: --plan <spec-path> --chain-kind local|gh [--model <model>]
+allowed-tools: Bash(~/.claude/skills/_bg/launch.sh:*)
+---
+
+You are running the `bossgremlin` workflow **in the background**. The skill is a thin wrapper over `~/.claude/skills/_bg/launch.sh`, which:
+
+1. Creates an isolated git worktree (detached HEAD) of the current project.
+2. Spawns the real boss (`~/.claude/skills/bossgremlin/bossgremlin.py`) detached from this session — it survives Ctrl-C, shell exit, and Claude Code quitting.
+3. Records per-gremlin state under `~/.local/state/claude-gremlins/<gremlin-id>/` — `state.json`, `boss_state.json`, per-handoff plan files, combined `log`.
+4. Returns within ~1s.
+
+A `SessionStart` / `UserPromptSubmit` hook notifies a future Claude session for this project when the chain finishes.
+
+## Arguments
+
+$ARGUMENTS
+
+## What to do
+
+Before invoking the launcher, compose a short (≤60 characters) human-readable phrase that summarizes the overall goal — this becomes the boss's `description` in status views. Example:
+
+- "refactor API then migrate callers then update docs" → `"api refactor + caller migration + docs"`
+
+Pass it as `--description "<phrase>"` before the `bossgremlin` kind argument:
+
+```
+~/.claude/skills/_bg/launch.sh --description "<phrase>" bossgremlin --plan <spec-path> --chain-kind <local|gh> [--model <model>]
+```
+
+Flags:
+
+- `--plan <spec-path>` — (required) absolute path to the top-level spec file describing the overall multi-step goal. Must be a non-empty file. This file is immutable for the life of the chain — the boss passes it to the first handoff agent and never reads it.
+- `--chain-kind local|gh` — (required) whether children are `localgremlin` (local branch, squash-merged) or `ghgremlin` (GitHub PR, squash-merged to main). A chain is homogeneous — all children are the same kind.
+- `--model <model>` — model to use for handoff agent calls (default: `sonnet`).
+
+## Where artifacts go
+
+- `~/.local/state/claude-gremlins/<boss-id>/boss_state.json` — ordered list of child ids with outcomes, per-handoff records (timestamps, plan paths, exit states), chain base ref.
+- `~/.local/state/claude-gremlins/<boss-id>/handoff-001.md`, `handoff-002.md`, … — updated plan documents produced by each handoff invocation, showing which tasks are done.
+- `~/.local/state/claude-gremlins/<boss-id>/handoff-001-child.md`, … — child plans passed to each child gremlin.
+- `~/.local/state/claude-gremlins/<boss-id>/handoff-001.state.json`, … — handoff signal files recording exit_state and reason.
+- `~/.local/state/claude-gremlins/<boss-id>/log` — boss lifecycle events (handoff invoked, child started, child landed, rescue attempts). Does not contain plan/diff/review content.
+- Per-child state dirs are preserved after land (as with standalone gremlins).
+
+## Observability
+
+The boss appears in `/gremlins` like any other gremlin (KIND=boss). Its stage column shows the current operation: `handoff`, `waiting`, `landing`, `rescuing`, or `done`. Children display their owning boss in the ID column as `[boss:<id>]`.
+
+## Stop and resume
+
+- `/gremlins stop <boss-id>` — sends SIGTERM to the boss; it stops the current child (or handoff) and exits. The chain is halted; children that already landed stay landed.
+- `/gremlins rescue <boss-id>` — resumes a dead or stalled boss. The boss re-reads `boss_state.json` and continues from where it stopped.
+
+## Do not
+
+- Do not tail the log or block waiting for the chain to finish.
+- Do not invoke `bossgremlin.py` directly — always go through the launcher.
+- Do not use `bossgremlin` for single-step tasks — use `/localgremlin` or `/ghgremlin`.

--- a/skills/bossgremlin/bossgremlin.py
+++ b/skills/bossgremlin/bossgremlin.py
@@ -147,7 +147,7 @@ def save_boss_state(state_dir: str, boss_state: dict) -> None:
 
 
 def run_handoff(gr_id: str, state_dir: str, boss_state: dict,
-                project_root: str, model: str) -> tuple:
+                project_root: str, model: str, target_branch: str) -> tuple:
     """Run handoff agent. Returns (exit_state, signal dict).
 
     Updates boss_state in place (handoff_count, current_plan, handoff_records).
@@ -164,7 +164,7 @@ def run_handoff(gr_id: str, state_dir: str, boss_state: dict,
     current_plan = boss_state["current_plan"]
     base_ref = boss_state["chain_base_ref"]
 
-    log(f"handoff {n}: plan={current_plan}, base={base_ref[:12]}")
+    log(f"handoff {n}: plan={current_plan}, base={base_ref[:12]}, rev={target_branch or 'HEAD'}")
     cmd = [
         handoff_script,
         "--plan", current_plan,
@@ -173,6 +173,11 @@ def run_handoff(gr_id: str, state_dir: str, boss_state: dict,
         "--model", model,
         "--timeout", str(HANDOFF_TIMEOUT),
     ]
+    if target_branch:
+        # Run in the real repo root so git can resolve the target branch, and
+        # pass --rev so handoff inspects landed work on that branch rather than
+        # whatever HEAD the caller happens to have checked out.
+        cmd += ["--rev", target_branch]
     rc = run_proc(cmd, cwd=project_root)
     check_stop()
 
@@ -379,6 +384,7 @@ def main(argv):
                 boss_state=boss_state,
                 project_root=project_root,
                 model=args.model,
+                target_branch=boss_state.get("target_branch", ""),
             )
             save_boss_state(state_dir, boss_state)
             check_stop()
@@ -404,16 +410,57 @@ def main(argv):
             current_child_id = launch_child(gr_id, launch_kind, child_plan)
             boss_state["current_child_id"] = current_child_id
             save_boss_state(state_dir, boss_state)
+            # Stop the freshly launched child if a stop was requested during
+            # or just after launch (pre-wait window).
+            if _stop_requested:
+                log(f"stop requested — stopping newly launched child {current_child_id}")
+                gremlins = os.path.expanduser("~/.claude/skills/gremlins/gremlins.py")
+                if os.access(gremlins, os.X_OK):
+                    subprocess.run([gremlins, "stop", current_child_id], capture_output=True)
+                sys.exit(130)
             check_stop()
 
         else:
             # Resume path: already have a child in flight
             log(f"resuming with in-flight child: {current_child_id}")
             if child_is_closed(current_child_id):
-                log(f"child {current_child_id} already closed — treating as landed")
-                boss_state["current_child_id"] = None
-                save_boss_state(state_dir, boss_state)
-                continue
+                # `closed` is a UI hide flag, not a success/failure signal.
+                # Inspect the finished marker and exit_code to determine outcome.
+                child_wdir = os.path.join(STATE_ROOT, current_child_id)
+                finished_path = os.path.join(child_wdir, "finished")
+                state_path = os.path.join(child_wdir, "state.json")
+                if os.path.isfile(finished_path) and os.path.isfile(state_path):
+                    try:
+                        child_state = load_json(state_path)
+                        child_succeeded = child_state.get("exit_code") == 0
+                    except Exception:
+                        child_succeeded = False
+                else:
+                    child_succeeded = False
+
+                if child_succeeded:
+                    # Already finished successfully and closed — treat as landed
+                    log(f"child {current_child_id} already finished and closed — treating as landed")
+                    boss_state["children"].append({
+                        "id": current_child_id,
+                        "outcome": "landed",
+                    })
+                    boss_state["current_child_id"] = None
+                    save_boss_state(state_dir, boss_state)
+                    continue
+                else:
+                    # Closed but not successfully finished — operator may have
+                    # manually hidden a failed child.  Halt for operator action.
+                    log(
+                        f"child {current_child_id} is closed but did not finish successfully"
+                        f" — operator action required"
+                    )
+                    boss_state["current_child_id"] = None
+                    save_boss_state(state_dir, boss_state)
+                    die(
+                        f"chain halted: child {current_child_id} was manually closed without"
+                        f" successfully finishing — inspect and resume or reassign"
+                    )
 
         # Step 2: inner loop — wait → land → (rescue → wait → land)* → bail
         was_rescued = False
@@ -443,9 +490,24 @@ def main(argv):
                     save_boss_state(state_dir, boss_state)
                     break  # inner loop done; outer loop continues to next handoff
                 else:
-                    log(f"landing failed for {current_child_id}")
+                    # The pipeline succeeded but land itself failed (e.g. merge
+                    # conflict, branch protection rejection, squash conflict).
+                    # Re-running the pipeline via rescue cannot clear this
+                    # blocker, so halt the chain for operator action.
+                    log(f"landing failed for {current_child_id} — operator action required")
+                    boss_state["children"].append({
+                        "id": current_child_id,
+                        "outcome": "land-failed",
+                    })
+                    boss_state["current_child_id"] = None
+                    save_boss_state(state_dir, boss_state)
+                    die(
+                        f"chain halted: child {current_child_id} pipeline succeeded but"
+                        f" land failed (merge conflict or branch protection?) —"
+                        f" resolve manually, then resume the boss"
+                    )
 
-            # Pipeline or land failure → rescue
+            # Pipeline failure → rescue
             set_stage(gr_id, "rescuing")
             if not rescue_child(current_child_id):
                 bail_reason = get_child_bail_reason(current_child_id)
@@ -454,7 +516,7 @@ def main(argv):
                     "id": current_child_id,
                     "outcome": f"bailed:{bail_reason}" if bail_reason else "bailed",
                 })
-                boss_state["current_child_id"] = current_child_id
+                boss_state["current_child_id"] = None
                 save_boss_state(state_dir, boss_state)
                 die(f"chain halted: child {current_child_id} failed and rescue was refused")
 

--- a/skills/bossgremlin/bossgremlin.py
+++ b/skills/bossgremlin/bossgremlin.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""bossgremlin.py — manager for chained gremlin workflows.
+
+Launched by launch.sh as kind=bossgremlin. Orchestrates a serial chain of
+child gremlins (all local or all gh), with the handoff agent deciding what
+to do between steps. Never reads plan/diff/review content — its decision
+surface is: handoff .state.json exit states, the finished marker, and the
+exit codes of land and rescue.
+
+Receives pipeline args from launch.sh:
+  bossgremlin.py --plan <spec-path> --chain-kind local|gh [--model <model>]
+  [--resume-from <stage>]    ← added by launch.sh --resume; ignored (we use
+                                boss_state.json for resumption)
+
+GR_ID env var is set by launch.sh.
+"""
+
+import argparse
+import datetime
+import json
+import os
+import pathlib
+import signal
+import subprocess
+import sys
+import time
+
+STATE_ROOT = os.path.join(
+    os.environ.get("XDG_STATE_HOME", os.path.join(os.path.expanduser("~"), ".local", "state")),
+    "claude-gremlins",
+)
+
+POLL_INTERVAL = 5  # seconds between finished-marker polls
+HANDOFF_TIMEOUT = int(os.environ.get("BOSSGREMLIN_HANDOFF_TIMEOUT", "3600"))
+
+_current_proc = None
+_stop_requested = False
+
+
+def _sigterm_handler(signum, frame):
+    global _stop_requested
+    _stop_requested = True
+    log("received SIGTERM — stopping after current operation")
+    if _current_proc is not None:
+        try:
+            _current_proc.send_signal(signal.SIGTERM)
+        except Exception:
+            pass
+
+
+signal.signal(signal.SIGTERM, _sigterm_handler)
+
+
+def log(msg: str) -> None:
+    ts = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"[{ts}] {msg}", flush=True)
+
+
+def die(msg: str) -> None:
+    log(f"fatal: {msg}")
+    sys.exit(1)
+
+
+def check_stop() -> None:
+    if _stop_requested:
+        log("stop requested — exiting")
+        sys.exit(130)
+
+
+def load_json(path: str) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_json(path: str, data: dict) -> None:
+    tmp = f"{path}.tmp.{os.getpid()}"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp, path)
+
+
+def set_stage(gr_id: str, stage: str) -> None:
+    script = os.path.expanduser("~/.claude/skills/_bg/set-stage.sh")
+    if os.access(script, os.X_OK):
+        subprocess.run([script, gr_id, stage], capture_output=True)
+
+
+def run_proc(cmd: list, **kwargs) -> int:
+    """Run subprocess, returning exit code. Forwards SIGTERM on stop."""
+    global _current_proc
+    proc = subprocess.Popen(cmd, **kwargs)
+    _current_proc = proc
+    try:
+        proc.wait()
+    except Exception:
+        proc.kill()
+        proc.wait()
+    finally:
+        _current_proc = None
+    return proc.returncode
+
+
+def get_head_ref(project_root: str) -> str:
+    r = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        capture_output=True, text=True, cwd=project_root,
+    )
+    if r.returncode != 0:
+        die(f"git rev-parse HEAD failed in {project_root}: {r.stderr.strip()}")
+    return r.stdout.strip()
+
+
+def get_current_branch(project_root: str) -> str:
+    r = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True, cwd=project_root,
+    )
+    if r.returncode != 0:
+        return ""
+    branch = r.stdout.strip()
+    return "" if branch == "HEAD" else branch
+
+
+def init_boss_state(spec_path: str, chain_kind: str, chain_base_ref: str,
+                    target_branch: str, state_dir: str) -> dict:
+    boss_state = {
+        "spec_path": spec_path,
+        "chain_kind": chain_kind,
+        "chain_base_ref": chain_base_ref,
+        "target_branch": target_branch,
+        "current_plan": spec_path,
+        "handoff_count": 0,
+        "current_child_id": None,
+        "children": [],
+        "handoff_records": [],
+    }
+    save_json(os.path.join(state_dir, "boss_state.json"), boss_state)
+    return boss_state
+
+
+def load_boss_state(state_dir: str) -> dict:
+    return load_json(os.path.join(state_dir, "boss_state.json"))
+
+
+def save_boss_state(state_dir: str, boss_state: dict) -> None:
+    save_json(os.path.join(state_dir, "boss_state.json"), boss_state)
+
+
+def run_handoff(gr_id: str, state_dir: str, boss_state: dict,
+                project_root: str, model: str) -> tuple:
+    """Run handoff agent. Returns (exit_state, signal dict).
+
+    Updates boss_state in place (handoff_count, current_plan, handoff_records).
+    Calls die() on infrastructure failure.
+    """
+    set_stage(gr_id, "handoff")
+    handoff_script = os.path.expanduser("~/.claude/skills/handoff/handoff.py")
+    if not os.access(handoff_script, os.X_OK):
+        die(f"handoff.py not executable at {handoff_script}")
+
+    n = boss_state["handoff_count"] + 1
+    out_path = os.path.join(state_dir, f"handoff-{n:03d}.md")
+    signal_path = os.path.join(state_dir, f"handoff-{n:03d}.state.json")
+    current_plan = boss_state["current_plan"]
+    base_ref = boss_state["chain_base_ref"]
+
+    log(f"handoff {n}: plan={current_plan}, base={base_ref[:12]}")
+    cmd = [
+        handoff_script,
+        "--plan", current_plan,
+        "--out", out_path,
+        "--base", base_ref,
+        "--model", model,
+        "--timeout", str(HANDOFF_TIMEOUT),
+    ]
+    rc = run_proc(cmd, cwd=project_root)
+    check_stop()
+
+    if rc != 0:
+        die(f"handoff agent exited {rc}")
+
+    if not os.path.isfile(signal_path):
+        die(f"handoff signal file not written: {signal_path}")
+
+    try:
+        sig = load_json(signal_path)
+    except Exception as exc:
+        die(f"could not parse handoff signal file {signal_path}: {exc}")
+
+    exit_state = sig.get("exit_state")
+    if exit_state not in ("next-plan", "chain-done", "bail"):
+        die(f"handoff signal file has unrecognized exit_state: {exit_state!r}")
+
+    now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    boss_state["handoff_records"].append({
+        "timestamp": now,
+        "n": n,
+        "plan_in": current_plan,
+        "plan_out": out_path,
+        "signal_file": signal_path,
+        "exit_state": exit_state,
+        "child_plan": sig.get("child_plan"),
+        "bail_reason": sig.get("reason"),
+    })
+    boss_state["handoff_count"] = n
+    if os.path.isfile(out_path):
+        boss_state["current_plan"] = out_path
+
+    log(f"handoff {n} result: {exit_state}")
+    return exit_state, sig
+
+
+def launch_child(gr_id: str, launch_kind: str, child_plan: str) -> str:
+    """Launch a child gremlin. Returns child gremlin ID."""
+    global _current_proc
+    launcher = os.path.expanduser("~/.claude/skills/_bg/launch.sh")
+    if not os.access(launcher, os.X_OK):
+        die(f"launch.sh not executable at {launcher}")
+
+    cmd = [launcher, "--parent", gr_id, "--print-id", launch_kind, "--plan", child_plan]
+    log(f"launching child ({launch_kind}): {child_plan}")
+
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True)
+    _current_proc = proc
+    try:
+        stdout, _ = proc.communicate()
+    finally:
+        _current_proc = None
+    check_stop()
+
+    if proc.returncode != 0:
+        die(f"launch.sh exited {proc.returncode}")
+
+    child_id = stdout.strip()
+    if not child_id:
+        die("launch.sh --print-id produced no output")
+
+    log(f"child launched: {child_id}")
+    return child_id
+
+
+def wait_for_child(child_id: str, gr_id: str) -> bool:
+    """Poll until child has a finished marker. Returns True on clean exit (exit_code 0).
+
+    On stop request, sends stop to the child before exiting.
+    """
+    child_wdir = os.path.join(STATE_ROOT, child_id)
+    finished_path = os.path.join(child_wdir, "finished")
+    state_path = os.path.join(child_wdir, "state.json")
+
+    log(f"waiting for child {child_id}...")
+    while True:
+        if _stop_requested:
+            log(f"stop requested — stopping child {child_id}")
+            gremlins = os.path.expanduser("~/.claude/skills/gremlins/gremlins.py")
+            if os.access(gremlins, os.X_OK):
+                subprocess.run([gremlins, "stop", child_id], capture_output=True)
+            sys.exit(130)
+
+        if os.path.isfile(finished_path):
+            break
+
+        if os.path.isfile(state_path):
+            try:
+                state = load_json(state_path)
+                if state.get("status") == "running":
+                    pid = state.get("pid")
+                    if pid is not None:
+                        try:
+                            os.kill(int(pid), 0)
+                        except (OSError, ValueError):
+                            log(f"child {child_id} crashed (pid {pid} gone)")
+                            break
+            except Exception:
+                pass
+
+        time.sleep(POLL_INTERVAL)
+
+    if os.path.isfile(state_path):
+        try:
+            state = load_json(state_path)
+            return state.get("exit_code") == 0
+        except Exception:
+            pass
+    return False
+
+
+def child_is_closed(child_id: str) -> bool:
+    return os.path.isfile(os.path.join(STATE_ROOT, child_id, "closed"))
+
+
+def get_child_bail_reason(child_id: str) -> str:
+    state_path = os.path.join(STATE_ROOT, child_id, "state.json")
+    if not os.path.isfile(state_path):
+        return ""
+    try:
+        state = load_json(state_path)
+        return state.get("bail_reason") or state.get("bail_class") or ""
+    except Exception:
+        return ""
+
+
+def land_child(child_id: str) -> bool:
+    gremlins = os.path.expanduser("~/.claude/skills/gremlins/gremlins.py")
+    if not os.access(gremlins, os.X_OK):
+        die(f"gremlins.py not executable at {gremlins}")
+    log(f"landing child {child_id}")
+    return run_proc([gremlins, "land", child_id]) == 0
+
+
+def rescue_child(child_id: str) -> bool:
+    gremlins = os.path.expanduser("~/.claude/skills/gremlins/gremlins.py")
+    if not os.access(gremlins, os.X_OK):
+        die(f"gremlins.py not executable at {gremlins}")
+    log(f"rescuing child {child_id} (headless)")
+    return run_proc([gremlins, "rescue", "--headless", child_id]) == 0
+
+
+def parse_args(argv):
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("--plan", required=True)
+    p.add_argument("--chain-kind", required=True, choices=["local", "gh"])
+    p.add_argument("--model", default="sonnet")
+    p.add_argument("--resume-from", default=None)
+    args, _ = p.parse_known_args(argv)
+    return args
+
+
+def main(argv):
+    args = parse_args(argv)
+
+    gr_id = os.environ.get("GR_ID")
+    if not gr_id:
+        die("GR_ID env var not set (should be set by launch.sh)")
+
+    state_dir = os.path.join(STATE_ROOT, gr_id)
+    if not os.path.isdir(state_dir):
+        die(f"state dir not found: {state_dir}")
+
+    try:
+        gremlin_state = load_json(os.path.join(state_dir, "state.json"))
+    except Exception as exc:
+        die(f"could not read state.json: {exc}")
+    project_root = gremlin_state.get("project_root", "")
+    if not project_root or not os.path.isdir(project_root):
+        die(f"project_root not usable: {project_root!r}")
+
+    spec_path = str(pathlib.Path(args.plan).resolve())
+    chain_kind = args.chain_kind
+    launch_kind = {"local": "localgremlin", "gh": "ghgremlin"}[chain_kind]
+
+    boss_state_file = os.path.join(state_dir, "boss_state.json")
+    if not os.path.isfile(boss_state_file):
+        log(f"chain start: kind={chain_kind}, spec={spec_path}")
+        chain_base_ref = get_head_ref(project_root)
+        target_branch = get_current_branch(project_root)
+        log(f"base ref: {chain_base_ref[:12]}, target branch: {target_branch or '(detached)'}")
+        boss_state = init_boss_state(
+            spec_path=spec_path,
+            chain_kind=chain_kind,
+            chain_base_ref=chain_base_ref,
+            target_branch=target_branch,
+            state_dir=state_dir,
+        )
+    else:
+        boss_state = load_boss_state(state_dir)
+        log(f"resuming chain: kind={chain_kind}, completed children: {len(boss_state['children'])}")
+
+    # Main loop: handoff → launch → wait → land/rescue → repeat
+    while True:
+        check_stop()
+        current_child_id = boss_state.get("current_child_id")
+
+        if current_child_id is None:
+            # Step 1: run handoff to decide what to do next
+            exit_state, sig = run_handoff(
+                gr_id=gr_id,
+                state_dir=state_dir,
+                boss_state=boss_state,
+                project_root=project_root,
+                model=args.model,
+            )
+            save_boss_state(state_dir, boss_state)
+            check_stop()
+
+            if exit_state == "chain-done":
+                log("chain complete")
+                set_stage(gr_id, "done")
+                save_boss_state(state_dir, boss_state)
+                sys.exit(0)
+
+            if exit_state == "bail":
+                reason = sig.get("reason") or "(no reason given)"
+                log(f"handoff bailed: {reason}")
+                save_boss_state(state_dir, boss_state)
+                die(f"chain halted by handoff: {reason}")
+
+            # next-plan: launch the next child
+            child_plan = sig.get("child_plan")
+            if not child_plan or not os.path.isfile(child_plan):
+                die(f"handoff returned next-plan but child_plan not found: {child_plan!r}")
+
+            check_stop()
+            current_child_id = launch_child(gr_id, launch_kind, child_plan)
+            boss_state["current_child_id"] = current_child_id
+            save_boss_state(state_dir, boss_state)
+            check_stop()
+
+        else:
+            # Resume path: already have a child in flight
+            log(f"resuming with in-flight child: {current_child_id}")
+            if child_is_closed(current_child_id):
+                log(f"child {current_child_id} already closed — treating as landed")
+                boss_state["current_child_id"] = None
+                save_boss_state(state_dir, boss_state)
+                continue
+
+        # Step 2: inner loop — wait → land → (rescue → wait → land)* → bail
+        was_rescued = False
+        while True:
+            check_stop()
+            child_wdir = os.path.join(STATE_ROOT, current_child_id)
+
+            if not os.path.isfile(os.path.join(child_wdir, "finished")):
+                set_stage(gr_id, "waiting")
+                success = wait_for_child(current_child_id, gr_id)
+            else:
+                try:
+                    child_state = load_json(os.path.join(child_wdir, "state.json"))
+                    success = child_state.get("exit_code") == 0
+                except Exception:
+                    success = False
+
+            check_stop()
+
+            if success:
+                set_stage(gr_id, "landing")
+                if land_child(current_child_id):
+                    outcome = "rescued-then-landed" if was_rescued else "landed"
+                    log(f"child {current_child_id} {outcome}")
+                    boss_state["children"].append({"id": current_child_id, "outcome": outcome})
+                    boss_state["current_child_id"] = None
+                    save_boss_state(state_dir, boss_state)
+                    break  # inner loop done; outer loop continues to next handoff
+                else:
+                    log(f"landing failed for {current_child_id}")
+
+            # Pipeline or land failure → rescue
+            set_stage(gr_id, "rescuing")
+            if not rescue_child(current_child_id):
+                bail_reason = get_child_bail_reason(current_child_id)
+                log(f"rescue refused for {current_child_id} ({bail_reason or 'no bail_reason'})")
+                boss_state["children"].append({
+                    "id": current_child_id,
+                    "outcome": f"bailed:{bail_reason}" if bail_reason else "bailed",
+                })
+                boss_state["current_child_id"] = current_child_id
+                save_boss_state(state_dir, boss_state)
+                die(f"chain halted: child {current_child_id} failed and rescue was refused")
+
+            was_rescued = True
+            log(f"rescue relaunched {current_child_id} — waiting again")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/skills/gremlins/gremlins.py
+++ b/skills/gremlins/gremlins.py
@@ -1395,7 +1395,10 @@ def do_land(target: str, force: bool = False) -> bool:
     elif kind == "ghgremlin":
         return _land_gh(gr_id, sf, wdir, state, force=force)
     elif kind == "bossgremlin":
-        print(f"bossgremlin chains complete automatically — use '/gremlins close {gr_id}' to hide it")
+        print(
+            f"bossgremlin chains complete automatically — use "
+            f"'gremlins close {gr_id}' (or '/gremlins close {gr_id}') to hide it"
+        )
         return False
     else:
         print(f"error: unknown gremlin kind {kind!r} — cannot land")
@@ -1412,7 +1415,7 @@ def collect_rows(here_root=None, kind_filter=None, since_secs=None,
     Collect and return a list of row dicts, sorted by started_at ascending.
 
     here_root         — if set, restrict to gremlins with this project_root.
-    kind_filter       — if set ('local' or 'gh'), restrict to that kind.
+    kind_filter       — if set ('local', 'gh', or 'boss'), restrict to that kind.
     since_secs        — if set, restrict to gremlins started within this many seconds.
     liveness_filter   — if set, a set of prefixes ('running', 'dead', 'stalled').
     include_closed    — if True, include closed gremlins (for drill-in / --recent).
@@ -1652,7 +1655,7 @@ def parse_args(argv=None):
         help="Show only stalled gremlins.",
     )
     parser.add_argument(
-        "--kind", choices=["local", "gh"], metavar="local|gh",
+        "--kind", choices=["local", "gh", "boss"], metavar="local|gh|boss",
         help="Filter to a specific gremlin kind.",
     )
     parser.add_argument(

--- a/skills/gremlins/gremlins.py
+++ b/skills/gremlins/gremlins.py
@@ -194,6 +194,8 @@ def kind_short(kind: str) -> str:
         return "local"
     if kind == "ghgremlin":
         return "gh"
+    if kind == "bossgremlin":
+        return "boss"
     return kind or ""
 
 
@@ -296,11 +298,13 @@ def print_table(rows):
 GREMLIN_STAGES = {
     "localgremlin": ["plan", "implement", "review-code", "address-code"],
     "ghgremlin": ["plan", "implement", "commit-pr", "request-copilot", "ghreview", "wait-copilot", "ghaddress"],
+    "bossgremlin": ["handoff", "waiting", "landing", "rescuing"],
 }
 
 GREMLIN_SCRIPTS = {
     "localgremlin": "~/.claude/skills/localgremlin/localgremlin.py",
     "ghgremlin": "~/.claude/skills/ghgremlin/ghgremlin.sh",
+    "bossgremlin": "~/.claude/skills/bossgremlin/bossgremlin.py",
 }
 
 
@@ -1390,6 +1394,9 @@ def do_land(target: str, force: bool = False) -> bool:
         return _land_local(gr_id, sf, wdir, state)
     elif kind == "ghgremlin":
         return _land_gh(gr_id, sf, wdir, state, force=force)
+    elif kind == "bossgremlin":
+        print(f"bossgremlin chains complete automatically — use '/gremlins close {gr_id}' to hide it")
+        return False
     else:
         print(f"error: unknown gremlin kind {kind!r} — cannot land")
         return False

--- a/skills/handoff/handoff.py
+++ b/skills/handoff/handoff.py
@@ -55,27 +55,38 @@ def auto_name_out(plan_path: pathlib.Path) -> pathlib.Path:
         n += 1
 
 
-def collect_git_context(base_ref: Optional[str]) -> Tuple[str, str, str]:
-    """Return (branch_name, git_log, git_diff) since merge-base with base_ref."""
+def collect_git_context(base_ref: Optional[str], rev: Optional[str] = None) -> Tuple[str, str, str]:
+    """Return (branch_name, git_log, git_diff) since merge-base with base_ref.
+
+    If rev is given, inspect that ref instead of HEAD (useful when the caller
+    cannot check out the target branch, e.g. the boss gremlin inspecting the
+    target branch tip from its frozen worktree context).
+    """
     target = base_ref or "main"
+    inspect_rev = rev or "HEAD"
 
     # Validate target ref exists early so we get a clear error message
     result = run_git("rev-parse", "--verify", target, check=False)
     if result.returncode != 0:
         die(f"--base ref not found in repo: {target!r}")
 
-    result = run_git("rev-parse", "--abbrev-ref", "HEAD")
-    branch = result.stdout.strip()
+    if rev is not None:
+        result = run_git("rev-parse", "--verify", rev, check=False)
+        if result.returncode != 0:
+            die(f"--rev ref not found in repo: {rev!r}")
 
-    result = run_git("merge-base", "HEAD", target, check=False)
+    result = run_git("rev-parse", "--abbrev-ref", inspect_rev, check=False)
+    branch = result.stdout.strip() if result.returncode == 0 else inspect_rev
+
+    result = run_git("merge-base", inspect_rev, target, check=False)
     if result.returncode != 0:
-        die(f"could not compute merge-base between HEAD and {target!r}")
+        die(f"could not compute merge-base between {inspect_rev!r} and {target!r}")
     merge_base = result.stdout.strip()
 
-    result = run_git("log", f"{merge_base}..HEAD", "--oneline")
+    result = run_git("log", f"{merge_base}..{inspect_rev}", "--oneline")
     git_log = result.stdout.strip()
 
-    result = run_git("diff", f"{merge_base}..HEAD")
+    result = run_git("diff", f"{merge_base}..{inspect_rev}")
     git_diff = result.stdout
 
     return branch, git_log, git_diff
@@ -170,6 +181,8 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     parser.add_argument("--model", dest="model", default="sonnet")
     parser.add_argument("--timeout", dest="timeout", type=int, default=None,
                         help="timeout in seconds for the inner claude agent (default: no timeout)")
+    parser.add_argument("--rev", dest="rev", default=None,
+                        help="inspect this ref instead of HEAD (e.g. a target branch name)")
     return parser.parse_args(argv)
 
 
@@ -206,7 +219,7 @@ def main(argv: List[str]) -> int:
     signal_path = out_path.parent / (out_path.stem + ".state.json")
 
     try:
-        branch, git_log, git_diff = collect_git_context(args.base)
+        branch, git_log, git_diff = collect_git_context(args.base, rev=args.rev)
     except SystemExit:
         raise
     except Exception as exc:


### PR DESCRIPTION
## Summary

- Adds `/bossgremlin` skill: a manager gremlin that chains multiple child gremlins (all local or all gh) serially without babysitting — give it a top-level spec and it runs handoff → launch → wait → land → repeat until the chain is done or bails
- The manager (`bossgremlin.py`) never reads plan/diff/review content; its entire decision surface is the handoff agent's `.state.json`, the `finished` marker, and exit codes from `land` and `rescue --headless`
- Per-handoff plan files (`handoff-001.md`, `handoff-001-child.md`, `handoff-001.state.json`, …) accumulate in the boss's state dir alongside a `boss_state.json` that records child outcomes and chain base ref — fully inspectable and resumable
- Boss shows in `/gremlins` as kind `boss`; children surface their owning boss via the existing `[boss:<id>]` column marker
- SIGTERM forwarded to current subprocess; during child-wait polling, explicitly calls `gremlins stop <child-id>` before exiting
- `launch.sh` and `gremlins.py` updated minimally: bossgremlin added to kind validation, `--plan` early-validation, `kind_short`, `GREMLIN_STAGES`, `GREMLIN_SCRIPTS`, and `do_land`

## Test plan

- [ ] Launch with a two-step local spec; confirm both children land and chain reports done
- [ ] Launch with a gh chain spec; confirm PRs created and merged serially
- [ ] Verify `/gremlins` shows boss as `boss` kind and children show `[boss:<id>]`
- [ ] Kill the boss mid-wait; confirm child is stopped; rescue boss and confirm chain resumes
- [ ] Force a child failure; confirm `rescue --headless` is called; exhaust rescue cap and confirm chain halts with recorded bail reason
- [ ] Confirm `launch.sh` rejects unknown kind (pre-existing behavior preserved)
- [ ] Confirm `gremlins land <boss-id>` prints the informative refusal message

🤖 Generated with [Claude Code](https://claude.com/claude-code)