### PR TITLE
Document /handoff and /bossgremlin; fix unused loop variable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Both `/ghgremlin` and `/localgremlin` accept `--design` as a first flag to invok
 - [`/localreview`](skills/localreview/SKILL.md) — foreground: run the triple-lens parallel code review over local changes, writing `review-code-*.md` files to `--dir` (cwd by default). No planning, no implementation, no background gremlin.
 - [`/localaddress`](skills/localaddress/SKILL.md) — foreground: read the three `review-code-*.md` files from `--dir` and address actionable findings. In a git repo, creates a single `Address review feedback` commit (no push).
 - [`/handoff`](skills/handoff/SKILL.md) — foreground: reads the current plan and landed diff, decides `next-plan` / `chain-done` / `bail`, and writes an updated plan plus a child plan for the next gremlin. Accepts `--plan <path> [--out <path>] [--base <ref>] [--model <model>] [--timeout <secs>]`.
+- [`/bossgremlin`](skills/bossgremlin/SKILL.md) — background chained serial workflow driven by a top-level spec; invokes `/handoff` between child gremlins and lands each before proceeding. Requires `--plan <spec-path> --chain-kind local|gh`. Monitor with `/gremlins` (`KIND=boss`); rescue a stalled chain with `rescue <boss-id>`.
 
 ## Not tracked
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ skills/
   localreview/        # /localreview: standalone triple-lens code review over local changes (foreground)
   localaddress/       # /localaddress: standalone address-code stage over existing review files (foreground)
   gremlins/           # /gremlins: on-demand status of background gremlins; supports stop/rescue/rm/close/land subcommands
+  handoff/            # /handoff: foreground chain-step decision agent; decides next-plan/chain-done/bail and writes child plan
+  bossgremlin/        # /bossgremlin: chained serial gremlin workflow; runs multiple child gremlins via handoff agent
 agents/
   pragmatic-developer.md
 commands/             # slash commands (created on first sync; no files tracked yet)
@@ -56,6 +58,8 @@ The skills cluster into a GitHub-issue-driven gremlin and a local gremlin (`/loc
 - [`/localreview`](skills/localreview/SKILL.md) — standalone triple-lens code review (holistic, detail, scope) over local changes, foreground. Writes `review-code-*.md` files to `--dir` (defaults to cwd).
 - [`/localaddress`](skills/localaddress/SKILL.md) — standalone address-code stage that reads `review-code-*.md` files from `--dir` and applies actionable findings. Foreground. In a git repo, creates one `Address review feedback` commit (no push).
 - [`/gremlins`](skills/gremlins/SKILL.md) — on-demand status of background gremlins. Subcommands: `stop <id>`, `rescue <id>`, `rm <id>`, `close <id>`, `land <id>` (squash-land a local gremlin or merge a gh PR). Flags include `--here`, `--running`, `--dead`, `--stalled`, `--kind`, `--since`, `--recent`, `--watch`.
+- [`/handoff`](skills/handoff/SKILL.md) — foreground chain-step decision agent. Reads the current plan and the diff landed so far, produces `next-plan` / `chain-done` / `bail`, and writes an updated plan plus a child plan for the next gremlin. Accepts `--plan <path> [--out <path>] [--base <ref>] [--model <model>] [--timeout <secs>]`.
+- [`/bossgremlin`](skills/bossgremlin/SKILL.md) — background chained serial workflow. Requires `--plan <spec-path>` (immutable top-level spec) and `--chain-kind local|gh`. The boss invokes `/handoff` between child gremlins, lands each one before proceeding, and notifies when the chain finishes. Use `/gremlins` to monitor (`KIND=boss`) and `rescue <boss-id>` to resume a stalled chain.
 
 `skills/ghgremlin/ghgremlin.sh` chains them: `/ghplan` → implement → `/ghreview` (Copilot + Claude in parallel with a scope reviewer) → `/ghaddress`, producing a merged-ready PR from a single instruction.
 

--- a/skills/localgremlin/_core.py
+++ b/skills/localgremlin/_core.py
@@ -501,7 +501,7 @@ def load_lenses() -> Tuple[str, str, str]:
         "detail": SCRIPT_DIR / "lens-detail-code.md",
         "scope": SCRIPT_DIR / "lens-scope-code.md",
     }
-    for _name, path in lens_files.items():
+    for path in lens_files.values():
         if not path.exists() or path.stat().st_size == 0:
             die(f"missing or empty lens file: {path}")
     # Explicit utf-8 — lens files contain em-dashes and other non-ASCII, so


### PR DESCRIPTION
## Summary

- Add `/handoff` and `/bossgremlin` to README.md (Layout tree + Skills section) — both skills existed but were absent from the docs
- Add `/bossgremlin` to CLAUDE.md's Additional skills section (only `/handoff` was listed)
- Replace `for _name, path in lens_files.items()` with `.values()` in `_core.py` since the key was unused

## Test plan

- [ ] Verify README.md Layout and Skills sections accurately reflect the skills directory
- [ ] Verify CLAUDE.md Additional skills lists both `/handoff` and `/bossgremlin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)