### PR TITLE
gremlins: fix gh-land halting boss chain on detached-HEAD cwd

### DIFF
--- a/skills/gremlins/gremlins.py
+++ b/skills/gremlins/gremlins.py
@@ -1076,6 +1076,36 @@ def expected_branch(state: dict, gr_id: str):
     return None
 
 
+def _resolve_landing_cwd(state: dict) -> str:
+    """Return a project_root suitable as cwd for `gh pr merge --delete-branch`.
+
+    For boss-launched children, state.project_root is the boss's worktree, which
+    is on a detached HEAD. After --delete-branch, gh tries to switch off the
+    deleted branch and fails with "could not determine current branch: failed
+    to run git: not on any branch". Walk parent_id up to the topmost ancestor
+    (the user's actual repo, on a real branch) to avoid that.
+    """
+    own_root = state.get("project_root") or ""
+    parent_id = state.get("parent_id") or ""
+    if not parent_id:
+        return own_root
+
+    seen = set()
+    current = state
+    while True:
+        pid = current.get("parent_id") or ""
+        if not pid or pid in seen:
+            break
+        seen.add(pid)
+        parent_sf = os.path.join(STATE_ROOT, pid, "state.json")
+        parent_state = load_state(parent_sf)
+        if not parent_state:
+            break
+        current = parent_state
+
+    return current.get("project_root") or own_root
+
+
 def _fast_forward_main(cwd):
     """Attempt to fast-forward local main to origin/main after a gh PR merge."""
     r = subprocess.run(["git", "fetch", "origin"], capture_output=True, text=True, cwd=cwd)
@@ -1574,7 +1604,7 @@ def _land_gh(gr_id: str, sf: str, wdir: str, state: dict, force: bool = False) -
         print("This gremlin may have been launched before pr_url tracking was added to ghgremlin.sh.")
         return False
 
-    project_root = state.get("project_root") or ""
+    project_root = _resolve_landing_cwd(state)
     cwd = project_root if project_root and os.path.isdir(project_root) else None
 
     print(f"Checking PR: {pr_url}")
@@ -1654,8 +1684,25 @@ def _land_gh(gr_id: str, sf: str, wdir: str, state: dict, force: bool = False) -
         if "already merged" in r.stdout.lower() or "already merged" in r.stderr.lower():
             print("PR was already merged.")
         else:
-            print(f"error: gh pr merge failed: {r.stderr.strip() or r.stdout.strip()}")
-            return False
+            # gh may exit non-zero on post-merge cleanup (e.g. --delete-branch
+            # tries to switch off the deleted branch and fails on a detached
+            # HEAD cwd) even though the PR did merge. Re-verify before bailing.
+            err = r.stderr.strip() or r.stdout.strip()
+            v = subprocess.run(
+                ["gh", "pr", "view", pr_url, "--json", "state"],
+                capture_output=True, text=True, cwd=cwd,
+            )
+            verified_merged = False
+            if v.returncode == 0:
+                try:
+                    verified_merged = json.loads(v.stdout).get("state") == "MERGED"
+                except json.JSONDecodeError:
+                    pass
+            if verified_merged:
+                print(f"warning: gh pr merge exited non-zero ({err}) but PR is MERGED on GitHub — proceeding with cleanup.")
+            else:
+                print(f"error: gh pr merge failed: {err}")
+                return False
     else:
         print("PR merged.")
 

--- a/skills/gremlins/gremlins.py
+++ b/skills/gremlins/gremlins.py
@@ -1090,20 +1090,30 @@ def _resolve_landing_cwd(state: dict) -> str:
     if not parent_id:
         return own_root
 
-    seen = set()
+    # Pre-seed cycle protection with the starting state's id so a pathological
+    # cycle that loops back through the starting gremlin trips on first revisit.
+    seen = {state.get("id") or ""}
     current = state
     while True:
         pid = current.get("parent_id") or ""
-        if not pid or pid in seen:
-            break
+        if not pid:
+            # Clean termination: reached the topmost ancestor. Note: if its
+            # project_root is empty/missing (e.g. corrupted boss state.json),
+            # the own_root fallback may still be detached — strictly no worse
+            # than the original failure mode.
+            return current.get("project_root") or own_root
+        if pid in seen:
+            # Cycle in parent chain — fall back to own_root rather than
+            # returning a possibly-detached intermediate ancestor.
+            return own_root
         seen.add(pid)
         parent_sf = os.path.join(STATE_ROOT, pid, "state.json")
         parent_state = load_state(parent_sf)
         if not parent_state:
-            break
+            # Unreadable parent state — fall back to own_root rather than
+            # returning a possibly-detached intermediate ancestor.
+            return own_root
         current = parent_state
-
-    return current.get("project_root") or own_root
 
 
 def _fast_forward_main(cwd):
@@ -1693,15 +1703,24 @@ def _land_gh(gr_id: str, sf: str, wdir: str, state: dict, force: bool = False) -
                 capture_output=True, text=True, cwd=cwd,
             )
             verified_merged = False
+            verify_err = ""
             if v.returncode == 0:
                 try:
                     verified_merged = json.loads(v.stdout).get("state") == "MERGED"
-                except json.JSONDecodeError:
-                    pass
+                except json.JSONDecodeError as e:
+                    verify_err = f"could not parse gh pr view response: {e}"
+            else:
+                verify_err = v.stderr.strip() or v.stdout.strip()
             if verified_merged:
                 print(f"warning: gh pr merge exited non-zero ({err}) but PR is MERGED on GitHub — proceeding with cleanup.")
             else:
-                print(f"error: gh pr merge failed: {err}")
+                if verify_err:
+                    # Verification was inconclusive (gh pr view failed or returned
+                    # unparseable output) — operator should check PR state manually
+                    # before reaching for `rescue` or re-running `land`.
+                    print(f"error: gh pr merge failed: {err}; verification inconclusive: {verify_err}")
+                else:
+                    print(f"error: gh pr merge failed: {err}")
                 return False
     else:
         print("PR merged.")


### PR DESCRIPTION
## Summary
- Resolve a non-detached cwd before invoking `gh pr merge` in `_land_gh`: new `_resolve_landing_cwd` helper walks `parent_id` up to the topmost ancestor's `project_root` (the user's real repo on a real branch), with cycle protection and a fallback to the gremlin's own `project_root`. Non-boss callers (empty `parent_id`) get `state.project_root` verbatim, preserving existing behavior.
- Re-verify PR state on non-zero `gh pr merge` exit via `gh pr view --json state`, and treat `MERGED` as success (warning) so post-merge cleanup hiccups never roll back a merged PR into a chain halt. Existing `"already merged"` short-circuit preserved.

## Why
Boss-driven `gremlins land <gh-child>` was halting the chain when the boss's worktree (used as the child's `project_root`) was on detached HEAD. `gh pr merge --squash --delete-branch` succeeded at merging on GitHub but failed on the post-merge branch-switch step (`could not determine current branch: failed to run git: not on any branch`), so `_land_gh` returned False and the boss reported "child pipeline succeeded but land failed" — even though PR #106 had actually merged.

## Test plan
- [ ] Non-boss `gh` gremlin lands as before (empty `parent_id` → helper returns `state.project_root` verbatim).
- [ ] Boss-launched child gh gremlin lands cleanly when the boss's worktree is on detached HEAD.
- [ ] If `gh pr merge` exits non-zero but `gh pr view` reports `MERGED`, landing proceeds with a warning and cleans up.
- [ ] If `gh pr merge` exits non-zero and the PR is not merged, landing still fails as before.

Closes #107