### PR TITLE
Add --model flag to ghgremlin.sh

### DIFF
--- a/skills/ghgremlin/ghgremlin.sh
+++ b/skills/ghgremlin/ghgremlin.sh
@@ -52,7 +52,8 @@ progress_tee() {
 REF=""
 RESUME_FROM=""
 PLAN_SOURCE=""
-USAGE='usage: ghgremlin.sh [-r <ref>] [--resume-from <stage>] [--plan <path|issue-ref>] "<instructions>"'
+MODEL=""
+USAGE='usage: ghgremlin.sh [-r <ref>] [--resume-from <stage>] [--plan <path|issue-ref>] [--model <model>] "<instructions>"'
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -r)
@@ -64,6 +65,9 @@ while [[ $# -gt 0 ]]; do
     --plan)
       [[ $# -ge 2 ]] || die "$USAGE"
       PLAN_SOURCE="$2"; shift 2 ;;
+    --model)
+      [[ $# -ge 2 ]] || die "$USAGE"
+      MODEL="$2"; shift 2 ;;
     --) shift; break ;;
     -*) die "unknown flag: $1" ;;
     *) break ;;
@@ -275,6 +279,7 @@ $ISSUE_BODY") || die "--plan: title-generation agent failed"
 fi
 
 CLAUDE_FLAGS=(--permission-mode bypassPermissions --output-format stream-json --verbose)
+[[ -n "$MODEL" ]] && CLAUDE_FLAGS+=(--model "$MODEL")
 # Stages run sequentially; the wait-copilot sleep 20 loop should not be extended beyond ~5 min intervals or the Anthropic prompt cache TTL expires and cache benefits between the review and address stages are lost.
 
 # Extract a URL from a Bash-tool_result event matching a regex, preferring

--- a/skills/ghgremlin/ghgremlin.sh
+++ b/skills/ghgremlin/ghgremlin.sh
@@ -204,7 +204,9 @@ if [[ -n "$PLAN_SOURCE" ]]; then
       [[ -s "$PLAN_SOURCE" ]] || die "--plan: file is empty: $PLAN_SOURCE"
       ISSUE_BODY=$(cat "$PLAN_SOURCE")
       echo "==> [1/6] plan supplied via --plan (file): $PLAN_SOURCE — posting as GitHub issue"
-      _issue_title=$(claude -p --permission-mode bypassPermissions --output-format text \
+      _title_flags=(--permission-mode bypassPermissions --output-format text)
+      [[ -n "$MODEL" ]] && _title_flags+=(--model "$MODEL")
+      _issue_title=$(claude -p "${_title_flags[@]}" \
         "Produce a concise GitHub issue title (under 80 characters) summarizing the spec below. Output ONLY the title, nothing else.
 
 $ISSUE_BODY") || die "--plan: title-generation agent failed"
@@ -278,8 +280,14 @@ $ISSUE_BODY") || die "--plan: title-generation agent failed"
   fi
 fi
 
+# On resume, restore MODEL from state.json if --model was not re-supplied.
+if [[ -z "$MODEL" && -n "$STATE_FILE" && -f "$STATE_FILE" ]]; then
+  MODEL=$(jq -r '.model // ""' "$STATE_FILE" 2>/dev/null || true)
+fi
+
 CLAUDE_FLAGS=(--permission-mode bypassPermissions --output-format stream-json --verbose)
 [[ -n "$MODEL" ]] && CLAUDE_FLAGS+=(--model "$MODEL")
+[[ -n "$MODEL" ]] && patch_state '.model = $m' --arg m "$MODEL"
 # Stages run sequentially; the wait-copilot sleep 20 loop should not be extended beyond ~5 min intervals or the Anthropic prompt cache TTL expires and cache benefits between the review and address stages are lost.
 
 # Extract a URL from a Bash-tool_result event matching a regex, preferring


### PR DESCRIPTION
Passes `--model` through to all inner `claude` invocations so callers can override the model without editing the script.

- Title-generation `claude -p` (inside `--plan` file-source branch) now inherits `--model` for full model consistency.
- `MODEL` is persisted to `state.json` so `--resume-from` invocations automatically restore the original model.