### PR TITLE
ghgremlin: anchor launch worktree at origin/<default-branch>

### DIFF
--- a/skills/_bg/launch.sh
+++ b/skills/_bg/launch.sh
@@ -474,12 +474,23 @@ if [[ -n "$_spec_copy_pending" ]]; then
     cp "$_spec_copy_pending" "$STATE_DIR/artifacts/spec.md" || die "could not copy spec to artifacts: $_spec_copy_pending"
 fi
 
-# Isolated workdir setup. For localgremlin in a git repo we create a named
-# branch (bg/localgremlin/<GR_ID>) so the commits the gremlin makes stay
-# reachable after finish.sh runs. For ghgremlin we use --detach because the
-# gremlin's stage 2b creates and pushes its own issue-N-<slug> branch; a
-# named bg/* ref would be a no-op.
+# Isolated workdir setup. Three branches:
+#   localgremlin: named branch bg/localgremlin/<GR_ID> based at HEAD so the
+#     commits the gremlin makes stay reachable after finish.sh runs.
+#     localgremlin is a feature-branch tool and squash-lands onto whatever
+#     branch the user is on, so HEAD is the right base.
+#   ghgremlin: detached worktree based at origin/<default-branch> (after a
+#     fetch). ghgremlin opens a PR against the default branch; basing the
+#     worktree at HEAD would let un-merged commits on the user's current
+#     branch leak into the PR diff. --detach is correct because stage 2b
+#     creates and pushes its own issue-N-<slug> branch — a named bg/* ref
+#     would be a no-op.
+#   bossgremlin: detached worktree at HEAD. The boss itself doesn't open
+#     PRs; it spawns child gremlins that re-enter launch.sh and resolve
+#     their own bases (gh chains additionally pin chain_base_ref via
+#     bossgremlin.py's get_default_branch).
 BRANCH=""
+WORKTREE_BASE_DISPLAY=""
 if [[ $IS_GIT -eq 1 ]]; then
     WORKDIR=$(mktemp -d -t "aibg-$KIND.XXXXXX") || die "mktemp failed"
     rmdir "$WORKDIR" || die "rmdir $WORKDIR failed"
@@ -488,6 +499,28 @@ if [[ $IS_GIT -eq 1 ]]; then
         BRANCH="bg/localgremlin/$GR_ID"
         git -C "$PROJECT_ROOT" worktree add -b "$BRANCH" "$WORKDIR" HEAD >/dev/null \
             || die "git worktree add -b failed"
+    elif [[ "$KIND" == "ghgremlin" ]]; then
+        # Network call at launch time — slower on a flaky connection, but the
+        # alternative (silently basing on a stale origin/<default>) is worse
+        # than a slow launch on a bad connection. die rather than fall back
+        # to HEAD: opening a PR against the wrong base is expensive.
+        git -C "$PROJECT_ROOT" fetch origin --quiet \
+            || die "git fetch origin failed"
+        # symbolic-ref refs/remotes/origin/HEAD is the cheap path. Some
+        # clones lack it (e.g. cloned with --no-checkout, or origin/HEAD
+        # was never set); fall back to `git remote show origin` which
+        # asks the server for the HEAD branch directly.
+        _default=$(git -C "$PROJECT_ROOT" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+            | sed 's@^refs/remotes/origin/@@' || true)
+        if [[ -z "$_default" ]]; then
+            _default=$(git -C "$PROJECT_ROOT" remote show origin 2>/dev/null \
+                | sed -n 's/^  HEAD branch: //p' || true)
+        fi
+        [[ -n "$_default" ]] || die "could not resolve origin's default branch"
+        SETUP_KIND="worktree"
+        WORKTREE_BASE_DISPLAY="origin/$_default"
+        git -C "$PROJECT_ROOT" worktree add --detach "$WORKDIR" "$WORKTREE_BASE_DISPLAY" >/dev/null \
+            || die "git worktree add ($WORKTREE_BASE_DISPLAY) failed"
     else
         SETUP_KIND="worktree"
         git -C "$PROJECT_ROOT" worktree add --detach "$WORKDIR" HEAD >/dev/null \
@@ -574,7 +607,8 @@ fi
 {
     cat <<EOF
 gremlin id:  $GR_ID
-workdir:     $WORKDIR
+workdir:     $WORKDIR${WORKTREE_BASE_DISPLAY:+
+base:        $WORKTREE_BASE_DISPLAY}
 log:         $STATE_DIR/log
 state file:  $STATE_FILE
 pid:         ${PID:-unknown}

--- a/skills/_bg/launch.sh
+++ b/skills/_bg/launch.sh
@@ -88,13 +88,14 @@ if [[ -n "$RESUME_GR_ID" ]]; then
     STATE_FILE="$STATE_DIR/state.json"
     [[ -d "$STATE_DIR" && -f "$STATE_FILE" ]] || die "no state at $STATE_DIR"
 
-    RESUME_KIND=$(jq   -r '.kind         // ""' "$STATE_FILE")
-    WORKDIR=$(jq       -r '.workdir      // ""' "$STATE_FILE")
-    BRANCH=$(jq        -r '.branch       // ""' "$STATE_FILE")
-    STAGE=$(jq         -r '.stage        // ""' "$STATE_FILE")
-    STATUS=$(jq        -r '.status       // ""' "$STATE_FILE")
-    OLD_PID=$(jq       -r '.pid          // ""' "$STATE_FILE")
-    EXIT_CODE=$(jq     -r '.exit_code    // ""' "$STATE_FILE")
+    RESUME_KIND=$(jq        -r '.kind          // ""' "$STATE_FILE")
+    WORKDIR=$(jq            -r '.workdir       // ""' "$STATE_FILE")
+    BRANCH=$(jq             -r '.branch        // ""' "$STATE_FILE")
+    WORKTREE_BASE_DISPLAY=$(jq -r '.worktree_base // ""' "$STATE_FILE")
+    STAGE=$(jq              -r '.stage         // ""' "$STATE_FILE")
+    STATUS=$(jq             -r '.status        // ""' "$STATE_FILE")
+    OLD_PID=$(jq            -r '.pid           // ""' "$STATE_FILE")
+    EXIT_CODE=$(jq          -r '.exit_code     // ""' "$STATE_FILE")
 
     # Full instructions are persisted to a sidecar file (not state.json) because
     # state.json's .instructions is a display-truncated summary (INSTR_SUMMARY
@@ -248,7 +249,8 @@ if [[ -n "$RESUME_GR_ID" ]]; then
         cat <<EOF
 resumed gremlin: $RESUME_GR_ID
 from stage:      $STAGE
-workdir:         $WORKDIR
+workdir:         $WORKDIR${WORKTREE_BASE_DISPLAY:+
+base:            $WORKTREE_BASE_DISPLAY}
 log:             $STATE_DIR/log
 state file:      $STATE_FILE
 pid:             ${PID:-unknown}
@@ -500,23 +502,21 @@ if [[ $IS_GIT -eq 1 ]]; then
         git -C "$PROJECT_ROOT" worktree add -b "$BRANCH" "$WORKDIR" HEAD >/dev/null \
             || die "git worktree add -b failed"
     elif [[ "$KIND" == "ghgremlin" ]]; then
-        # Network call at launch time — slower on a flaky connection, but the
-        # alternative (silently basing on a stale origin/<default>) is worse
-        # than a slow launch on a bad connection. die rather than fall back
-        # to HEAD: opening a PR against the wrong base is expensive.
+        # Resolve the default branch via gh (matches bossgremlin.py's
+        # get_default_branch — single source of truth for "what does origin
+        # consider its default?"). gh is already a hard dependency of
+        # ghgremlin (see line 276 above), so no new dependency.
+        _default=$(gh repo view --json defaultBranchRef \
+            -q .defaultBranchRef.name 2>/dev/null || true)
+        [[ -n "$_default" ]] || die "could not resolve origin's default branch via gh repo view"
+        # Explicit refspec so single-branch / narrow-refspec clones still
+        # fetch the resolved default branch (a bare `git fetch origin` would
+        # honor the configured refspec and could skip it). die rather than
+        # fall back to HEAD: opening a PR against the wrong base is more
+        # expensive than failing the launch on a bad network.
         git -C "$PROJECT_ROOT" fetch origin --quiet \
-            || die "git fetch origin failed"
-        # symbolic-ref refs/remotes/origin/HEAD is the cheap path. Some
-        # clones lack it (e.g. cloned with --no-checkout, or origin/HEAD
-        # was never set); fall back to `git remote show origin` which
-        # asks the server for the HEAD branch directly.
-        _default=$(git -C "$PROJECT_ROOT" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
-            | sed 's@^refs/remotes/origin/@@' || true)
-        if [[ -z "$_default" ]]; then
-            _default=$(git -C "$PROJECT_ROOT" remote show origin 2>/dev/null \
-                | sed -n 's/^  HEAD branch: //p' || true)
-        fi
-        [[ -n "$_default" ]] || die "could not resolve origin's default branch"
+            "refs/heads/$_default:refs/remotes/origin/$_default" \
+            || die "git fetch origin $_default failed (could not fetch default branch)"
         SETUP_KIND="worktree"
         WORKTREE_BASE_DISPLAY="origin/$_default"
         git -C "$PROJECT_ROOT" worktree add --detach "$WORKDIR" "$WORKTREE_BASE_DISPLAY" >/dev/null \
@@ -566,6 +566,7 @@ jq -n \
     --arg     workdir              "$WORKDIR" \
     --arg     setup_kind           "$SETUP_KIND" \
     --arg     branch               "$BRANCH" \
+    --arg     worktree_base        "$WORKTREE_BASE_DISPLAY" \
     --arg     status               "running" \
     --arg     started_at           "$NOW_ISO" \
     --arg     instructions         "$INSTR_SUMMARY" \
@@ -574,7 +575,8 @@ jq -n \
     --argjson description_explicit "$DESC_EXPLICIT_JSON" \
     --argjson pipeline_args        "$PIPELINE_ARGS_JSON" \
     '{id: $id, kind: $kind, project_root: $project_root, workdir: $workdir,
-      setup_kind: $setup_kind, branch: $branch, status: $status,
+      setup_kind: $setup_kind, branch: $branch, worktree_base: $worktree_base,
+      status: $status,
       started_at: $started_at, instructions: $instructions,
       description: $description, description_explicit: $description_explicit,
       parent_id: $parent_id,


### PR DESCRIPTION
## Summary

Standalone `/ghgremlin` launches were creating their worktree at `HEAD`, so any un-merged commits on the caller's feature branch leaked into the gremlin's eventual PR diff. This patch special-cases `ghgremlin` in `_bg/launch.sh`: fetch `origin`, resolve the default branch via `git symbolic-ref refs/remotes/origin/HEAD` (with `git remote show origin` as a fallback for clones missing that ref), and base the detached worktree at `origin/<default>`.

Both `git fetch` failure and an unresolved default branch `die` rather than fall back to `HEAD` — opening a PR against the wrong base is more expensive than re-running on a working network.

`localgremlin` keeps its `HEAD` base (it's a feature-branch tool that squash-lands onto whatever branch the user is on). `bossgremlin`'s own worktree also stays at `HEAD`; `gh` chains already pin `chain_base_ref` via `bossgremlin.py`'s `get_default_branch`, and child `ghgremlin`s re-enter `launch.sh` and resolve their own bases.

The launcher now prints a `base:` line when the worktree base was resolved (i.e. for `ghgremlin`) so the caller can see what the gremlin will diff against. `--resume` is unaffected: it reuses the existing worktree, whose base was set at the original launch.

## Test plan

- [ ] From a feature branch with un-merged commits ahead of `main`, run `/ghgremlin <small task>`; confirm the PR diff contains only the gremlin's changes.
- [ ] Confirm `localgremlin` still bases its worktree at `HEAD` (squash-land target unchanged).
- [ ] Confirm `bossgremlin --chain-kind gh` still functions; child `ghgremlin`s anchor at `origin/<default>` independently.
- [ ] Verify the launcher's stdout shows `base: origin/<default>` for `ghgremlin` and omits the line for other kinds.
- [ ] Force a `git fetch` failure (e.g. unreachable remote) and confirm `launch.sh` `die`s rather than silently falling through.

Closes #98