### PR TITLE
ghaddress: file issues for out-of-scope review comments

### DIFF
--- a/skills/ghaddress/SKILL.md
+++ b/skills/ghaddress/SKILL.md
@@ -30,7 +30,7 @@ $ARGUMENTS[1:]
 ## Process
 
 1. Read all review comments above carefully.
-2. For each actionable comment:
+2. For each comment, decide whether it is in-scope to address in this PR or out-of-scope (OOS). For each in-scope comment:
    a. Understand what the reviewer is asking for.
    b. Read the relevant code to understand the current state.
    c. Make the fix or change requested.
@@ -38,11 +38,74 @@ $ARGUMENTS[1:]
    a. `git add` the changed files (by name, not `-A`).
    b. `git commit` with a message summarizing what was addressed.
    c. `git push` to the PR branch.
-4. Only after the push succeeds, reply to each comment thread:
-   - For review comments, use `gh api repos/{owner}/{repo}/pulls/<number>/comments/{comment_id}/replies -f body="<reply>"`.
-   - For questions or acknowledgements (no code change needed), reply briefly.
-   - Skip comments that have already been resolved.
-5. Summarize what was done.
+4. Only after the push succeeds, reply to each comment thread. Skip comments that have already been resolved.
+   - For in-scope comments you addressed: reply briefly acknowledging the fix.
+   - For questions or acknowledgements that need no code change: reply briefly.
+   - For OOS comments: run the OOS triage in the next section before replying.
+   - Post replies to review comments with `gh api repos/{owner}/{repo}/pulls/<number>/comments/{comment_id}/replies -f body="<reply>"`.
+5. Summarize what was done, including any issues filed for OOS comments and any `gh issue create` failures.
+
+## Out-of-scope triage (file issues for real defects)
+
+For each comment you marked OOS, decide whether it looks like a real defect or noise. The goal is that real defects survive the OOS decision as filed issues, while pure noise doesn't pollute the issue tracker.
+
+**File a new issue when the OOS comment flags any of:**
+
+- A bug or regression
+- A security or data-correctness concern
+- A performance pathology
+- A hidden invariant being violated
+- Anything else that, if true, would warrant a fix in some future PR
+
+**Don't file an issue when:**
+
+- The reviewer's claim is wrong — they misread the code, missed context, or are factually incorrect.
+- The comment is a subjective style nit, naming bikeshed, or "consider extracting…" preference with no defect claim.
+- The reviewer themselves marked the comment as non-blocking, nit, or fyi.
+- The comment is already addressed elsewhere (e.g., another comment in the same review covers the same point).
+
+**Tie-breaker:** If you're genuinely unsure whether the comment is a real defect or the reviewer is wrong, **file the issue**. Over-filing is cheap; losing a real bug is not. A human triaging the issue can close it as invalid.
+
+### Filing the issue
+
+Use `gh issue create` with:
+
+- **Title**: a short distillation of the comment (no special prefix). Aim for a sentence fragment that names the defect, not the comment ID.
+- **Body**: must stand on its own — a reader should not need to chase the PR to understand the issue. Include:
+  - A short summary of the defect in your own words.
+  - The reviewer's comment, quoted or summarized, so the original framing is preserved.
+  - `Ref #<pr-number>` so GitHub cross-links the PR.
+  - A permalink to the originating review comment (the comment's `html_url` from the API response).
+
+Example invocation (pass body via heredoc to preserve formatting):
+
+```
+gh issue create --title "<short distillation>" --body "$(cat <<'EOF'
+<summary>
+
+Reviewer comment:
+> <quoted or summarized comment>
+
+Ref #<pr-number>
+<permalink to review comment>
+EOF
+)"
+```
+
+Capture the issue number/URL from the command's output for the reply.
+
+### Replying on the PR thread
+
+- **Issue filed**: reply `Filed as #N` (or `Filed as <issue-url>`) so the reviewer and any later reader can find it.
+- **No issue (noise / reviewer wrong / already addressed)**: reply with a brief dismissal reason — enough that a human skimming the PR understands why no further action was taken.
+
+### When `gh issue create` fails
+
+Issue-creation failure is not a reason to stop addressing the rest of the PR. Do **not** write a bail marker.
+
+- Log the failure prominently in the run output (a clear `ERROR: failed to file issue for comment <id>: <error>` line, and include it in the final summary).
+- Fall back to a dismissal-style reply on the PR thread that names what the issue *would* have said (intended title and a one-line summary), so the comment is not silently dropped.
+- Continue with the remaining comments.
 
 ## Bail markers (only when running under a gremlin)
 

--- a/skills/ghaddress/SKILL.md
+++ b/skills/ghaddress/SKILL.md
@@ -119,7 +119,7 @@ Use the helper:
   ~/.claude/skills/_bg/set-bail.sh "$GR_ID" secrets "<one-line reason>"
   ```
 
-- For any other reason you decline to proceed (ambiguous reviewer ask, conflicting comments, scope outside this PR, etc.):
+- For any other reason you decline to proceed (ambiguous reviewer ask, conflicting comments, etc.):
 
   ```
   ~/.claude/skills/_bg/set-bail.sh "$GR_ID" other "<one-line reason>"

--- a/skills/ghaddress/SKILL.md
+++ b/skills/ghaddress/SKILL.md
@@ -34,11 +34,15 @@ $ARGUMENTS[1:]
    a. Understand what the reviewer is asking for.
    b. Read the relevant code to understand the current state.
    c. Make the fix or change requested.
-3. After making all code changes, stage, commit, and push:
+
+   OOS comments are deferred to step 4 and the *Out-of-scope triage* section below — do not act on them in this step.
+3. After making all in-scope code changes, stage, commit, and push:
    a. `git add` the changed files (by name, not `-A`).
    b. `git commit` with a message summarizing what was addressed.
    c. `git push` to the PR branch.
-4. Only after the push succeeds, reply to each comment thread. Skip comments that have already been resolved.
+
+   If there were no in-scope changes (every comment was OOS or already-resolved), skip 3a–3c and proceed directly to step 4 — `git commit` would fail with "nothing to commit" and gate out the OOS triage, which is the case where the new behavior matters most.
+4. Reply to each comment thread (after the push succeeds, if step 3 ran). Skip comments that have already been resolved.
    - For in-scope comments you addressed: reply briefly acknowledging the fix.
    - For questions or acknowledgements that need no code change: reply briefly.
    - For OOS comments: run the OOS triage in the next section before replying.
@@ -70,21 +74,22 @@ For each comment you marked OOS, decide whether it looks like a real defect or n
 
 Use `gh issue create` with:
 
+- **Repo**: always pass `--repo <owner>/<repo>` explicitly, derived from the same `gh pr view` data already fetched (e.g., `gh pr view <number> --json baseRepository`). This skill's frontmatter is `context: fork`, and a fork checkout configured with a downstream `origin` would otherwise silently file the issue in the wrong tracker — the failure mode is silent.
 - **Title**: a short distillation of the comment (no special prefix). Aim for a sentence fragment that names the defect, not the comment ID.
 - **Body**: must stand on its own — a reader should not need to chase the PR to understand the issue. Include:
   - A short summary of the defect in your own words.
-  - The reviewer's comment, quoted or summarized, so the original framing is preserved.
-  - `Ref #<pr-number>` so GitHub cross-links the PR.
+  - The reviewer's comment, quoted or summarized, so the original framing is preserved. **Before quoting, scan the comment text for secrets or sensitive data (credentials, API keys, tokens, internal URLs, customer data). If any are present, redact them in the issue body — replace with `[redacted]` — or if redaction isn't safe/clean, skip filing the issue and bail with `set-bail.sh "$GR_ID" secrets ...` instead. Issues are public and permanent; do not promote secrets from a review comment into a new issue.**
+  - A PR cross-link. Use `Ref #<pr-number>` when filing in the same repo as the PR (the common case). Use `Ref <owner>/<repo>#<pr-number>` if you ever file cross-repo, since plain `#<n>` only autolinks within the same repo.
   - A permalink to the originating review comment (the comment's `html_url` from the API response).
 
 Example invocation (pass body via heredoc to preserve formatting):
 
 ```
-gh issue create --title "<short distillation>" --body "$(cat <<'EOF'
+gh issue create --repo <owner>/<repo> --title "<short distillation>" --body "$(cat <<'EOF'
 <summary>
 
 Reviewer comment:
-> <quoted or summarized comment>
+> <quoted or summarized comment, with any secrets redacted>
 
 Ref #<pr-number>
 <permalink to review comment>
@@ -104,7 +109,7 @@ Capture the issue number/URL from the command's output for the reply.
 Issue-creation failure is not a reason to stop addressing the rest of the PR. Do **not** write a bail marker.
 
 - Log the failure prominently in the run output (a clear `ERROR: failed to file issue for comment <id>: <error>` line, and include it in the final summary).
-- Fall back to a dismissal-style reply on the PR thread that names what the issue *would* have said (intended title and a one-line summary), so the comment is not silently dropped.
+- Fall back to a reply on the PR thread that **clearly marks itself as a failed filing attempt** so a future human triager can tell it apart from an intentional noise dismissal. Open with `Tried to file as "<intended title>" but \`gh issue create\` failed: <error>. Please file manually if this is a real defect.` followed by the one-line summary that would have been the issue body's lead. Do not phrase it as a generic dismissal — the PR thread is the durable surface a human reviewer will see, and indistinguishable phrasing erases the audit trail.
 - Continue with the remaining comments.
 
 ## Bail markers (only when running under a gremlin)
@@ -124,5 +129,7 @@ Use the helper:
   ```
   ~/.claude/skills/_bg/set-bail.sh "$GR_ID" other "<one-line reason>"
   ```
+
+Note: out-of-scope comments are **not** a bail reason — they go through the *Out-of-scope triage* section above (file an issue or post a dismissal/failure-marker reply). A `gh issue create` failure is also not a bail reason; fall back per that section.
 
 In both cases, also state in your final summary that you bailed and why. If you successfully addressed every actionable comment, do not write a bail marker — just exit normally.


### PR DESCRIPTION
## Summary
- Splits the `/ghaddress` per-comment loop so OOS comments go through a second decision: real defect vs noise.
- Real defects (or ambiguous cases, by tie-breaker) get `gh issue create` first, then the PR thread reply becomes `Filed as #N`. Pure noise gets a brief dismissal reply, no issue.
- Issue-creation failures log prominently and fall back to a dismissal reply that names the intended issue title -- they do not bail the address stage. Behavior change is in `skills/ghaddress/SKILL.md` only; `/ghgremlin` invokes `/ghaddress` directly so no wrapper change is needed.

## Test plan
- [ ] Run `/ghaddress` on a PR with a mix of comments that should be (a) addressed, (b) filed as issues, (c) dismissed as noise; confirm one issue per OOS-defect comment with a self-contained body, `Ref #<pr>`, and a permalink, and confirm the matching `Filed as #N` reply lands on the originating thread.
- [ ] Run `/ghaddress` on a PR with only style/nit OOS comments; confirm no issues are filed and the dismissal replies state a brief reason.
- [ ] Simulate a `gh issue create` failure (e.g., revoke issue scope on the token); confirm the address stage finishes, the failure is logged loudly, and the comment thread gets a dismissal reply naming the intended issue title rather than being silently dropped.
- [ ] Run an end-to-end `/ghgremlin` whose review surfaces at least one OOS-defect comment; confirm the gremlin completes its address stage and the issue + reply pair land on the PR.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)