### PR TITLE
Clear completed tasks from /handoff rolling plan

### DIFF
--- a/skills/bossgremlin/SKILL.md
+++ b/skills/bossgremlin/SKILL.md
@@ -39,7 +39,7 @@ Flags:
 ## Where artifacts go
 
 - `~/.local/state/claude-gremlins/<boss-id>/boss_state.json` — ordered list of child ids with outcomes, per-handoff records (timestamps, plan paths, exit states), chain base ref.
-- `~/.local/state/claude-gremlins/<boss-id>/handoff-001.md`, `handoff-002.md`, … — updated plan documents produced by each handoff invocation, showing which tasks are done.
+- `~/.local/state/claude-gremlins/<boss-id>/handoff-001.md`, `handoff-002.md`, … — rolling plan documents produced by each handoff invocation, each containing only the work still remaining at that point. The sequence of files is the audit trail of progression.
 - `~/.local/state/claude-gremlins/<boss-id>/handoff-001-child.md`, … — child plans passed to each child gremlin.
 - `~/.local/state/claude-gremlins/<boss-id>/handoff-001.state.json`, … — handoff signal files recording exit_state and reason.
 - `~/.local/state/claude-gremlins/<boss-id>/log` — boss lifecycle events (handoff invoked, child started, child landed, rescue attempts). Does not contain plan/diff/review content.

--- a/skills/handoff/handoff.py
+++ b/skills/handoff/handoff.py
@@ -149,7 +149,7 @@ Git diff since chain start:
      - Under `## Open questions`, carry forward unresolved entries; drop entries tied to completed tasks.
      - If a task is only partly landed, keep it (rewritten if needed to reflect what remains).
    - **`chain-done`**: minimal output. A short note that the chain is complete is enough — no leftover task list, no carried-over context. The signal file carries the structured outcome.
-   - **`bail`**: record the bail reason prominently at the top, then list the still-remaining tasks. Completed tasks are still dropped.
+   - **`bail`**: same pruning rules as `next-plan` (only remaining tasks, surrounding sections trimmed accordingly, unresolved `## Open questions` carried forward), with a bail-reason banner added prominently at the top.
 
 5. If exit state is **`next-plan`**, write a **child plan** to: `{child_plan_path}`
    - Use the standard localgremlin plan structure exactly:

--- a/skills/handoff/handoff.py
+++ b/skills/handoff/handoff.py
@@ -141,10 +141,15 @@ Git diff since chain start:
    - **`next-plan`**: some tasks remain unimplemented; the next gremlin should tackle them.
    - **`bail`**: something prevents safe continuation (broken state, incoherent plan, security issue, etc.).
 
-4. Write an **updated plan document** to: `{out_path}`
-   - Free-form markdown. A human reading it must be able to see what is done and what remains.
-   - Mark completed tasks (e.g. `[x]`) and leave remaining tasks as `[ ]`.
-   - If `bail`, record the bail reason prominently at the top.
+4. Write an **updated plan document** (the "rolling plan") to: `{out_path}`
+
+   The rolling plan describes only **remaining** work. Completed tasks are removed entirely — no `[x]` markers, no struck-through entries, no "completed" appendix. The chain of versioned plan files plus git history is the audit trail; the rolling plan does not repeat it. Do not propagate the overarching goal of the chain forward into the rolling plan — that lives upstream, in the original spec.
+
+   - **`next-plan`**: include only the tasks that are not yet implemented (still `[ ]`). Prune the surrounding sections (`## Context`, `## Approach`, `## Open questions`, etc.) to match: drop sections whose reason for existing was a now-completed task; keep or trim the rest so the document stays a coherent description of the remaining work.
+     - Under `## Open questions`, carry forward unresolved entries; drop entries tied to completed tasks.
+     - If a task is only partly landed, keep it (rewritten if needed to reflect what remains).
+   - **`chain-done`**: minimal output. A short note that the chain is complete is enough — no leftover task list, no carried-over context. The signal file carries the structured outcome.
+   - **`bail`**: record the bail reason prominently at the top, then list the still-remaining tasks. Completed tasks are still dropped.
 
 5. If exit state is **`next-plan`**, write a **child plan** to: `{child_plan_path}`
    - Use the standard localgremlin plan structure exactly:
@@ -165,7 +170,7 @@ Git diff since chain start:
      ## Open questions
      <risks or open questions, or "(none)" if there are none>
      ```
-   - The child plan must be self-contained — a fresh gremlin with only this file must know exactly what to implement.
+   - The child plan must be self-contained — a fresh gremlin with only this file must know exactly what to implement. Do not propagate the overarching goal of the chain into the child plan; scope it to the next chunk.
 
 6. Write the **signal marker** to: `{signal_path}`
    - Valid JSON, exactly this structure:


### PR DESCRIPTION
## Summary
- Rewrites the `/handoff` inner-agent prompt so the rolling plan emitted between chain steps contains only remaining work — no `[x]` markers, no struck-through entries, no "completed" appendix. The chain of versioned plan files plus git history is the audit trail.
- Per exit state: `next-plan` prunes surrounding sections to match remaining tasks and carries forward unresolved `## Open questions`; `chain-done` produces a minimal completion marker; `bail` follows the same pruning rules as `next-plan` with a bail-reason banner added at the top.
- Tells the agent not to propagate the overarching chain goal into either the rolling plan or the child plan; child plans remain self-contained for their chunk.
- Updates the `handoff-NNN.md` artifact description in `skills/bossgremlin/SKILL.md` to reflect the new "remaining work only" semantics.

Scope note: this PR only changes the **handoff rolling plan** convention. Per-gremlin `plan.md` files still use `[x]` to mark completed tasks, and `gremlins.py`'s commit-message synthesis still parses those markers from `## Tasks` — that behavior is unchanged. No Python orchestration changes are needed: `bossgremlin.py` only feeds the rolling plan back into the next handoff invocation and never parses `[x]` itself.

## Test plan
- [ ] Run `/bossgremlin` end-to-end on a multi-step spec; confirm successive `handoff-NNN.md` files shrink as tasks land and contain no `[x]` entries.
- [ ] Verify a `chain-done` rolling plan is a brief completion marker with no leftover task list.
- [ ] Verify a `bail` rolling plan starts with the bail reason banner and contains only still-remaining tasks, with surrounding sections pruned.
- [ ] Diff a child plan against one produced by the previous version; confirm structure and contents are unchanged.

Closes #64