### PR TITLE
Post local --plan files as GitHub issues before implementing

### DIFF
--- a/skills/ghgremlin/ghgremlin.sh
+++ b/skills/ghgremlin/ghgremlin.sh
@@ -170,11 +170,25 @@ if [[ -n "$PLAN_SOURCE" ]]; then
   else
     # Fresh launch: classify source shape.
     if [[ -f "$PLAN_SOURCE" ]]; then
-      # Local file source. No Closes link (no issue to close).
+      # Local file source: post as a GitHub issue so the PR closes it.
       [[ -s "$PLAN_SOURCE" ]] || die "--plan: file is empty: $PLAN_SOURCE"
       ISSUE_BODY=$(cat "$PLAN_SOURCE")
       cp "$PLAN_SOURCE" "$PLAN_MD" || die "--plan: failed to copy to $PLAN_MD"
-      echo "==> [1/6] plan supplied via --plan (file): $PLAN_SOURCE"
+      echo "==> [1/6] plan supplied via --plan (file): $PLAN_SOURCE — posting as GitHub issue"
+      _issue_title=$(claude -p --permission-mode bypassPermissions --output-format text \
+        "Produce a concise GitHub issue title (under 80 characters) summarizing the spec below. Output ONLY the title, nothing else.
+
+$ISSUE_BODY") || die "--plan: title-generation agent failed"
+      _issue_title=$(printf '%s' "$_issue_title" | head -1 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+      _issue_title="${_issue_title:0:80}"
+      [[ -n "$_issue_title" ]] || die "--plan: title agent returned empty output"
+      _create_out=$(gh issue create --repo "$REPO" \
+        --title "$_issue_title" \
+        --body-file "$PLAN_SOURCE") || die "--plan: failed to create GitHub issue"
+      ISSUE_URL=$(printf '%s' "$_create_out" | grep -oE 'https://github\.com/[^ ]+/issues/[0-9]+' | tail -1)
+      [[ -n "$ISSUE_URL" ]] || die "--plan: could not extract issue URL from gh output: $_create_out"
+      ISSUE_NUM=$(basename "$ISSUE_URL")
+      echo "    issue: $ISSUE_URL"
     else
       # Issue reference. Accepted shapes:
       #   42         → issue #42 in the current repo

--- a/skills/ghgremlin/ghgremlin.sh
+++ b/skills/ghgremlin/ghgremlin.sh
@@ -173,7 +173,6 @@ if [[ -n "$PLAN_SOURCE" ]]; then
       # Local file source: post as a GitHub issue so the PR closes it.
       [[ -s "$PLAN_SOURCE" ]] || die "--plan: file is empty: $PLAN_SOURCE"
       ISSUE_BODY=$(cat "$PLAN_SOURCE")
-      cp "$PLAN_SOURCE" "$PLAN_MD" || die "--plan: failed to copy to $PLAN_MD"
       echo "==> [1/6] plan supplied via --plan (file): $PLAN_SOURCE — posting as GitHub issue"
       _issue_title=$(claude -p --permission-mode bypassPermissions --output-format text \
         "Produce a concise GitHub issue title (under 80 characters) summarizing the spec below. Output ONLY the title, nothing else.
@@ -188,7 +187,10 @@ $ISSUE_BODY") || die "--plan: title-generation agent failed"
       ISSUE_URL=$(printf '%s' "$_create_out" | grep -oE 'https://github\.com/[^ ]+/issues/[0-9]+' | tail -1)
       [[ -n "$ISSUE_URL" ]] || die "--plan: could not extract issue URL from gh output: $_create_out"
       ISSUE_NUM=$(basename "$ISSUE_URL")
+      patch_state '.issue_url = $url | .issue_num = $num' \
+        --arg url "$ISSUE_URL" --arg num "$ISSUE_NUM"
       echo "    issue: $ISSUE_URL"
+      cp "$PLAN_SOURCE" "$PLAN_MD" || die "--plan: failed to copy to $PLAN_MD"
     else
       # Issue reference. Accepted shapes:
       #   42         → issue #42 in the current repo
@@ -415,10 +417,9 @@ if run_stage commit-pr; then
   set_stage commit-pr
   echo "==> [2b/6] committing + opening PR"
   # With an issue to close, name the branch after it and include `Closes #N`
-  # in the commit + PR body. Without one (--plan from a file, or cross-repo
-  # issue ref), the branch name derives from the plan description and no
-  # Closes link is emitted — the PR would otherwise auto-close an unrelated
-  # issue in the target repo.
+  # in the commit + PR body. Without one (cross-repo issue ref), the branch
+  # name derives from the plan description and no Closes link is emitted —
+  # the PR would otherwise auto-close an issue in a different repo.
   if [[ -n "$ISSUE_NUM" ]]; then
     _pr_prompt="Create a new branch from the default branch, commit all changes with a descriptive message, push the branch, and open a PR with 'gh pr create'. Name the branch 'issue-${ISSUE_NUM}-<short-slug>', end the commit message with 'Closes #${ISSUE_NUM}', and include 'Closes #${ISSUE_NUM}' in the PR body. Print ONLY the PR URL on the final line of your response."
   else


### PR DESCRIPTION
## Summary

- When `--plan <local-file>` is passed to `/ghgremlin`, a GitHub issue is now created before any implementation begins — title generated by a summarizing agent, body = file contents.
- The gremlin then proceeds as if `--plan <issue-num>` was passed, so the PR includes `Closes #N` and merging closes the issue.
- If issue creation fails for any reason, the gremlin halts immediately with an error.
- No change to behavior when `--plan` points to an existing issue ref or cross-repo ref.

## Test plan

- [ ] `ghgremlin --plan spec.md` creates a GitHub issue before implementation begins
- [ ] The resulting PR description contains `Closes #N` for the new issue
- [ ] Merging the PR closes the issue
- [ ] If `gh issue create` fails, the gremlin exits with an error and no PR is opened
- [ ] `ghgremlin --plan 42` (issue ref) behaves identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)