### PR TITLE
Fix launch.sh exiting 1 on successful user-invoked gremlin launch

### DIFF
--- a/skills/_bg/launch.sh
+++ b/skills/_bg/launch.sh
@@ -584,3 +584,4 @@ Claude session for this project when it finishes.
 EOF
 } >&$( [[ $PRINT_ID -eq 1 ]] && echo 2 || echo 1 )
 [[ $PRINT_ID -eq 1 ]] && printf '%s\n' "$GR_ID"
+exit 0


### PR DESCRIPTION
## Summary
- Append `exit 0` to `skills/_bg/launch.sh` so the script returns 0 on the user-invoked path (`PRINT_ID=0`), where the trailing `[[ ]] && printf` test otherwise leaked exit status 1 into the script's exit code.
- The `--print-id` path used by `bossgremlin.py` was already exit-0 (the test passes, `printf` runs); this fix only affects the user-invoked path.

## Test plan
- [ ] Launch a gremlin without `--print-id`, confirm exit code 0 and that the gremlin actually runs.
- [ ] Launch a gremlin with `--print-id`, confirm `GR_ID` still prints to stdout and exit code is 0.
- [ ] Confirm `--resume` path is untouched (it has its own `exit 0` at line 294).

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)