### PR TITLE
Fix invalid `gh issue view --json repository` in ghgremlin.sh

### DIFF
--- a/skills/ghgremlin/ghgremlin.sh
+++ b/skills/ghgremlin/ghgremlin.sh
@@ -243,13 +243,13 @@ $ISSUE_BODY") || die "--plan: title-generation agent failed"
       else
         die "--plan: not a readable file or recognized issue reference: $PLAN_SOURCE"
       fi
-      _issue_json=$(gh issue view "$_issue_ref" --repo "$_target_repo" --json number,url,body,repository 2>&1) \
+      _issue_json=$(gh issue view "$_issue_ref" --repo "$_target_repo" --json number,url,body 2>&1) \
         || die "--plan: could not resolve issue $PLAN_SOURCE: $_issue_json"
       ISSUE_BODY=$(jq -r '.body // ""' <<<"$_issue_json")
       [[ -n "$ISSUE_BODY" ]] || die "--plan: issue $PLAN_SOURCE has an empty body"
       _resolved_url=$(jq -r '.url // ""' <<<"$_issue_json")
       _resolved_num=$(jq -r '.number // ""' <<<"$_issue_json")
-      _resolved_nwo=$(jq -r '.repository.nameWithOwner // empty' <<<"$_issue_json")
+      _resolved_nwo="$_target_repo"
       # Only set ISSUE_URL/ISSUE_NUM (which drive the `Closes #N` link) when
       # the resolved issue's repo matches the PR's target repo. Cross-repo
       # issue sources get the body as plan content but no auto-close link.


### PR DESCRIPTION
## Summary
- `repository` is not a valid `gh issue view --json` field, so every `/ghgremlin --plan <issue-ref>` invocation died at the plan stage with `could not resolve issue`.
- The target repo is already known from `--plan` source parsing (lines 234–242), so set `_resolved_nwo="$_target_repo"` directly instead of re-resolving via the (non-existent) `.repository.nameWithOwner` field.

## Test plan
- [x] Verified `gh issue view --help` field list excludes `repository`.
- [x] Re-rescued the stalled `fix-handoff-git-context-worktree-bug-e18f6c` gremlin after applying the fix; it progressed past the previously failing `plan` stage into `implement`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)