### PR TITLE
Pass overarching spec as north star to every handoff

### DIFF
--- a/skills/bossgremlin/bossgremlin.py
+++ b/skills/bossgremlin/bossgremlin.py
@@ -168,6 +168,7 @@ def run_handoff(gr_id: str, state_dir: str, boss_state: dict,
     out_path = os.path.join(state_dir, f"handoff-{n:03d}.md")
     signal_path = os.path.join(state_dir, f"handoff-{n:03d}.state.json")
     current_plan = boss_state["current_plan"]
+    spec_path = boss_state.get("spec_path", "")
     base_ref = boss_state["chain_base_ref"]
     chain_kind = boss_state.get("chain_kind")
     target_branch = boss_state.get("target_branch", "")
@@ -202,10 +203,12 @@ def run_handoff(gr_id: str, state_dir: str, boss_state: dict,
     else:
         die(f"unknown chain_kind: {chain_kind!r}")
 
-    log(f"handoff {n}: plan={current_plan}, base={base_ref[:12]}, rev={rev_label}, cwd={handoff_cwd}")
+    log(f"handoff {n}: plan={current_plan}, spec={spec_path}, base={base_ref[:12]}, rev={rev_label}, cwd={handoff_cwd}")
+    spec_args = ["--spec", spec_path] if spec_path else []
     cmd = [
         handoff_script,
         "--plan", current_plan,
+        *spec_args,
         "--out", out_path,
         "--base", base_ref,
         "--model", model,

--- a/skills/bossgremlin/bossgremlin.py
+++ b/skills/bossgremlin/bossgremlin.py
@@ -168,7 +168,7 @@ def run_handoff(gr_id: str, state_dir: str, boss_state: dict,
     out_path = os.path.join(state_dir, f"handoff-{n:03d}.md")
     signal_path = os.path.join(state_dir, f"handoff-{n:03d}.state.json")
     current_plan = boss_state["current_plan"]
-    spec_path = boss_state.get("spec_path", "")
+    spec_path = boss_state["spec_path"]
     base_ref = boss_state["chain_base_ref"]
     chain_kind = boss_state.get("chain_kind")
     target_branch = boss_state.get("target_branch", "")
@@ -203,8 +203,16 @@ def run_handoff(gr_id: str, state_dir: str, boss_state: dict,
     else:
         die(f"unknown chain_kind: {chain_kind!r}")
 
-    log(f"handoff {n}: plan={current_plan}, spec={spec_path}, base={base_ref[:12]}, rev={rev_label}, cwd={handoff_cwd}")
-    spec_args = ["--spec", spec_path] if spec_path else []
+    # Only forward --spec once the rolling plan has diverged from the spec.
+    # On handoff #1, init_boss_state seeds current_plan = spec_path, so
+    # passing --spec would render the same document twice in the prompt
+    # (once as north-star, once as the input plan). Skipping --spec there
+    # avoids the duplication; the north-star section first appears on the
+    # handoff that runs against an actual rolling plan (#2+).
+    forward_spec = bool(spec_path) and spec_path != current_plan
+    spec_log = spec_path if forward_spec else "(none)"
+    log(f"handoff {n}: plan={current_plan}, spec={spec_log}, base={base_ref[:12]}, rev={rev_label}, cwd={handoff_cwd}")
+    spec_args = ["--spec", spec_path] if forward_spec else []
     cmd = [
         handoff_script,
         "--plan", current_plan,

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: handoff
 description: Reads the current plan document and the diff accumulated on the branch, decides whether the chain is complete or a next step is needed, and writes an updated plan plus (on next-plan) a child plan suitable for launch.sh --plan. Foreground, not backgrounded.
-argument-hint: --plan <path> [--out <path>] [--base <ref>] [--model <model>] [--timeout <secs>]
+argument-hint: --plan <path> [--spec <path>] [--out <path>] [--base <ref>] [--model <model>] [--timeout <secs>]
 allowed-tools: Bash(~/.claude/skills/handoff/handoff.py:*)
 ---
 
@@ -39,6 +39,7 @@ Forward them verbatim to the script:
 Flags:
 
 - `--plan <path>` — (required) path to the current plan document.
+- `--spec <path>` — overarching chain spec, surfaced to the agent as a read-only "north star" so subsequent handoffs see the original goal alongside the rolling remaining-work plan. Optional (the standalone `/handoff` use case has no separate spec).
 - `--out <path>` — path for the updated plan output. Auto-named from `--plan` if omitted (e.g. `plan.md` → `plan-001.md`, `plan-001.md` → `plan-002.md`).
 - `--base <ref>` — git ref to use as the chain-start point for diff/log collection. Defaults to `main`.
 - `--model <model>` — model for the inner agent. Defaults to `sonnet`.

--- a/skills/handoff/handoff.py
+++ b/skills/handoff/handoff.py
@@ -104,14 +104,27 @@ def build_prompt(
     out_path: pathlib.Path,
     child_plan_path: pathlib.Path,
     signal_path: pathlib.Path,
+    spec_text: Optional[str] = None,
 ) -> str:
     diff_body = git_diff[:50000] if git_diff else "(empty — no changes yet)"
     diff_trunc = f"\n(diff truncated to 50000 chars; {len(git_diff)} chars total)" if len(git_diff) > 50000 else ""
     log_body = git_log if git_log else "(no commits yet — branch just started)"
 
+    spec_section = ""
+    if spec_text is not None:
+        spec_section = f"""## Overarching goal (north star)
+
+This is the original chain spec. It does not change between handoffs and is read-only context for understanding what the chain as a whole is working toward. Use it to judge whether the rolling input plan below is on track and to scope the next step coherently. Do not echo it into the updated plan — it stays in `--spec`.
+
+~~~~
+{spec_text}
+~~~~
+
+"""
+
     return f"""You are a chain-manager agent. Inspect the plan document and the work that has landed on the current branch, then decide whether the chain is complete or a next step is needed.
 
-## Input plan
+{spec_section}## Input plan
 
 ~~~~
 {plan_text}
@@ -184,9 +197,11 @@ Write all required files before finishing. Do not explain your reasoning in stdo
 
 
 def parse_args(argv: List[str]) -> argparse.Namespace:
-    usage = "usage: handoff.py --plan <path> [--out <path>] [--base <ref>] [--model <model>] [--timeout <secs>]"
+    usage = "usage: handoff.py --plan <path> [--spec <path>] [--out <path>] [--base <ref>] [--model <model>] [--timeout <secs>]"
     parser = argparse.ArgumentParser(add_help=False, usage=usage)
     parser.add_argument("--plan", dest="plan", required=True)
+    parser.add_argument("--spec", dest="spec", default=None,
+                        help="overarching chain spec used as read-only north-star context")
     parser.add_argument("--out", dest="out", default=None)
     parser.add_argument("--base", dest="base", default=None)
     parser.add_argument("--model", dest="model", default="sonnet")
@@ -217,6 +232,22 @@ def main(argv: List[str]) -> int:
     except OSError as exc:
         die(f"failed to read --plan {plan_path}: {exc}")
 
+    spec_text: Optional[str] = None
+    if args.spec is not None:
+        spec_path = pathlib.Path(args.spec).resolve()
+        if not spec_path.exists():
+            die(f"--spec does not exist: {spec_path}")
+        if not spec_path.is_file():
+            die(f"--spec is not a file: {spec_path}")
+        if spec_path.stat().st_size == 0:
+            die(f"--spec is empty: {spec_path}")
+        try:
+            spec_text = spec_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            die(f"--spec is not valid UTF-8: {spec_path}")
+        except OSError as exc:
+            die(f"failed to read --spec {spec_path}: {exc}")
+
     if args.out:
         out_path = pathlib.Path(args.out).resolve()
         if not out_path.parent.exists():
@@ -244,6 +275,7 @@ def main(argv: List[str]) -> int:
         out_path=out_path,
         child_plan_path=child_plan_path,
         signal_path=signal_path,
+        spec_text=spec_text,
     )
 
     cmd = ["claude", "-p", "--model", args.model, *CLAUDE_FLAGS, prompt]

--- a/skills/handoff/handoff.py
+++ b/skills/handoff/handoff.py
@@ -112,13 +112,15 @@ def build_prompt(
 
     spec_section = ""
     if spec_text is not None:
+        spec_body = spec_text[:50000]
+        spec_trunc = f"\n(spec truncated to 50000 chars; {len(spec_text)} chars total)" if len(spec_text) > 50000 else ""
         spec_section = f"""## Overarching goal (north star)
 
 This is the original chain spec. It does not change between handoffs and is read-only context for understanding what the chain as a whole is working toward. Use it to judge whether the rolling input plan below is on track and to scope the next step coherently. Do not echo it into the updated plan — it stays in `--spec`.
 
 ~~~~
-{spec_text}
-~~~~
+{spec_body}
+~~~~{spec_trunc}
 
 """
 
@@ -232,21 +234,28 @@ def main(argv: List[str]) -> int:
     except OSError as exc:
         die(f"failed to read --plan {plan_path}: {exc}")
 
+    # Spec is best-effort context, not a hard chain anchor: if it's missing,
+    # moved, or unreadable, fall back to rendering without the north-star
+    # section rather than halting the whole boss chain. The rolling plan and
+    # landed diff alone are still enough for a coherent next-step decision
+    # (which is exactly what the standalone /handoff invocation does without
+    # --spec). Warn so the operator can notice and fix the path if intended.
     spec_text: Optional[str] = None
     if args.spec is not None:
         spec_path = pathlib.Path(args.spec).resolve()
         if not spec_path.exists():
-            die(f"--spec does not exist: {spec_path}")
-        if not spec_path.is_file():
-            die(f"--spec is not a file: {spec_path}")
-        if spec_path.stat().st_size == 0:
-            die(f"--spec is empty: {spec_path}")
-        try:
-            spec_text = spec_path.read_text(encoding="utf-8")
-        except UnicodeDecodeError:
-            die(f"--spec is not valid UTF-8: {spec_path}")
-        except OSError as exc:
-            die(f"failed to read --spec {spec_path}: {exc}")
+            sys.stderr.write(f"warning: --spec does not exist, continuing without north-star context: {spec_path}\n")
+        elif not spec_path.is_file():
+            sys.stderr.write(f"warning: --spec is not a file, continuing without north-star context: {spec_path}\n")
+        elif spec_path.stat().st_size == 0:
+            sys.stderr.write(f"warning: --spec is empty, continuing without north-star context: {spec_path}\n")
+        else:
+            try:
+                spec_text = spec_path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                sys.stderr.write(f"warning: --spec is not valid UTF-8, continuing without north-star context: {spec_path}\n")
+            except OSError as exc:
+                sys.stderr.write(f"warning: failed to read --spec, continuing without north-star context: {spec_path}: {exc}\n")
 
     if args.out:
         out_path = pathlib.Path(args.out).resolve()


### PR DESCRIPTION
## Summary
- After PR #65, the rolling plan only carries remaining work, so any handoff after the first lost sight of the chain's original goal.
- `bossgremlin.run_handoff()` now forwards `boss_state["spec_path"]` as a new optional `--spec` flag on every `handoff.py` invocation.
- `handoff.py` reads the spec and renders an "Overarching goal (north star)" section above the rolling input plan, framed as read-only context that must not be echoed into the updated plan. The flag stays optional so the standalone `/handoff` use case keeps working without a separate spec.

## Test plan
- [ ] Run a `bossgremlin` chain with two or more handoffs and confirm the second-and-later handoff prompts include the original spec under the north-star section.
- [ ] Run `/handoff --plan <path>` (no `--spec`) and confirm the prompt renders without the north-star section.
- [ ] Confirm the rolling plan output does not duplicate the spec content.

Closes #66