### PR TITLE
Stream agent activity to gremlin log files

### DIFF
--- a/skills/ghgremlin/ghgremlin.sh
+++ b/skills/ghgremlin/ghgremlin.sh
@@ -13,13 +13,36 @@ set_stage() {
   "$SET_STAGE_SH" "$GR_ID" "$@" >/dev/null 2>&1 || true
 }
 
-# Tee stream-json to stdout while printing a live progress trace of tool_use
-# events to stderr.
+# Tee stream-json to stdout while printing a live progress trace of agent
+# activity (session init, tool calls, thinking, text, tool results, and final
+# summary) to stderr. All output is trimmed to 200 chars per line.
 progress_tee() {
   tee >(jq -r --unbuffered '
-    select(.type=="assistant") | .message.content[]?
-    | select(.type=="tool_use")
-    | "    · \(.name) \(.input.file_path // .input.command // .input.pattern // "")"
+    if .type == "system" and .subtype == "init" then
+      "    @ session=\(.session_id // "?") model=\(.model // "?") cwd=\(.cwd // "?")"
+    elif .type == "assistant" then
+      .message.content[]?
+      | if .type == "tool_use" then
+          "    · \(.name) \(.input.file_path // .input.command // .input.pattern // "" | .[0:200])"
+        elif .type == "thinking" then
+          "    ~ think: \(.thinking // "" | gsub("\n"; " ") | .[0:200])"
+        elif .type == "text" then
+          "    ~ text: \(.text // "" | gsub("\n"; " ") | .[0:200])"
+        else empty
+        end
+    elif .type == "user" then
+      .message.content[]?
+      | select(.type == "tool_result")
+      | "    < result\(if .is_error then " ERROR" else "" end): \(
+          if (.content | type) == "array"
+          then ([.content[] | .text // ""] | join(" ") | gsub("\n"; " ") | .[0:200])
+          else (.content // "" | tostring | gsub("\n"; " ") | .[0:200])
+          end
+        )"
+    elif .type == "result" then
+      "    = done: subtype=\(.subtype // "?") turns=\(.num_turns // "?") cost=\(.total_cost_usd // .cost_usd // "?")"
+    else empty
+    end
   ' 2>/dev/null >&2)
 }
 

--- a/skills/ghgremlin/ghgremlin.sh
+++ b/skills/ghgremlin/ghgremlin.sh
@@ -18,12 +18,13 @@ set_stage() {
 # summary) to stderr. All output is trimmed to 200 chars per line.
 progress_tee() {
   tee >(jq -r --unbuffered '
+    def trimline: tostring | gsub("\n"; " ") | .[0:200];
     if .type == "system" and .subtype == "init" then
-      "    @ session=\(.session_id // "?") model=\(.model // "?") cwd=\(.cwd // "?")"
+      "    @ session=\((.session_id // "?") | trimline) model=\((.model // "?") | trimline) cwd=\((.cwd // "?") | trimline)"
     elif .type == "assistant" then
       .message.content[]?
       | if .type == "tool_use" then
-          "    · \(.name) \(.input.file_path // .input.command // .input.pattern // "" | .[0:200])"
+          "    · \(.name) \(.input.file_path // .input.command // .input.pattern // .input.url // .input.output_file // "" | gsub("\n"; " ") | .[0:200])"
         elif .type == "thinking" then
           "    ~ think: \(.thinking // "" | gsub("\n"; " ") | .[0:200])"
         elif .type == "text" then
@@ -40,7 +41,9 @@ progress_tee() {
           end
         )"
     elif .type == "result" then
-      "    = done: subtype=\(.subtype // "?") turns=\(.num_turns // "?") cost=\(.total_cost_usd // .cost_usd // "?")"
+      ("    = done: subtype=\(.subtype // "?") turns=\(.num_turns // "?") cost=\(.total_cost_usd // .cost_usd // "?")"
+       | gsub("\n"; " ")
+       | .[0:200])
     else empty
     end
   ' 2>/dev/null >&2)

--- a/skills/localgremlin/_core.py
+++ b/skills/localgremlin/_core.py
@@ -194,6 +194,9 @@ def _emit_event(prefix: str, evt: dict) -> None:
             ct = c.get("type")
             if ct == "text":
                 out.write(f"{prefix}text: {_trunc(c.get('text', ''))}\n")
+            elif ct == "thinking":
+                thought = c.get("thinking", "") or ""
+                out.write(f"{prefix}think: {_trunc(thought)}\n")
             elif ct == "tool_use":
                 inp = c.get("input") or {}
                 arg = ""


### PR DESCRIPTION
## Summary

- `ghgremlin.sh`: `progress_tee()` previously only extracted `tool_use` events to stderr. It now emits session init (`@`), thinking blocks (`~ think:`), text responses (`~ text:`), tool results (`< result:`), and the final cost/turn summary (`= done:`) — all trimmed to 200 chars.
- `localgremlin/_core.py`: `_emit_event()` now handles `thinking` content blocks so they appear in the log alongside text, tool calls, and tool results.

Since the background launcher already redirects stderr to `$STATE_DIR/log` via `2>&1`, no new output paths are needed — the existing log file gets richer content automatically.

## Test plan

- [ ] Run `/localgremlin` and `tail -f` the gremlin log; verify thinking blocks, text responses, tool calls, and tool results appear interleaved with stage markers
- [ ] Run `/ghgremlin` and verify the same in its log
- [ ] Confirm tool result bodies are trimmed (no multi-KB file dumps in the log)
- [ ] Confirm stage marker lines (`==> [N/M] ...`) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)