### PR TITLE
Decouple /design from /localgremlin and /ghgremlin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,6 @@ The `localgremlin` skill runs plan → implement → three parallel reviewers (h
 
 The review-code and address-code stage bodies live in [`skills/localgremlin/_core.py`](skills/localgremlin/_core.py) alongside the orchestrator, so the standalone `/localreview` and `/localaddress` skills execute the same code as the gremlin's review and address stages.
 
-Both `/ghgremlin` and `/localgremlin` accept `--design` as a first flag to invoke `/design` before the gremlin, running an interactive spec conversation and handing off automatically when the user is ready.
-
 ## Additional skills
 
 - [`/gremlins`](skills/gremlins/SKILL.md) — on-demand status of all background gremlins on this machine. Key subcommands: `stop <id>` (SIGTERM), `rescue <id>` (Phase A: inline `claude -p` diagnoses and fixes the failure in the foreground; Phase B: `launch.sh --resume` relaunches the pipeline at the failed stage in the background under the original gremlin id, with a `(rescue)` liveness marker), `rm <id>` (delete state directory, worktree directory, and branch), `close <id>` (mark finished gremlin closed), `land <id>` (squash-land a local gremlin or merge a gh PR and clean up). Use `--here` to filter to the current repo.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ home/CLAUDE.md        # global preferences, synced to ~/.claude/CLAUDE.md
 settings.json         # harness settings: hooks, permissions, plugins
 skills/
   _bg/                # background-gremlin scripts: finish.sh, launch.sh, liveness.sh, session-summary.sh, set-stage.sh
-  design/             # /design: chat-driven spec writer; hands off to /ghgremlin or /localgremlin
+  design/             # /design: chat-driven spec writer; produces /tmp/design-<slug>.md
   ghplan/             # /ghplan: draft a plan, post it as a GitHub issue
   ghgremlin/          # /ghgremlin: run the full gremlin in the background via skills/_bg/launch.sh
   ghreview/           # /ghreview: review a PR and post inline comments
@@ -47,14 +47,14 @@ Before any non-dry-run `push`, the script snapshots `~/.claude/` into `/tmp/clau
 
 ## Skills
 
-The skills cluster into a GitHub-issue-driven gremlin and a local gremlin (`/localgremlin`), with `/design` as an optional first step for either and `/ghreview` / `/ghaddress` usable on their own:
+The skills cluster into a GitHub-issue-driven gremlin and a local gremlin (`/localgremlin`), with `/design` as an optional standalone spec writer and `/ghreview` / `/ghaddress` usable on their own:
 
-- [`/design`](skills/design/SKILL.md) — runs a WHAT-focused spec conversation; writes the spec to `/tmp/design-<slug>.md` by default; can hand off to `/ghgremlin` or `/localgremlin`. Pass `--target localgremlin` (or `ghgremlin`) to pre-select the handoff target — this is what the `--design` flag on `/localgremlin` and `/ghgremlin` sets automatically.
+- [`/design`](skills/design/SKILL.md) — runs a WHAT-focused spec conversation; writes the spec to `/tmp/design-<slug>.md` and stops. The user can then pass that path to `/ghgremlin` or `/localgremlin` themselves.
 - [`/ghplan`](skills/ghplan/SKILL.md) — draft a plan and post it as a new GitHub issue.
 - [`/ghgremlin`](skills/ghgremlin/SKILL.md) — run the full gremlin run end-to-end via [`skills/ghgremlin/ghgremlin.sh`](skills/ghgremlin/ghgremlin.sh).
 - [`/ghreview`](skills/ghreview/SKILL.md) — review a PR and post inline comments.
 - [`/ghaddress`](skills/ghaddress/SKILL.md) — address review comments on a PR and reply to each thread.
-- [`/localgremlin`](skills/localgremlin/SKILL.md) — local (no-GitHub) counterpart to `/ghgremlin`: runs plan → implement → three parallel reviewers (holistic, detail, scope) → address-code locally via [`skills/localgremlin/localgremlin.py`](skills/localgremlin/localgremlin.py), with all artifacts written to `~/.local/state/claude-gremlins/<id>/artifacts/` (off the product branch). Accepts `--design` to invoke `/design` first. Review-code and address-code stage bodies live in [`skills/localgremlin/_core.py`](skills/localgremlin/_core.py) and are shared with the standalone skills below.
+- [`/localgremlin`](skills/localgremlin/SKILL.md) — local (no-GitHub) counterpart to `/ghgremlin`: runs plan → implement → three parallel reviewers (holistic, detail, scope) → address-code locally via [`skills/localgremlin/localgremlin.py`](skills/localgremlin/localgremlin.py), with all artifacts written to `~/.local/state/claude-gremlins/<id>/artifacts/` (off the product branch). Review-code and address-code stage bodies live in [`skills/localgremlin/_core.py`](skills/localgremlin/_core.py) and are shared with the standalone skills below.
 - [`/localreview`](skills/localreview/SKILL.md) — standalone triple-lens code review (holistic, detail, scope) over local changes, foreground. Writes `review-code-*.md` files to `--dir` (defaults to cwd).
 - [`/localaddress`](skills/localaddress/SKILL.md) — standalone address-code stage that reads `review-code-*.md` files from `--dir` and applies actionable findings. Foreground. In a git repo, creates one `Address review feedback` commit (no push).
 - [`/gremlins`](skills/gremlins/SKILL.md) — on-demand status of background gremlins. Subcommands: `stop <id>`, `rescue <id>`, `rm <id>`, `close <id>`, `land <id>` (squash-land a local gremlin or merge a gh PR). Flags include `--here`, `--running`, `--dead`, `--stalled`, `--kind`, `--since`, `--recent`, `--watch`.
@@ -65,7 +65,7 @@ The skills cluster into a GitHub-issue-driven gremlin and a local gremlin (`/loc
 
 ### Background execution
 
-Both `/ghgremlin` and `/localgremlin` run **in the background**. Both accept `--design` as a first flag to invoke `/design` before the gremlin. Their SKILL.md wrappers hand off to [`skills/_bg/launch.sh`](skills/_bg/launch.sh), which:
+Both `/ghgremlin` and `/localgremlin` run **in the background**. Their SKILL.md wrappers hand off to [`skills/_bg/launch.sh`](skills/_bg/launch.sh), which:
 
 - Creates an isolated worktree (via `git worktree add --detach` for git projects, `cp -a` otherwise) so concurrent invocations don't collide.
 - Discovers the gremlin script by trying `<kind>.py` before `<kind>.sh` — so [`localgremlin.py`](skills/localgremlin/localgremlin.py) takes precedence over any `.sh` fallback.
@@ -73,7 +73,7 @@ Both `/ghgremlin` and `/localgremlin` run **in the background**. Both accept `--
 - Records per-gremlin state under `~/.local/state/claude-gremlins/<id>/` — or `$XDG_STATE_HOME/claude-gremlins/<id>/` if `XDG_STATE_HOME` is set — (`state.json`, combined `log`, `finished` / `closed` markers), deliberately rooted outside `~/.claude/` so Claude Code's sensitive-file guardrail doesn't block subagent writes. [`skills/_bg/finish.sh`](skills/_bg/finish.sh) writes the terminal `status` / `exit_code` and drops the `finished` marker that `session-summary.sh` keys off.
 - Returns within ~1s with the gremlin id, workdir, log path, and state-file path.
 
-`/localgremlin` artifacts under `~/.local/state/claude-gremlins/<id>/artifacts/`: `plan.md`, `review-code-holistic-<model>.md`, `review-code-detail-<model>.md`, `review-code-scope-<model>.md`. If launched with `--design`, a `spec.md` is also written there.
+`/localgremlin` artifacts under `~/.local/state/claude-gremlins/<id>/artifacts/`: `plan.md`, `review-code-holistic-<model>.md`, `review-code-detail-<model>.md`, `review-code-scope-<model>.md`. If a spec file is passed as the first positional argument, it is also copied there as `spec.md`.
 
 A pair of hooks (`SessionStart` + `UserPromptSubmit`, wired in [`settings.json`](settings.json)) invokes [`skills/_bg/session-summary.sh`](skills/_bg/session-summary.sh), which reports running and newly-finished gremlins for the current project so you're notified the next time you open Claude Code in that tree. Closed state dirs older than 14 days are pruned on the next hook firing.
 

--- a/scripts/e2e-bossgremlin.sh
+++ b/scripts/e2e-bossgremlin.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# E2E test for /bossgremlin --chain-kind local.
+# Creates a sandbox branch, launches the boss with a real spec, polls until
+# done or stalled, asserts structural pass conditions, and emits a JSON summary
+# as the final stdout line.
+set -euo pipefail
+
+# ── Setup ──────────────────────────────────────────────────────────────────────
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "[e2e] FAIL: not in a git repo" >&2; exit 1
+}
+
+SPEC="$REPO_ROOT/scripts/e2e/bossgremlin-spec.md"
+LAUNCH_SH="$HOME/.claude/skills/_bg/launch.sh"
+
+[[ -f "$SPEC" && -s "$SPEC" ]] || {
+    echo "[e2e] FAIL: spec not found or empty: $SPEC" >&2; exit 1
+}
+[[ -x "$LAUNCH_SH" ]] || {
+    echo "[e2e] FAIL: launch.sh not executable: $LAUNCH_SH" >&2; exit 1
+}
+
+ORIG_BRANCH=$(git -C "$REPO_ROOT" symbolic-ref --short HEAD 2>/dev/null || echo "")
+MAX_WAIT=${E2E_TIMEOUT:-7200}
+
+SANDBOX_BRANCH="bossgremlin-e2e/$(date +%Y%m%d-%H%M%S)"
+git -C "$REPO_ROOT" checkout -b "$SANDBOX_BRANCH" main
+echo "[e2e] sandbox branch: $SANDBOX_BRANCH"
+
+cleanup() {
+    [[ -n "${BOSS_ID:-}" && -n "${STATE_DIR:-}" ]] && {
+        local _pid=""
+        _pid=$(python3 -c "
+import json
+try:
+    print(json.load(open('${STATE_DIR}/state.json')).get('pid') or '')
+except Exception:
+    print('')
+" 2>/dev/null) || true
+        [[ -n "$_pid" ]] && kill "$_pid" 2>/dev/null || true
+    }
+    [[ -n "$ORIG_BRANCH" ]] && git -C "$REPO_ROOT" checkout "$ORIG_BRANCH" 2>/dev/null || true
+    [[ "${PASS_FAIL:-fail}" != "pass" ]] && git -C "$REPO_ROOT" branch -D "$SANDBOX_BRANCH" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+START_TS=$(date +%s)
+
+# ── Launch ──────────────────────────────────────────────────────────────────────
+
+BOSS_ID=$(
+    "$LAUNCH_SH" \
+        --print-id \
+        --description "e2e: stages docs across gremlin SKILL.md files" \
+        bossgremlin \
+        --chain-kind local \
+        --plan "$SPEC"
+)
+[[ -n "$BOSS_ID" ]] || {
+    echo "[e2e] FAIL: launcher printed no ID" >&2; exit 1
+}
+
+STATE_DIR="$HOME/.local/state/claude-gremlins/$BOSS_ID"
+echo "[e2e] boss launched: $BOSS_ID"
+
+# ── Poll ────────────────────────────────────────────────────────────────────────
+
+BOSS_EXIT_CODE=""
+STALL_COUNT=0
+
+while true; do
+    sleep 30
+    ELAPSED=$(( $(date +%s) - START_TS ))
+
+    if [[ $ELAPSED -ge $MAX_WAIT ]]; then
+        echo "[e2e] +${ELAPSED}s poll timeout after ${MAX_WAIT}s — boss still running"
+        BOSS_EXIT_CODE="timeout"
+        break
+    fi
+
+    # Read exit_code, status, pid, stage in a single call; 'error' on failure
+    STATE_LINE=$(python3 -c "
+import json
+try:
+    with open('$STATE_DIR/state.json') as f:
+        s = json.load(f)
+    ec = s.get('exit_code')
+    print('null' if ec is None else str(ec),
+          s.get('status', ''),
+          str(s.get('pid') or ''),
+          s.get('stage', ''), sep='\t')
+except Exception:
+    print('error', '', '', '', sep='\t')
+" 2>/dev/null) || STATE_LINE="error"
+
+    IFS=$'\t' read -r EC BSTATUS PID BSTAGE <<< "$STATE_LINE"
+
+    if [[ "${EC:-error}" == "error" ]]; then
+        echo "[e2e] +${ELAPSED}s state.json unreadable, retrying..."
+        continue
+    fi
+
+    if [[ "$EC" != "null" ]]; then
+        BOSS_EXIT_CODE="$EC"
+        echo "[e2e] +${ELAPSED}s boss stage=${BSTAGE:-?} exit_code=$EC"
+        break
+    fi
+
+    # Stall: process dead for two consecutive poll cycles
+    if [[ "$BSTATUS" == "running" && -n "$PID" ]] && ! kill -0 "$PID" 2>/dev/null; then
+        STALL_COUNT=$(( STALL_COUNT + 1 ))
+        echo "[e2e] +${ELAPSED}s boss stage=${BSTAGE:-?} (stall detected, cycle $STALL_COUNT/2)"
+        if [[ "$STALL_COUNT" -ge 2 ]]; then
+            echo "[e2e] boss stalled — proceeding to assertions"
+            break
+        fi
+    else
+        STALL_COUNT=0
+        echo "[e2e] +${ELAPSED}s boss stage=${BSTAGE:-?} (still running)"
+    fi
+done
+
+# ── Assertions ──────────────────────────────────────────────────────────────────
+
+FAILURES=()
+CHAIN_EXIT_STATE=""
+CHILD_COUNT=0
+BAD_CHILDREN=""
+
+# Parse boss_state.json for: last handoff exit_state, child count, bad outcomes
+if [[ -f "$STATE_DIR/boss_state.json" ]]; then
+    BS_LINE=$(python3 -c "
+import json
+try:
+    with open('$STATE_DIR/boss_state.json') as f:
+        bs = json.load(f)
+    recs = bs.get('handoff_records', [])
+    exit_state = recs[-1]['exit_state'] if recs else ''
+    children = bs.get('children', [])
+    bad = ','.join(
+        c['id'] + ':' + c.get('outcome', '')
+        for c in children
+        if c.get('outcome') not in ('landed', 'rescued-then-landed')
+    )
+    print(exit_state, len(children), bad if bad else 'NONE')
+except Exception as e:
+    print('parse_error', 0, str(e).replace(' ', '_'))
+" 2>/dev/null) || BS_LINE="parse_error 0 unknown"
+    IFS=' ' read -r CHAIN_EXIT_STATE CHILD_COUNT BAD_CHILDREN_OR_NONE <<< "$BS_LINE"
+    if [[ "$CHAIN_EXIT_STATE" == "parse_error" ]]; then
+        FAILURES+=("boss_state.json parse failed: $BAD_CHILDREN_OR_NONE")
+        CHAIN_EXIT_STATE=""
+        CHILD_COUNT=0
+        BAD_CHILDREN_OR_NONE="NONE"
+    fi
+    [[ "$BAD_CHILDREN_OR_NONE" == "NONE" ]] && BAD_CHILDREN="" || BAD_CHILDREN="$BAD_CHILDREN_OR_NONE"
+else
+    FAILURES+=("boss_state.json not found")
+    CHAIN_EXIT_STATE="missing"
+fi
+
+# A: boss exit code is 0
+if [[ "$BOSS_EXIT_CODE" != "0" ]]; then
+    FAILURES+=("boss exited ${BOSS_EXIT_CODE:-stalled (no exit code)}")
+fi
+
+# B: chain ended with chain-done
+if [[ "$CHAIN_EXIT_STATE" != "chain-done" ]]; then
+    FAILURES+=("last handoff exited '$CHAIN_EXIT_STATE' (expected chain-done)")
+fi
+
+# C: at least 2 children ran
+if [[ "$CHILD_COUNT" -lt 2 ]]; then
+    FAILURES+=("only $CHILD_COUNT children ran (expected >= 2)")
+fi
+
+# D: all children have a passing outcome
+if [[ -n "$BAD_CHILDREN" ]]; then
+    FAILURES+=("children with bad outcomes: $BAD_CHILDREN")
+fi
+
+# E: clean working tree on sandbox branch
+DIRTY=$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null) || DIRTY=""
+if [[ -n "$DIRTY" ]]; then
+    FAILURES+=("dirty working tree on sandbox branch")
+fi
+
+# F: no orphaned running/stalled children from this run
+ORPHAN_IDS=$(python3 -c "
+import json, os, glob
+orphans = []
+for path in glob.glob(os.path.expanduser('~/.local/state/claude-gremlins/*/state.json')):
+    try:
+        with open(path) as f:
+            s = json.load(f)
+        if s.get('parent_id') == '$BOSS_ID' and s.get('exit_code') is None:
+            orphans.append(s.get('id', os.path.basename(os.path.dirname(path))))
+    except Exception:
+        pass
+print(','.join(orphans))
+" 2>/dev/null) || ORPHAN_IDS=""
+if [[ -n "$ORPHAN_IDS" ]]; then
+    FAILURES+=("orphaned running/stalled children: $ORPHAN_IDS")
+fi
+
+# ── Output ──────────────────────────────────────────────────────────────────────
+
+ELAPSED=$(( $(date +%s) - START_TS ))
+
+if [[ ${#FAILURES[@]} -gt 0 ]]; then
+    for f in "${FAILURES[@]}"; do
+        echo "[e2e] FAIL: $f"
+    done
+    echo "[e2e] FAIL"
+    PASS_FAIL="fail"
+else
+    echo "[e2e] PASS"
+    PASS_FAIL="pass"
+fi
+
+# Serialize failure reasons array for JSON
+FAILURE_REASONS_JSON=$(python3 -c "
+import json, sys
+print(json.dumps(sys.argv[1:]))
+" "${FAILURES[@]+"${FAILURES[@]}"}")
+
+# Emit final-line JSON summary (must be last stdout line)
+export BOSS_ID STATE_DIR SANDBOX_BRANCH PASS_FAIL CHAIN_EXIT_STATE ELAPSED FAILURE_REASONS_JSON
+python3 -c "
+import json, os
+
+state_dir = os.environ['STATE_DIR']
+try:
+    with open(os.path.join(state_dir, 'boss_state.json')) as f:
+        bs = json.load(f)
+    children = bs.get('children', [])
+    child_ids = [c['id'] for c in children]
+    child_outcomes = {c['id']: c.get('outcome', '') for c in children}
+    recs = bs.get('handoff_records', [])
+    chain_exit = recs[-1]['exit_state'] if recs else ''
+except Exception:
+    child_ids = []
+    child_outcomes = {}
+    chain_exit = os.environ.get('CHAIN_EXIT_STATE', '')
+
+print(json.dumps({
+    'outcome': os.environ['PASS_FAIL'],
+    'boss_id': os.environ['BOSS_ID'],
+    'sandbox_branch': os.environ['SANDBOX_BRANCH'],
+    'boss_log': os.path.join(state_dir, 'log'),
+    'child_ids': child_ids,
+    'child_outcomes': child_outcomes,
+    'chain_exit_state': chain_exit,
+    'failure_reasons': json.loads(os.environ['FAILURE_REASONS_JSON']),
+    'elapsed_seconds': int(os.environ['ELAPSED']),
+}, separators=(',', ':')))
+" || echo "{\"outcome\":\"$PASS_FAIL\",\"boss_id\":\"$BOSS_ID\",\"sandbox_branch\":\"$SANDBOX_BRANCH\",\"error\":\"json_construction_failed\",\"elapsed_seconds\":$ELAPSED}"
+
+[[ "$PASS_FAIL" == "pass" ]]

--- a/scripts/e2e/bossgremlin-spec.md
+++ b/scripts/e2e/bossgremlin-spec.md
@@ -1,0 +1,78 @@
+# Stages documentation for gremlin SKILL.md files
+
+## Context
+
+The three gremlin skills — `/localgremlin`, `/ghgremlin`, and `/bossgremlin` — each run a
+multi-stage pipeline that is described only at a high level in their SKILL.md files. The
+current documentation covers where artifacts land and what arguments to pass, but does not
+enumerate the discrete pipeline stages or describe what each stage produces. This gap makes
+it hard to interpret the `/gremlins` stage-column output, understand which artifacts to
+inspect after a partial run, or reason about what happened when a stage fails mid-chain.
+
+## Goal
+
+Add a `## Stages` subsection to each of the three gremlin SKILL.md files that enumerates
+the stages each gremlin runs and describes what each stage produces. The subsections should
+be accurate, concise, and consistent in style across all three files.
+
+## Tasks
+
+**Implement one SKILL.md file per child gremlin. Do not bundle all three into a single child.**
+
+### Task 1 — `skills/localgremlin/SKILL.md`
+
+Add a `## Stages` section describing the four pipeline stages and their outputs:
+
+1. **plan** — runs the planning agent against the instructions or supplied `--plan` file;
+   produces `artifacts/plan.md`.
+2. **implement** — implements the plan; produces commits on the `bg/localgremlin/<id>` branch.
+3. **review-code** — runs three parallel reviewers (holistic, detail, scope) using two
+   different models; produces `artifacts/review-code-holistic-<model>.md`,
+   `artifacts/review-code-detail-<model>.md`, and `artifacts/review-code-scope-<model>.md`.
+4. **address-code** — addresses actionable review findings; produces an
+   "Address review feedback" commit (absent if reviewers found nothing actionable).
+
+Position the section after `## Where artifacts go` and before `## Arguments`.
+
+### Task 2 — `skills/ghgremlin/SKILL.md`
+
+Add a `## Stages` section describing the four pipeline stages:
+
+1. **plan** — invokes `/ghplan`; produces a GitHub issue containing the implementation plan.
+2. **implement** — implements the plan; produces commits and opens a GitHub PR.
+3. **review** — invokes `/ghreview` with a scope reviewer running in parallel; collects
+   Copilot and Claude review comments on the PR.
+4. **address** — invokes `/ghaddress`; produces new commits on the PR that address reviewer
+   findings.
+
+Position the section after `## Where artifacts go` and before `## Arguments`.
+
+### Task 3 — `skills/bossgremlin/SKILL.md`
+
+Add a `## Stages` section describing the boss's repeating handoff loop. The boss does not
+run a linear stage sequence — it loops through handoff → child pipeline → land until the
+handoff agent signals completion.
+
+Each loop iteration:
+
+1. **handoff** — invokes the `/handoff` agent with the overarching spec and the diff
+   accumulated so far; produces `handoff-NNN.md` (updated rolling plan for the remaining
+   work), `handoff-NNN-child.md` (plan handed to the next child), and
+   `handoff-NNN.state.json` (exit state: `next-plan`, `chain-done`, or `bail`). Exits the
+   loop when the exit state is `chain-done` or `bail`.
+2. **waiting** — launches the child gremlin with the child plan and polls its `state.json`
+   until the child's full pipeline exits. If the child fails, rescues it once before
+   retrying.
+3. **landing** — squash-merges the child's branch into the boss's target branch.
+
+On `chain-done`, the target branch contains the squash-merged output of every child gremlin
+in order.
+
+Position the section after the workflow overview bullet list (items 1–4) and before
+`## Arguments`.
+
+## Non-goals
+
+- Do not change any other content in the SKILL.md files.
+- Do not add stages documentation to any files other than the three listed above.
+- Do not restructure or reformat sections that are not being modified.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -1,21 +1,14 @@
 ---
 name: design
-description: Chat with the user about a feature or goal and produce a spec describing WHAT to build, not HOW. Writes the spec to /tmp by default; can hand off to /ghgremlin or /localgremlin at the end of the conversation.
-argument-hint: [--target <localgremlin|ghgremlin>] [-a <model>] [-b <model>] [<optional seed topic>]
+description: Chat with the user about a feature or goal and produce a spec describing WHAT to build, not HOW. Writes the spec to /tmp/design-<slug>.md and stops.
+argument-hint: [<optional seed topic>]
 ---
 
 You are having a design conversation with the user. Goal: produce a spec describing **WHAT** feature or behavior they want — **not HOW** to build it.
 
-## Arguments
-
-Parse `$ARGUMENTS` before treating anything as the seed topic:
-
-- `--target <localgremlin|ghgremlin>` — if present, record the target and treat the remainder as the seed topic. The target was chosen by the caller (`/localgremlin --design` or `/ghgremlin --design`), so no need to ask the user which target to use at handoff.
-- `-a <model>` / `-b <model>` — pipeline flags opaque to this skill. If present, record them as **pipeline flags** to be forwarded at handoff. Do not apply them to the design conversation itself.
-
 ## Ground rules
 
-- **This skill produces a spec, not a plan.** It does not enumerate tasks, files, steps, or modules — whether invoked directly or via `--design` from another skill.
+- **This skill produces a spec, not a plan.** It does not enumerate tasks, files, steps, or modules.
 - **No implementation details.** No file paths, API shapes, code snippets, class names, framework choices, data structures, algorithm picks. If the user volunteers any, capture the *intent* behind it as behavior or constraint and steer back to outcomes.
 - **Focus on:** the problem, who has it, what the feature does from outside, constraints, acceptance criteria, non-goals.
 - **Probe actively for ambiguity.** "Sync the data" → "between what and what? on what trigger? with what consistency guarantee?" Don't let vague language pass.
@@ -24,7 +17,7 @@ Parse `$ARGUMENTS` before treating anything as the seed topic:
 
 ## Flow
 
-1. If `$ARGUMENTS` is non-empty (after stripping `--target` and any `-a`/`-b` flags), treat the remainder as the seed topic and ask the user to elaborate.
+1. If `$ARGUMENTS` is non-empty, treat it as the seed topic and ask the user to elaborate.
 2. Otherwise, open with "What do you want to design?"
 3. Ask questions until the picture is clear enough to hand off to an implementer. Cover, in any order: problem / users / behavior (incl. important edge cases) / constraints / acceptance criteria / non-goals.
 4. Don't exhaust the user. A short, clear spec beats a long, complete one. Stop asking when further questions would be hypothetical.
@@ -45,20 +38,9 @@ Markdown. Sections in this order; omit any that have nothing useful to say:
 
 Loose and readable, not a form. Short enough to absorb in one sitting.
 
-## Hand-off
+## Finishing up
 
-When the user signals they're ready to build — "looks good", "let's implement it", "ghgremlin it", "localgremlin", "hand off", or similar:
-
-- **If `--target` was parsed from `$ARGUMENTS`**, invoke that target directly without asking the user. Pass any recorded pipeline flags (`-a`/`-b`) followed by the spec path:
-  - `Skill(skill="localgremlin", args="<pipeline-flags> /tmp/design-<slug>.md")`
-  - `Skill(skill="ghgremlin", args="<pipeline-flags> /tmp/design-<slug>.md")`
-  - Omit `<pipeline-flags>` if none were recorded.
-
-- **If no `--target` was set**, offer the two targets and invoke whichever the user picks:
-  - **`/ghgremlin`** — files a GitHub issue + PR, runs Copilot + Claude reviews. Good for shareable, reviewable work.
-  - **`/localgremlin`** — runs the full plan → review → implement → review → address pipeline locally, no GitHub. Good for exploratory work in the current repo.
-
-If the user ends the conversation without handing off, just confirm the spec path and stop. The file is the artifact.
+When the conversation reaches a natural stopping point — the user signals they're done ("looks good", "that's enough", etc.) or further questions would be hypothetical — confirm the spec path (`/tmp/design-<slug>.md`) and stop. The file is the artifact; the user takes it from there.
 
 ## What this skill is NOT
 

--- a/skills/ghgremlin/SKILL.md
+++ b/skills/ghgremlin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ghgremlin
 description: Run the end-to-end plan → implement → review → address workflow in the background by invoking ~/.claude/skills/_bg/launch.sh. Creates a GitHub issue, opens a PR implementing it, collects Copilot + Claude reviews, and addresses them. The launcher returns immediately; you'll be notified when the gremlin finishes.
-argument-hint: [--design] [-r <ref>] [--plan <path|issue-ref> | <instructions>]
+argument-hint: [-r <ref>] [--plan <path|issue-ref> | <instructions>]
 allowed-tools: Bash(~/.claude/skills/_bg/launch.sh:*)
 ---
 
@@ -18,7 +18,7 @@ A `SessionStart` / `UserPromptSubmit` hook notifies a future Claude session for 
 
 Gremlin artifacts live outside the product branch. Point the user at:
 
-- `~/.local/state/claude-gremlins/<gremlin-id>/artifacts/spec.md` — the finalized design spec (only if launched with `--design`).
+- `~/.local/state/claude-gremlins/<gremlin-id>/artifacts/spec.md` — the spec file, if one was passed as the first positional argument.
 - `~/.local/state/claude-gremlins/<gremlin-id>/log` — combined stdout/stderr of the gremlin.
 - `~/.local/state/claude-gremlins/<gremlin-id>/state.json` — gremlin status, exit code, workdir path.
 
@@ -29,16 +29,6 @@ $ARGUMENTS
 Forward them verbatim to the launcher. Quote the instructions string so shell word-splitting doesn't break it.
 
 ## What to do
-
-If `$ARGUMENTS` begins with `--design` (it must be the first token), strip that flag and invoke the design skill instead of the launcher:
-
-```
-Skill(skill="design", args="--target ghgremlin <remaining-args>")
-```
-
-Do not proceed to the launcher invocation. The design skill will run an interactive design conversation and, when the user is ready, will invoke the launcher automatically.
-
----
 
 Before invoking the launcher, compose a short (≤60 characters) human-readable phrase that summarizes the task — this becomes the gremlin's `description` in status views (`/gremlins`, session-summary hook). Examples:
 

--- a/skills/localgremlin/SKILL.md
+++ b/skills/localgremlin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: localgremlin
 description: Run the end-to-end plan → implement → review-code → address-code workflow in the background by invoking ~/.claude/skills/_bg/launch.sh. Plan and code reviews land in `~/.local/state/claude-gremlins/<gremlin-id>/artifacts/` alongside the run log (kept off the product branch); the code review uses two different models in parallel. The launcher returns immediately; you'll be notified when the gremlin finishes.
-argument-hint: [--design] [-a <model>] [-b <model>] [-c <model>] [--plan <path> | <instructions>]
+argument-hint: [-a <model>] [-b <model>] [-c <model>] [--plan <path> | <instructions>]
 allowed-tools: Bash(~/.claude/skills/_bg/launch.sh:*)
 ---
 
@@ -18,7 +18,7 @@ A `SessionStart` / `UserPromptSubmit` hook notifies a future Claude session for 
 
 Plan and code-review artifacts live outside the product branch — they are scaffolding, not product. Point the user at:
 
-- `~/.local/state/claude-gremlins/<gremlin-id>/artifacts/spec.md` — the finalized design spec (only if launched with `--design`).
+- `~/.local/state/claude-gremlins/<gremlin-id>/artifacts/spec.md` — the spec file, if one was passed as the first positional argument.
 - `~/.local/state/claude-gremlins/<gremlin-id>/artifacts/plan.md` — the implementation plan.
 - `~/.local/state/claude-gremlins/<gremlin-id>/artifacts/review-code-holistic-<model>.md`, `review-code-detail-<model>.md`, and `review-code-scope-<model>.md` — the three parallel code reviews.
 - `~/.local/state/claude-gremlins/<gremlin-id>/log` — combined stdout/stderr of the gremlin.
@@ -36,16 +36,6 @@ $ARGUMENTS
 Forward them verbatim to the launcher. Quote the instructions string so shell word-splitting doesn't break it.
 
 ## What to do
-
-If `$ARGUMENTS` begins with `--design` (it must be the first token), strip that flag and invoke the design skill instead of the launcher:
-
-```
-Skill(skill="design", args="--target localgremlin <remaining-args>")
-```
-
-Do not proceed to the launcher invocation. The design skill will run an interactive design conversation and, when the user is ready, will invoke the launcher automatically.
-
----
 
 Before invoking the launcher, compose a short (≤60 characters) human-readable phrase that summarizes the task — this becomes the gremlin's `description` in status views (`/gremlins`, session-summary hook). Examples:
 


### PR DESCRIPTION
## Summary
- Remove `--design` entry-flag from `/localgremlin` and `/ghgremlin` (no more foreground conversational prelude on background-only skills)
- Remove `--target` flag and auto-handoff from `/design`; the skill now writes the spec to `/tmp/design-<slug>.md` and stops
- Update `CLAUDE.md` and `README.md` to drop references to `--design` as a gremlin flag and `--target` as a `/design` flag
- Reword the gremlin SKILL.md `spec.md` artifact bullet to match what `launch.sh` actually does (copies the first positional arg if it's a readable file)

This unblocks direct CLI invocation of the gremlins, which can't host a `/design` conversation.

## Test plan
- [ ] `/localgremlin <plan-path>` still works exactly as before
- [ ] `/ghgremlin <plan-path>` still works exactly as before
- [ ] `/design` produces a spec at `/tmp/design-<slug>.md` and stops without invoking another skill
- [ ] `grep -R -- --design` over the repo returns no hits in gremlin skills/launcher
- [ ] `grep -R -- --target` over `skills/design/` returns no hits

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)