### PR TITLE
Anchor gh bossgremlin chains to the repo default branch

### DIFF
--- a/skills/bossgremlin/bossgremlin.py
+++ b/skills/bossgremlin/bossgremlin.py
@@ -122,6 +122,42 @@ def get_current_branch(project_root: str) -> str:
     return "" if branch == "HEAD" else branch
 
 
+def get_default_branch(project_root: str) -> str:
+    """Resolve the repo's default branch via gh CLI. Calls die() on failure."""
+    r = subprocess.run(
+        ["gh", "repo", "view", "--json", "defaultBranchRef",
+         "-q", ".defaultBranchRef.name"],
+        capture_output=True, text=True, cwd=project_root,
+    )
+    if r.returncode != 0:
+        die(f"gh repo view failed in {project_root}: {r.stderr.strip()}")
+    name = r.stdout.strip()
+    if not name:
+        die(f"gh repo view returned empty default branch in {project_root}")
+    return name
+
+
+def get_remote_branch_sha(project_root: str, branch: str) -> str:
+    """Fetch origin/<branch> and return its SHA. Calls die() on failure."""
+    try:
+        fetch = subprocess.run(
+            ["git", "fetch", "origin", branch],
+            capture_output=True, text=True, cwd=project_root,
+            timeout=HANDOFF_FETCH_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        die(f"git fetch origin {branch} timed out after {HANDOFF_FETCH_TIMEOUT}s at chain start")
+    if fetch.returncode != 0:
+        die(f"git fetch origin {branch} failed at chain start: {fetch.stderr.strip()}")
+    r = subprocess.run(
+        ["git", "rev-parse", f"origin/{branch}"],
+        capture_output=True, text=True, cwd=project_root,
+    )
+    if r.returncode != 0:
+        die(f"git rev-parse origin/{branch} failed: {r.stderr.strip()}")
+    return r.stdout.strip()
+
+
 def init_boss_state(spec_path: str, chain_kind: str, chain_base_ref: str,
                     target_branch: str, state_dir: str) -> dict:
     boss_state = {
@@ -392,9 +428,17 @@ def main(argv):
     boss_state_file = os.path.join(state_dir, "boss_state.json")
     if not os.path.isfile(boss_state_file):
         log(f"chain start: kind={chain_kind}, spec={spec_path}")
-        chain_base_ref = get_head_ref(project_root)
-        target_branch = get_current_branch(project_root)
-        log(f"base ref: {chain_base_ref[:12]}, target branch: {target_branch or '(detached)'}")
+        if chain_kind == "gh":
+            # gh children open PRs from the repo's default branch and land
+            # there, regardless of where the user happens to be. Anchor the
+            # chain to origin/<default-branch> so handoff diffs land cleanly.
+            target_branch = get_default_branch(project_root)
+            chain_base_ref = get_remote_branch_sha(project_root, target_branch)
+            log(f"base ref: {chain_base_ref[:12]} (origin/{target_branch}), target branch: {target_branch}")
+        else:
+            chain_base_ref = get_head_ref(project_root)
+            target_branch = get_current_branch(project_root)
+            log(f"base ref: {chain_base_ref[:12]}, target branch: {target_branch or '(detached)'}")
         boss_state = init_boss_state(
             spec_path=spec_path,
             chain_kind=chain_kind,

--- a/skills/bossgremlin/bossgremlin.py
+++ b/skills/bossgremlin/bossgremlin.py
@@ -32,7 +32,11 @@ STATE_ROOT = os.path.join(
 
 POLL_INTERVAL = 5  # seconds between finished-marker polls
 HANDOFF_TIMEOUT = int(os.environ.get("BOSSGREMLIN_HANDOFF_TIMEOUT", "3600"))
+# Bounds every interaction with `origin` (chain-start fetch of the default
+# branch and per-handoff fetch of the target branch). Named for the historical
+# per-handoff use; kept under the same env var for backwards compatibility.
 HANDOFF_FETCH_TIMEOUT = int(os.environ.get("BOSSGREMLIN_HANDOFF_FETCH_TIMEOUT", "60"))
+GH_VIEW_TIMEOUT = 30  # seconds; bounds `gh repo view` at chain start
 
 _current_proc = None
 _stop_requested = False
@@ -124,11 +128,17 @@ def get_current_branch(project_root: str) -> str:
 
 def get_default_branch(project_root: str) -> str:
     """Resolve the repo's default branch via gh CLI. Calls die() on failure."""
-    r = subprocess.run(
-        ["gh", "repo", "view", "--json", "defaultBranchRef",
-         "-q", ".defaultBranchRef.name"],
-        capture_output=True, text=True, cwd=project_root,
-    )
+    try:
+        r = subprocess.run(
+            ["gh", "repo", "view", "--json", "defaultBranchRef",
+             "-q", ".defaultBranchRef.name"],
+            capture_output=True, text=True, cwd=project_root,
+            timeout=GH_VIEW_TIMEOUT,
+        )
+    except FileNotFoundError:
+        die("gh CLI not found on PATH — required to resolve default branch for gh chain")
+    except subprocess.TimeoutExpired:
+        die(f"gh repo view timed out after {GH_VIEW_TIMEOUT}s in {project_root}")
     if r.returncode != 0:
         die(f"gh repo view failed in {project_root}: {r.stderr.strip()}")
     name = r.stdout.strip()
@@ -137,24 +147,35 @@ def get_default_branch(project_root: str) -> str:
     return name
 
 
-def get_remote_branch_sha(project_root: str, branch: str) -> str:
-    """Fetch origin/<branch> and return its SHA. Calls die() on failure."""
+def fetch_origin_branch(project_root: str, branch: str, *, context: str) -> None:
+    """Fetch origin/<branch> with a bounded timeout. Calls die() on failure.
+
+    Uses an explicit refspec so a branch name starting with `-` cannot be
+    parsed by `git fetch` as an option. `context` is interpolated into error
+    messages (e.g. "at chain start" vs "before handoff").
+    """
+    refspec = f"refs/heads/{branch}:refs/remotes/origin/{branch}"
     try:
         fetch = subprocess.run(
-            ["git", "fetch", "origin", branch],
+            ["git", "fetch", "origin", refspec],
             capture_output=True, text=True, cwd=project_root,
             timeout=HANDOFF_FETCH_TIMEOUT,
         )
     except subprocess.TimeoutExpired:
-        die(f"git fetch origin {branch} timed out after {HANDOFF_FETCH_TIMEOUT}s at chain start")
+        die(f"git fetch origin {refspec} timed out after {HANDOFF_FETCH_TIMEOUT}s {context}")
     if fetch.returncode != 0:
-        die(f"git fetch origin {branch} failed at chain start: {fetch.stderr.strip()}")
+        die(f"git fetch origin {refspec} failed {context}: {fetch.stderr.strip()}")
+
+
+def get_remote_branch_sha(project_root: str, branch: str) -> str:
+    """Fetch origin/<branch> and return its SHA. Calls die() on failure."""
+    fetch_origin_branch(project_root, branch, context="at chain start")
     r = subprocess.run(
-        ["git", "rev-parse", f"origin/{branch}"],
+        ["git", "rev-parse", f"refs/remotes/origin/{branch}"],
         capture_output=True, text=True, cwd=project_root,
     )
     if r.returncode != 0:
-        die(f"git rev-parse origin/{branch} failed: {r.stderr.strip()}")
+        die(f"git rev-parse refs/remotes/origin/{branch} failed: {r.stderr.strip()}")
     return r.stdout.strip()
 
 
@@ -222,16 +243,7 @@ def run_handoff(gr_id: str, state_dir: str, boss_state: dict,
         # which never trigger _fast_forward_main locally). Bound the fetch so
         # an unreachable origin can't stall the chain indefinitely between
         # handoffs.
-        try:
-            fetch = subprocess.run(
-                ["git", "fetch", "origin", target_branch],
-                capture_output=True, text=True, cwd=project_root,
-                timeout=HANDOFF_FETCH_TIMEOUT,
-            )
-        except subprocess.TimeoutExpired:
-            die(f"git fetch origin {target_branch} timed out after {HANDOFF_FETCH_TIMEOUT}s")
-        if fetch.returncode != 0:
-            die(f"git fetch origin {target_branch} failed: {fetch.stderr.strip()}")
+        fetch_origin_branch(project_root, target_branch, context="before handoff")
         handoff_cwd = project_root
         rev_label = f"origin/{target_branch}"
         rev_args = ["--rev", rev_label]


### PR DESCRIPTION
## Summary

For gh chains, `bossgremlin` previously captured `target_branch` from `git rev-parse --abbrev-ref HEAD` at chain start. But ghgremlin children create their PRs from the default branch, so `origin/<target_branch>` only matched "where PRs land" when the user happened to be on the default branch at launch time. From a feature branch this either silently emitted `chain-done` (if `origin/<feature>` was stale) or hard-failed at the first handoff fetch (if the feature branch wasn't on origin at all).

Fix:

- For gh chains, resolve the default branch via `gh repo view --json defaultBranchRef` at chain start (cached in `boss_state`).
- Use that as `target_branch`, and set `chain_base_ref` to the SHA of `origin/<default-branch>` (also fetched at chain start) so handoff diffs are exactly the PRs landed during the chain.
- Local chains keep the existing HEAD/current-branch anchoring.

The user's current branch is now irrelevant to a gh chain — they can launch from anywhere.

Closes #63

## Test plan

- [ ] Launch a gh boss chain from a feature branch and verify it correctly inspects `origin/main` (or the configured default) at each handoff.
- [ ] Launch a gh boss chain from `main` and verify behavior is unchanged.
- [ ] Launch a local boss chain and verify HEAD-based anchoring is unchanged.
- [ ] Verify `boss_state.json` records `target_branch` as the default branch name and `chain_base_ref` as the `origin/<default>` SHA for gh chains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)