### PR TITLE
Improve child gremlin identity in /gremlins output

### DIFF
--- a/skills/gremlins/gremlins.py
+++ b/skills/gremlins/gremlins.py
@@ -30,7 +30,7 @@ STATE_ROOT = os.path.join(
     "claude-gremlins",
 )
 
-FMT = "%-5s  %-47s  %-22s  %-28s  %-5s  %s"
+FMT = "%-5s  %-47s  %-22s  %-28s  %-5s  %-20s  %s"
 
 # Headless rescue caps. The attempt cap is shared across interactive and
 # headless rescues — both check `rescue_count`, but interactive only warns
@@ -263,14 +263,13 @@ def build_row(gr_id, sf, wdir, state, live):
     age = humanize_age(started_at)
     sid = display_id(gr_id)
     parent_id = state.get("parent_id") or ""
-    if parent_id:
-        boss_prefix = f"[boss:{display_id(parent_id)}] "
-        desc_trim = (boss_prefix + desc)[:60]
+    boss_disp = display_id(parent_id) if parent_id else ""
 
     return {
         "started_at": started_at,
         "kind": k,
         "sid": sid,
+        "boss": boss_disp,
         "stage": stage_trim,
         "live": live_trim,
         "live_full": live,
@@ -286,9 +285,9 @@ def build_row(gr_id, sf, wdir, state, live):
 
 def print_table(rows):
     """Print header + rows using the fixed format string."""
-    print(FMT % ("KIND", "ID", "STAGE", "LIVENESS", "AGE", "DESCRIPTION"))
+    print(FMT % ("KIND", "ID", "STAGE", "LIVENESS", "AGE", "BOSS", "DESCRIPTION"))
     for r in rows:
-        print(FMT % (r["kind"], r["sid"], r["stage"], r["live"], r["age"], r["desc"]))
+        print(FMT % (r["kind"], r["sid"], r["stage"], r["live"], r["age"], r["boss"], r["desc"]))
 
 
 # ---------------------------------------------------------------------------

--- a/skills/gremlins/gremlins.py
+++ b/skills/gremlins/gremlins.py
@@ -263,7 +263,7 @@ def build_row(gr_id, sf, wdir, state, live):
     age = humanize_age(started_at)
     sid = display_id(gr_id)
     parent_id = state.get("parent_id") or ""
-    boss_disp = display_id(parent_id) if parent_id else ""
+    boss_disp = display_id(parent_id)[:20] if parent_id else ""
 
     return {
         "started_at": started_at,

--- a/skills/gremlins/gremlins.py
+++ b/skills/gremlins/gremlins.py
@@ -264,8 +264,8 @@ def build_row(gr_id, sf, wdir, state, live):
     sid = display_id(gr_id)
     parent_id = state.get("parent_id") or ""
     if parent_id:
-        boss_marker = f" [boss:{display_id(parent_id)}]"
-        sid = (sid + boss_marker)[:47]
+        boss_prefix = f"[boss:{display_id(parent_id)}] "
+        desc_trim = (boss_prefix + desc)[:60]
 
     return {
         "started_at": started_at,

--- a/skills/handoff/handoff.py
+++ b/skills/handoff/handoff.py
@@ -146,6 +146,8 @@ Git diff since chain start:
    - Use the standard localgremlin plan structure exactly:
 
      ```
+     # <short one-line title summarising what this step implements>
+
      ## Context
      <brief description of what this child gremlin should implement>
 


### PR DESCRIPTION
## Summary

- Child gremlin plans now start with a meaningful `# <title>` heading, so their ID slug and description are derived from the actual task rather than the generic section header "Context"
- The ID column is never truncated — the boss marker that previously crowded it is moved to a dedicated `BOSS` column
- New `BOSS` column shows the parent gremlin's ID for child gremlins, empty for top-level gremlins

## Test plan

- [ ] Run a boss gremlin chain and verify child gremlin IDs and descriptions reflect the task title from the handoff-generated child plan
- [ ] Confirm the `BOSS` column appears in `/gremlins` output and shows the boss ID for child gremlins
- [ ] Confirm the `ID` column is never truncated regardless of slug length

🤖 Generated with [Claude Code](https://claude.com/claude-code)