### PR TITLE
Thread cwd into gh subprocess calls in _land_gh

### DIFF
--- a/skills/gremlins/gremlins.py
+++ b/skills/gremlins/gremlins.py
@@ -1366,7 +1366,7 @@ def _land_gh(gr_id: str, sf: str, wdir: str, state: dict, force: bool = False) -
     r = subprocess.run(
         ["gh", "pr", "view", pr_url, "--json",
          "state,mergeable,reviewDecision,statusCheckRollup"],
-        capture_output=True, text=True,
+        capture_output=True, text=True, cwd=cwd,
     )
     if r.returncode != 0:
         print(f"error: could not fetch PR info: {r.stderr.strip()}")
@@ -1417,7 +1417,7 @@ def _land_gh(gr_id: str, sf: str, wdir: str, state: dict, force: bool = False) -
         time.sleep(5)
         r = subprocess.run(
             ["gh", "pr", "view", pr_url, "--json", "mergeable"],
-            capture_output=True, text=True,
+            capture_output=True, text=True, cwd=cwd,
         )
         if r.returncode == 0:
             try:
@@ -1433,7 +1433,7 @@ def _land_gh(gr_id: str, sf: str, wdir: str, state: dict, force: bool = False) -
     print(f"Merging: {pr_url}")
     r = subprocess.run(
         ["gh", "pr", "merge", pr_url, "--squash", "--delete-branch"],
-        capture_output=True, text=True,
+        capture_output=True, text=True, cwd=cwd,
     )
     if r.returncode != 0:
         if "already merged" in r.stdout.lower() or "already merged" in r.stderr.lower():


### PR DESCRIPTION
## Summary
- `_land_gh` computed `cwd = project_root` but only passed it to `_fast_forward_main` and `_cleanup_gremlin`. The three intervening `gh` subprocess calls inherited the caller's cwd, which broke `gh pr merge --delete-branch` when invoked from a boss gremlin's detached-HEAD worktree (`"not on any branch"`).
- Fix: pass `cwd=cwd` to the `gh pr view` (status), `gh pr view` (mergeable retry), and `gh pr merge` calls in `_land_gh`.
- Audited `_land_local`, `_land_boss`, and their helpers (`_preflight_land`, `_squash_land`, `_ff_land`, `_fast_forward_main`, `_cleanup_gremlin`) — all already thread `cwd` correctly.

## Test plan
- [ ] From a detached-HEAD worktree, run `gremlins land <gh-id>` against a real ready-to-merge PR and confirm it succeeds.

Closes #84