### PR TITLE
ghgremlin: sweep stale impl-handoff branches

### DIFF
--- a/skills/bossgremlin/bossgremlin.py
+++ b/skills/bossgremlin/bossgremlin.py
@@ -191,6 +191,11 @@ def init_boss_state(spec_path: str, chain_kind: str, chain_base_ref: str,
         "current_child_id": None,
         "children": [],
         "handoff_records": [],
+        # Latest operator_followups list reported by handoff. Each handoff
+        # rewrites this with the conservative carry-forward set the handoff
+        # agent produced, so by chain-done it holds the final list of
+        # operator tasks the human still owes between phase landings.
+        "operator_followups": [],
     }
     save_json(os.path.join(state_dir, "boss_state.json"), boss_state)
     return boss_state
@@ -289,6 +294,15 @@ def run_handoff(gr_id: str, state_dir: str, boss_state: dict,
     if exit_state not in ("next-plan", "chain-done", "bail"):
         die(f"handoff signal file has unrecognized exit_state: {exit_state!r}")
 
+    # Coerce operator_followups to a list of strings. Old handoff signals
+    # predating the field land here as None or absent; treat that as no
+    # followups so a chain that started under an older handoff still reads.
+    raw_followups = sig.get("operator_followups")
+    if isinstance(raw_followups, list):
+        followups = [str(item) for item in raw_followups if str(item).strip()]
+    else:
+        followups = []
+
     now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
     boss_state["handoff_records"].append({
         "timestamp": now,
@@ -299,12 +313,18 @@ def run_handoff(gr_id: str, state_dir: str, boss_state: dict,
         "exit_state": exit_state,
         "child_plan": sig.get("child_plan"),
         "bail_reason": sig.get("reason"),
+        "operator_followups": followups,
     })
     boss_state["handoff_count"] = n
+    boss_state["operator_followups"] = followups
     if os.path.isfile(out_path):
         boss_state["current_plan"] = out_path
 
     log(f"handoff {n} result: {exit_state}")
+    if followups:
+        log(f"  operator follow-ups carried by handoff {n}: {len(followups)}")
+        for item in followups:
+            log(f"    - {item}")
     return exit_state, sig
 
 
@@ -493,6 +513,16 @@ def main(argv):
 
             if exit_state == "chain-done":
                 log("chain complete")
+                followups = boss_state.get("operator_followups") or []
+                if followups:
+                    log(
+                        f"operator follow-ups ({len(followups)}) — owed by the "
+                        f"human between phase landings:"
+                    )
+                    for item in followups:
+                        log(f"  - {item}")
+                else:
+                    log("operator follow-ups: (none)")
                 set_stage(gr_id, "done")
                 save_boss_state(state_dir, boss_state)
                 sys.exit(0)

--- a/skills/ghgremlin/ghgremlin.sh
+++ b/skills/ghgremlin/ghgremlin.sh
@@ -488,6 +488,19 @@ Implement the plan above by making the code changes in this repo. You may commit
   HANDOFF_BRANCH=""
   _commit_count=0
   if [[ "$IMPL_HEAD_ADVANCED" == "1" ]]; then
+    # Sweep stale hand-off branches from prior crashed runs. A run that died
+    # between `git switch -c` below and commit-pr's `git branch -m` leaves
+    # its branch under the dead PID's name; the new run picks a fresh PID
+    # so the live work isn't blocked, but the stale branch lingers as cruft.
+    # `git branch -D` refuses to delete a branch checked out in any worktree,
+    # so concurrent gremlins are safe.
+    while IFS= read -r _stale; do
+      [[ -n "$_stale" ]] || continue
+      if git branch -D "$_stale" 2>/dev/null; then
+        echo "    swept stale hand-off branch: $_stale"
+      fi
+    done < <(git for-each-ref --format='%(refname:short)' 'refs/heads/ghgremlin-impl-handoff-*')
+
     HANDOFF_BRANCH="ghgremlin-impl-handoff-$$"
     if git show-ref --verify --quiet "refs/heads/$HANDOFF_BRANCH"; then
       die "hand-off branch $HANDOFF_BRANCH already exists; refusing to clobber"

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -21,10 +21,19 @@ This skill runs **in the foreground** — it blocks until the inner agent finish
 ## Exit states
 
 - **`next-plan`**: implementation work remains; a child plan has been written for the next gremlin.
-- **`chain-done`**: all implementation tasks are landed; the chain is complete. Pending operator tasks do not block this state — they surface in the final rolling plan's `## Operator follow-ups` section.
-- **`bail`**: something prevents safe continuation; reason is in the signal file and updated plan. Includes the case where remaining work is dominated by operator tasks with no coherent code-only chunk to hand a child.
+- **`chain-done`**: all implementation tasks are landed; the chain is complete. Pending operator tasks do **not** block this state and are **not** an alternative bail reason — they are surfaced via the signal file's `operator_followups` array (and the final rolling plan's `## Operator follow-ups` section, if any pending). A chain whose remaining work is operator-only exits as `chain-done`.
+- **`bail`**: something prevents safe continuation; reason is in the signal file and updated plan. Reserved for genuine blockers (broken state, incoherent plan, security issue, etc.) — operator-only remaining work is not one of them.
 
 Script exit code 0 on any recognized outcome; 1 on infrastructure failure (read the signal file to distinguish outcomes).
+
+## Signal file
+
+The signal file written to `<out-stem>.state.json` always contains:
+
+- `exit_state` — `"next-plan"`, `"chain-done"`, or `"bail"`.
+- `child_plan` — absolute path to the child plan when `next-plan`; `null` otherwise.
+- `reason` — short string when `bail`; `null` otherwise.
+- `operator_followups` — array of one-line strings, one per pending operator task. Empty array (`[]`) when there are none. Populated on every exit state, including `chain-done`, so the boss orchestrator can persist the final operator-task list even when the rolling plan has been pruned to a "chain complete" note.
 
 ## Implementation vs operator tasks
 

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -20,11 +20,30 @@ This skill runs **in the foreground** — it blocks until the inner agent finish
 
 ## Exit states
 
-- **`next-plan`**: work remains; a child plan has been written for the next gremlin.
-- **`chain-done`**: all tasks are implemented; the chain is complete.
-- **`bail`**: something prevents safe continuation; reason is in the signal file and updated plan.
+- **`next-plan`**: implementation work remains; a child plan has been written for the next gremlin.
+- **`chain-done`**: all implementation tasks are landed; the chain is complete. Pending operator tasks do not block this state — they surface in the final rolling plan's `## Operator follow-ups` section.
+- **`bail`**: something prevents safe continuation; reason is in the signal file and updated plan. Includes the case where remaining work is dominated by operator tasks with no coherent code-only chunk to hand a child.
 
 Script exit code 0 on any recognized outcome; 1 on infrastructure failure (read the signal file to distinguish outcomes).
+
+## Implementation vs operator tasks
+
+A child gremlin runs inside a **detached-HEAD worktree, against a single feature branch, ending in one squash-merged PR**. The handoff agent classifies every still-open task in the input plan as either:
+
+- **Implementation** — a code/doc/config change that lands inside the child's PR. These flow into the child plan.
+- **Operator** — work that requires escaping the worktree scope. These are filtered out of the child plan and land in the rolling plan's `## Operator follow-ups` section for the human to pick up between phase landings.
+
+Operator signals the agent looks for:
+
+- Mutates `~/.claude/` or other live user state (`scripts/sync.sh push`/`pull`, hand-edits under `~/.claude/`).
+- Launches another gremlin (`/localgremlin`, `/ghgremlin`, `/bossgremlin`, end-to-end smoke runs).
+- Pushes outside the PR flow (`git push origin main`, force-pushes, manual merges).
+- `/gremlins` operator commands (`land`, `rescue`, `stop`, `close`, `rm`).
+- Post-merge verification (PR CI green checks, deploy confirmation, dashboard watching).
+
+Edits to tracked repo files like `CLAUDE.md`, `scripts/sync.sh`, or `pipeline/DESIGN.md` are **implementation**, even if those files are mirrored to `~/.claude/` by `sync.sh` — the child edits the in-repo file, the human runs the sync later.
+
+Spec authors should label genuinely operator-level acceptance criteria explicitly (e.g. "Operator verification:" prefix, or a separate `## Operator acceptance` section) so the agent classifies correctly. The filter is robust to inline mixing, but explicit labels reduce ambiguity.
 
 ## Arguments
 

--- a/skills/handoff/handoff.py
+++ b/skills/handoff/handoff.py
@@ -361,8 +361,36 @@ def main(argv: List[str]) -> int:
         print(f"    updated plan: {out_path}", flush=True)
         print(f"    signal file:  {signal_path}", flush=True)
 
-    followups = state.get("operator_followups") or []
-    if isinstance(followups, list) and followups:
+    # Validate and normalize operator_followups. The agent prompt requires
+    # this field on every exit state as a list of one-line strings; warn
+    # loudly (rather than silently coerce) if it's missing or the wrong
+    # shape, since silent drops here lose operator tasks the human owes.
+    raw_followups = state.get("operator_followups", "__missing__")
+    if raw_followups == "__missing__":
+        sys.stderr.write(
+            "warning: signal file is missing required field 'operator_followups'; "
+            "treating as empty list\n"
+        )
+        followups: List[str] = []
+    elif not isinstance(raw_followups, list):
+        sys.stderr.write(
+            f"warning: signal file 'operator_followups' is not a list "
+            f"(got {type(raw_followups).__name__}); treating as empty\n"
+        )
+        followups = []
+    else:
+        followups = []
+        for item in raw_followups:
+            if not isinstance(item, str):
+                sys.stderr.write(
+                    f"warning: signal file 'operator_followups' contains a "
+                    f"non-string entry ({type(item).__name__}); coercing to str\n"
+                )
+                item = str(item)
+            item = item.strip()
+            if item:
+                followups.append(item)
+    if followups:
         print(f"    operator follow-ups ({len(followups)}):", flush=True)
         for item in followups:
             print(f"      - {item}", flush=True)

--- a/skills/handoff/handoff.py
+++ b/skills/handoff/handoff.py
@@ -147,26 +147,51 @@ Git diff since chain start:
 ```
 {diff_trunc}
 
+## Implementation vs operator boundary
+
+A child gremlin operates **inside a detached-HEAD worktree, against a single feature branch, ending in one squash-merged PR**. Anything that requires being outside that scope — the user's live config, another worktree, multiple branches, post-merge actions, sibling gremlin launches — is an **operator task**, owned by the human between phase landings.
+
+Classify a task as **operator** if executing it inside a child gremlin's worktree would be impossible, destructive, or undefined. Concrete signals:
+
+- **Mutates `~/.claude/` or other live user state directly**: `scripts/sync.sh push`, `scripts/sync.sh pull`, hand-edits under `~/.claude/`, copying files into `~/.claude/`. (The child has unmerged code in its worktree; mirroring that into `~/.claude/` would suddenly run unmerged code on the user's machine.)
+- **Launches another gremlin**: `/localgremlin`, `/ghgremlin`, `/bossgremlin`, or a smoke-run / end-to-end run that boils down to invoking one. Recursive gremlin launch from a detached worktree is undefined behavior.
+- **Pushes to a remote outside the PR flow**: `git push origin main`, force-pushes, manual `gh pr merge`, direct merges. The child's only remote interaction is opening (and updating) one PR.
+- **Operator commands**: `/gremlins land`, `/gremlins rescue`, `/gremlins stop`, `/gremlins close`, `/gremlins rm`. These are human controls, not workflow steps.
+- **Post-merge verification**: "verify the merged PR's CI is green", "confirm the production deploy", "watch the release dashboard". The child finishes before its PR merges.
+
+Classify as **implementation** if it is a code/doc/config change that lands in the child's PR. Examples that *look* operator-adjacent but are implementation:
+
+- "Update `CLAUDE.md` to mention `pipeline/`" — edits a tracked repo file. The fact that `CLAUDE.md` is mirrored to `~/.claude/CLAUDE.md` by `sync.sh` is irrelevant: the child edits the in-repo file, the human runs `sync.sh push` later.
+- "Extend `scripts/sync.sh` `DIR_PAIRS` with `pipeline:...`" — edits a tracked script. Implementation.
+- "Add `pipeline/DESIGN.md`" — creates a tracked file. Implementation.
+- "Run `scripts/sync.sh push --dry-run` and confirm output is clean" — operator. The dry-run reads live `~/.claude/` state and isn't a code change. (A dry-run *check encoded as a unit test* against fixture data would be implementation; a real `--dry-run` invocation against the user's live tree is not.)
+
+The distinction is **what the task changes** (tracked repo files = implementation) vs **what the task reads or mutates outside the worktree** (live user config, sibling processes, remotes outside the PR = operator). When in doubt, ask: "Could a fresh gremlin with no access to my home directory do this?" If no, operator.
+
+If the spec author wrote operator-flavoured language inline with implementation work, **rewrite or drop it; do not copy it verbatim into the child plan**. Operator tasks land only in the rolling plan's `## Operator follow-ups` section, where the human operator picks them up between phase landings.
+
 ## Your task
 
 1. Read the plan. Identify every task listed under `## Tasks`.
 2. Compare each task against the landed diff and git log to determine whether it has been implemented.
-3. Decide the exit state:
-   - **`chain-done`**: all tasks in the plan are implemented and landed.
-   - **`next-plan`**: some tasks remain unimplemented; the next gremlin should tackle them.
-   - **`bail`**: something prevents safe continuation (broken state, incoherent plan, security issue, etc.).
+3. Classify every still-open task as **implementation** or **operator** using the boundary above. Operator tasks never land in a child plan.
+4. Decide the exit state:
+   - **`chain-done`**: all *implementation* tasks in the plan are implemented and landed. (Operator tasks do not block `chain-done` — they are surfaced separately for the human operator.)
+   - **`next-plan`**: at least one *implementation* task remains; the next gremlin should tackle it.
+   - **`bail`**: something prevents safe continuation (broken state, incoherent plan, security issue, etc.). Also bail when the remaining work is essentially all operator tasks and there is no coherent code-only chunk to hand a child — a chain whose remaining phase is operator-driven should halt for the human, not spawn a doomed child. As a rough heuristic, if more than ~2 of the remaining tasks are operator-classified relative to the implementation tasks, prefer `bail` with a reason that names the operator-only nature of the remaining work.
 
-4. Write an **updated plan document** (the "rolling plan") to: `{out_path}`
+5. Write an **updated plan document** (the "rolling plan") to: `{out_path}`
 
    The rolling plan describes only **remaining** work. Completed tasks are removed entirely — no `[x]` markers, no struck-through entries, no "completed" appendix. The chain of versioned plan files plus git history is the audit trail; the rolling plan does not repeat it. Do not propagate the overarching goal of the chain forward into the rolling plan — that lives upstream, in the original spec.
 
    - **`next-plan`**: include only the tasks that are not yet implemented (still `[ ]`). Prune the surrounding sections (`## Context`, `## Approach`, `## Open questions`, etc.) to match: drop sections whose reason for existing was a now-completed task; keep or trim the rest so the document stays a coherent description of the remaining work.
      - Under `## Open questions`, carry forward unresolved entries; drop entries tied to completed tasks.
      - If a task is only partly landed, keep it (rewritten if needed to reflect what remains).
-   - **`chain-done`**: minimal output. A short note that the chain is complete is enough — no leftover task list, no carried-over context. The signal file carries the structured outcome.
-   - **`bail`**: same pruning rules as `next-plan` (only remaining tasks, surrounding sections trimmed accordingly, unresolved `## Open questions` carried forward), with a bail-reason banner added prominently at the top.
+     - Add an `## Operator follow-ups` section listing every task you classified as operator-level (still pending). These are not handed to a child gremlin — they wait for the human between phase landings. Carry forward operator follow-ups from the previous rolling plan if they have not been done; drop ones that have. If there are no pending operator tasks, omit the section.
+   - **`chain-done`**: minimal output. A short note that the chain is complete is enough — no leftover task list, no carried-over context. If any operator follow-ups remain pending, list them under `## Operator follow-ups` so the human sees them in the final rolling plan; otherwise omit. The signal file carries the structured outcome.
+   - **`bail`**: same pruning rules as `next-plan` (only remaining tasks, surrounding sections trimmed accordingly, unresolved `## Open questions` carried forward, `## Operator follow-ups` if any), with a bail-reason banner added prominently at the top.
 
-5. If exit state is **`next-plan`**, write a **child plan** to: `{child_plan_path}`
+6. If exit state is **`next-plan`**, write a **child plan** to: `{child_plan_path}`
    - Use the standard localgremlin plan structure exactly:
 
      ```
@@ -180,14 +205,15 @@ Git diff since chain start:
 
      ## Tasks
      - [ ] Task N: ...
-     <only the tasks that are not yet done>
+     <only the implementation tasks that are not yet done — never operator tasks>
 
      ## Open questions
      <risks or open questions, or "(none)" if there are none>
      ```
    - The child plan must be self-contained — a fresh gremlin with only this file must know exactly what to implement. Do not propagate the overarching goal of the chain into the child plan; scope it to the next chunk.
+   - **No operator tasks in the child plan, ever.** Before writing the child plan, re-read your own draft `## Tasks` list and ask, for each item: "Is this something a code-only gremlin in a detached worktree can do, ending in one PR?" If any task fails that test, revise — rewrite it as the underlying code change if there is one, or move it to `## Operator follow-ups` in the rolling plan and drop it from the child plan.
 
-6. Write the **signal marker** to: `{signal_path}`
+7. Write the **signal marker** to: `{signal_path}`
    - Valid JSON, exactly this structure:
      ```json
      {{"exit_state": "next-plan|chain-done|bail", "child_plan": "<absolute path or null>", "reason": "<bail reason or null>"}}

--- a/skills/handoff/handoff.py
+++ b/skills/handoff/handoff.py
@@ -172,24 +172,24 @@ If the spec author wrote operator-flavoured language inline with implementation 
 
 ## Your task
 
-1. Read the plan. Identify every task listed under `## Tasks`.
-2. Compare each task against the landed diff and git log to determine whether it has been implemented.
+1. Read the plan. Identify every task listed under `## Tasks`, plus every pending entry under `## Operator follow-ups` if the input plan has that section (a previous handoff may have written it). Both sets feed step 3's classification.
+2. Compare each `## Tasks` entry against the landed diff and git log to determine whether it has been implemented. Operator follow-ups generally leave no signal in the worktree's diff (they happen outside the worktree by design), so do not infer their completion from git history.
 3. Classify every still-open task as **implementation** or **operator** using the boundary above. Operator tasks never land in a child plan.
 4. Decide the exit state:
-   - **`chain-done`**: all *implementation* tasks in the plan are implemented and landed. (Operator tasks do not block `chain-done` — they are surfaced separately for the human operator.)
+   - **`chain-done`**: all *implementation* tasks in the plan are implemented and landed. Operator tasks do **not** block `chain-done` — they are surfaced separately for the human operator via the `operator_followups` field in the signal file (and the `## Operator follow-ups` section in the rolling plan, if any pending). A chain whose remaining work is operator-only therefore exits as `chain-done`.
    - **`next-plan`**: at least one *implementation* task remains; the next gremlin should tackle it.
-   - **`bail`**: something prevents safe continuation (broken state, incoherent plan, security issue, etc.). Also bail when the remaining work is essentially all operator tasks and there is no coherent code-only chunk to hand a child — a chain whose remaining phase is operator-driven should halt for the human, not spawn a doomed child. As a rough heuristic, if more than ~2 of the remaining tasks are operator-classified relative to the implementation tasks, prefer `bail` with a reason that names the operator-only nature of the remaining work.
+   - **`bail`**: something prevents safe continuation (broken state, incoherent plan, security issue, etc.). Reserved for genuine blockers. Operator-only remaining work is **not** a bail reason — it is `chain-done`.
 
 5. Write an **updated plan document** (the "rolling plan") to: `{out_path}`
 
    The rolling plan describes only **remaining** work. Completed tasks are removed entirely — no `[x]` markers, no struck-through entries, no "completed" appendix. The chain of versioned plan files plus git history is the audit trail; the rolling plan does not repeat it. Do not propagate the overarching goal of the chain forward into the rolling plan — that lives upstream, in the original spec.
 
-   - **`next-plan`**: include only the tasks that are not yet implemented (still `[ ]`). Prune the surrounding sections (`## Context`, `## Approach`, `## Open questions`, etc.) to match: drop sections whose reason for existing was a now-completed task; keep or trim the rest so the document stays a coherent description of the remaining work.
+   - **`next-plan`**: include only the implementation tasks that are not yet implemented (still `[ ]`). Prune the surrounding sections (`## Context`, `## Approach`, `## Open questions`, etc.) to match: drop sections whose reason for existing was a now-completed task; keep or trim the rest so the document stays a coherent description of the remaining work.
      - Under `## Open questions`, carry forward unresolved entries; drop entries tied to completed tasks.
      - If a task is only partly landed, keep it (rewritten if needed to reflect what remains).
-     - Add an `## Operator follow-ups` section listing every task you classified as operator-level (still pending). These are not handed to a child gremlin — they wait for the human between phase landings. Carry forward operator follow-ups from the previous rolling plan if they have not been done; drop ones that have. If there are no pending operator tasks, omit the section.
-   - **`chain-done`**: minimal output. A short note that the chain is complete is enough — no leftover task list, no carried-over context. If any operator follow-ups remain pending, list them under `## Operator follow-ups` so the human sees them in the final rolling plan; otherwise omit. The signal file carries the structured outcome.
-   - **`bail`**: same pruning rules as `next-plan` (only remaining tasks, surrounding sections trimmed accordingly, unresolved `## Open questions` carried forward, `## Operator follow-ups` if any), with a bail-reason banner added prominently at the top.
+     - Add an `## Operator follow-ups` section listing every pending operator task. Treat the input plan's `## Operator follow-ups` section as authoritative for prior follow-ups: carry forward every item that still appears there. Only drop an entry if the input plan or git history makes its completion unambiguous (e.g. the human/operator removed it from the input plan, or a commit message explicitly states the operator step was done). Do **not** infer completion from git diff/log or implementation progress alone — operator tasks happen outside the worktree, so the safe behavior is conservative carry-forward. Add any new operator-classified items found in this pass alongside the carried-forward entries. If after all that there are no pending operator tasks, omit the section.
+   - **`chain-done`**: minimal output. A short note that the chain is complete is enough — no leftover task list, no carried-over context. If any pending operator follow-ups remain (under the carry-forward rule above), list them under `## Operator follow-ups` so the human sees them in the final rolling plan; otherwise omit. The signal file carries the structured outcome (including `operator_followups`).
+   - **`bail`**: same pruning rules as `next-plan` (only remaining implementation tasks, surrounding sections trimmed accordingly, unresolved `## Open questions` carried forward, `## Operator follow-ups` carried forward under the conservative rule above), with a bail-reason banner added prominently at the top.
 
 6. If exit state is **`next-plan`**, write a **child plan** to: `{child_plan_path}`
    - Use the standard localgremlin plan structure exactly:
@@ -216,10 +216,11 @@ If the spec author wrote operator-flavoured language inline with implementation 
 7. Write the **signal marker** to: `{signal_path}`
    - Valid JSON, exactly this structure:
      ```json
-     {{"exit_state": "next-plan|chain-done|bail", "child_plan": "<absolute path or null>", "reason": "<bail reason or null>"}}
+     {{"exit_state": "next-plan|chain-done|bail", "child_plan": "<absolute path or null>", "reason": "<bail reason or null>", "operator_followups": ["<task>", ...]}}
      ```
    - `child_plan`: `{child_plan_path}` (as a string) if exit state is `next-plan`, otherwise `null`.
    - `reason`: a short human-readable explanation if exit state is `bail`, otherwise `null`.
+   - `operator_followups`: an array of one-line strings describing every pending operator task, mirroring the rolling plan's `## Operator follow-ups` section. Empty array `[]` if there are none. Required on every exit state — including `chain-done`, where this is how the boss orchestrator learns about operator tasks the human still owes after the rolling plan has been pruned to a "chain complete" note.
 
 Write all required files before finishing. Do not explain your reasoning in stdout — the files are the output."""
 
@@ -359,6 +360,12 @@ def main(argv: List[str]) -> int:
         print(f"    bail reason:  {reason}", flush=True)
         print(f"    updated plan: {out_path}", flush=True)
         print(f"    signal file:  {signal_path}", flush=True)
+
+    followups = state.get("operator_followups") or []
+    if isinstance(followups, list) and followups:
+        print(f"    operator follow-ups ({len(followups)}):", flush=True)
+        for item in followups:
+            print(f"      - {item}", flush=True)
 
     return 0
 


### PR DESCRIPTION
## Summary
- Sweep stale `ghgremlin-impl-handoff-*` branches in the implement-stage tail before creating the new one.
- A run that died between `git switch -c "ghgremlin-impl-handoff-$$"` and commit-pr's `git branch -m` leaves the branch behind under the dead PID's name; the next run's fresh PID avoids a collision (so this isn't a correctness bug), but the cruft accumulates.
- `git branch -D` refuses to delete a branch checked out in any worktree, so concurrent gremlins are safe.

Closes #94

## Test plan
- [ ] Manual: in a worktree, simulate a crashed run by creating a `ghgremlin-impl-handoff-9999` branch (`git branch ghgremlin-impl-handoff-9999 HEAD`) and confirm a fresh `ghgremlin.sh` run sweeps it before creating its own hand-off branch.
- [ ] Manual: confirm a `ghgremlin-impl-handoff-*` branch checked out in another worktree is left alone (no error, no deletion).