### PR TITLE
bossgremlin: accept GitHub issue refs for --plan

### DIFF
--- a/pipeline/gh_utils.py
+++ b/pipeline/gh_utils.py
@@ -54,19 +54,32 @@ def parse_issue_ref(
     return None, None
 
 
+VIEW_ISSUE_TIMEOUT = 30  # seconds; bounds `gh issue view` shell-out
+
+
 def view_issue(issue_ref: str, repo: str) -> dict:
     """Fetch ``number``, ``url``, ``body`` for an issue via ``gh issue view``.
 
-    Returns the parsed JSON dict. Raises ``RuntimeError`` when ``gh`` fails or
-    returns unparseable output.
+    Returns the parsed JSON dict. Raises ``RuntimeError`` when ``gh`` fails,
+    times out, or returns unparseable output. The timeout is bounded so a
+    hung ``gh`` (network stall, credential prompt) cannot block chain start
+    indefinitely.
     """
-    r = subprocess.run(
-        [
-            "gh", "issue", "view", issue_ref, "--repo", repo,
-            "--json", "number,url,body",
-        ],
-        capture_output=True, text=True, check=False,
-    )
+    try:
+        r = subprocess.run(
+            [
+                "gh", "issue", "view", issue_ref, "--repo", repo,
+                "--json", "number,url,body",
+            ],
+            capture_output=True, text=True, check=False,
+            timeout=VIEW_ISSUE_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"timed out after {VIEW_ISSUE_TIMEOUT}s while resolving issue "
+            f"{issue_ref!r} in {repo!r} via `gh issue view`; check GitHub "
+            f"CLI authentication, prompts, and network connectivity"
+        ) from exc
     if r.returncode != 0:
         raise RuntimeError(
             f"could not resolve issue {issue_ref!r} in {repo!r}: {r.stderr.strip()}"

--- a/pipeline/gh_utils.py
+++ b/pipeline/gh_utils.py
@@ -6,10 +6,11 @@ live here so the stage modules stay focused on orchestration.
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 import sys
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Tuple
 
 
 def get_repo() -> str:
@@ -23,6 +24,60 @@ def get_repo() -> str:
             f"not in a gh-recognized repo: {r.stderr.strip() or r.stdout.strip()}"
         )
     return r.stdout.strip()
+
+
+def parse_issue_ref(
+    plan_source: str, repo: str
+) -> Tuple[Optional[str], Optional[str]]:
+    """Parse an issue reference string into ``(target_repo, issue_num)``.
+
+    Recognized shapes (matching ghgremlin's --plan contract):
+      * ``42`` / ``#42``                              → (repo, "42")
+      * ``owner/name#42``                             → ("owner/name", "42")
+      * ``https://github.com/owner/name/issues/42``   → ("owner/name", "42")
+
+    Returns ``(None, None)`` when ``plan_source`` doesn't match any shape so
+    the caller can distinguish issue refs from local file paths.
+    """
+    m = re.match(r"^#?([0-9]+)$", plan_source)
+    if m:
+        return repo, m.group(1)
+    m = re.match(r"^([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#([0-9]+)$", plan_source)
+    if m:
+        return m.group(1), m.group(2)
+    m = re.match(
+        r"^https://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/([0-9]+)(#.*)?$",
+        plan_source,
+    )
+    if m:
+        return m.group(1), m.group(2)
+    return None, None
+
+
+def view_issue(issue_ref: str, repo: str) -> dict:
+    """Fetch ``number``, ``url``, ``body`` for an issue via ``gh issue view``.
+
+    Returns the parsed JSON dict. Raises ``RuntimeError`` when ``gh`` fails or
+    returns unparseable output.
+    """
+    r = subprocess.run(
+        [
+            "gh", "issue", "view", issue_ref, "--repo", repo,
+            "--json", "number,url,body",
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    if r.returncode != 0:
+        raise RuntimeError(
+            f"could not resolve issue {issue_ref!r} in {repo!r}: {r.stderr.strip()}"
+        )
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"gh issue view returned invalid JSON for {issue_ref!r} in {repo!r}. "
+            f"stdout: {r.stdout.strip()} stderr: {r.stderr.strip()}"
+        ) from exc
 
 
 def extract_gh_url(

--- a/pipeline/orchestrators/boss.py
+++ b/pipeline/orchestrators/boss.py
@@ -491,27 +491,58 @@ def _resolve_plan_source(plan: str, state_dir: str) -> Tuple[str, str, str]:
     spec_dest = os.path.join(state_dir, "spec.md")
 
     if os.path.isfile(spec_dest) and os.path.getsize(spec_dest) > 0:
+        # Rescue path: a previous run already wrote the snapshot. Recover any
+        # issue_url / issue_num it persisted to state.json so the rescue
+        # doesn't silently strip the issue link from boss_state.json. (We
+        # avoid re-fetching from GitHub — the snapshot is authoritative.)
         log(f"reusing existing spec snapshot: {spec_dest}")
-        return spec_dest, "", ""
+        recovered_url = ""
+        recovered_num = ""
+        try:
+            state_data = load_json(os.path.join(state_dir, "state.json"))
+            recovered_url = state_data.get("issue_url") or ""
+            recovered_num = state_data.get("issue_num") or ""
+        except Exception:
+            pass
+        return spec_dest, recovered_url, recovered_num
+
+    # Classify the input shape *before* shelling out to `gh repo view`. For a
+    # typo like `--plan not-a-ref`, this lets us fail fast with a clear error
+    # instead of forcing the caller to be inside a gh-recognized repo first.
+    target_repo, issue_ref = parse_issue_ref(plan, "")
 
     if os.path.isfile(plan):
-        if os.path.getsize(plan) == 0:
-            die(f"--plan: file is empty: {plan}")
-        shutil.copyfile(plan, spec_dest)
+        try:
+            if os.path.getsize(plan) == 0:
+                die(f"--plan: file is empty: {plan}")
+            shutil.copyfile(plan, spec_dest)
+        except OSError as exc:
+            die(f"--plan: failed to read/copy local plan file {plan!r}: {exc}")
         log(f"plan source (file): {plan} → {spec_dest}")
         return spec_dest, "", ""
+
+    if target_repo is None and issue_ref is None:
+        # parse_issue_ref returned (None, None) for the bare-number form
+        # only because we passed an empty repo. Re-check by looking for the
+        # bare-number shape directly so the error message is accurate.
+        if not re.match(r"^#?[0-9]+$", plan):
+            die(f"--plan: not a readable file or recognized issue reference: {plan}")
 
     if shutil.which("gh") is None:
         die(f"--plan: gh CLI not found; required to resolve issue reference {plan!r}")
 
-    try:
-        repo = get_repo()
-    except RuntimeError as exc:
-        die(f"--plan: {exc}")
-
-    target_repo, issue_ref = parse_issue_ref(plan, repo)
-    if target_repo is None:
-        die(f"--plan: not a readable file or recognized issue reference: {plan}")
+    # Resolve the bare-number form against the current repo; cross-repo
+    # forms (`owner/name#42` or full URLs) already carry their own repo.
+    if target_repo is None or target_repo == "":
+        try:
+            target_repo = get_repo()
+        except RuntimeError as exc:
+            die(f"--plan: {exc}")
+        # Re-parse against the resolved repo to populate issue_ref for the
+        # bare-number form.
+        target_repo, issue_ref = parse_issue_ref(plan, target_repo)
+        if target_repo is None:
+            die(f"--plan: not a readable file or recognized issue reference: {plan}")
 
     try:
         issue_data = view_issue(issue_ref, target_repo)
@@ -527,6 +558,9 @@ def _resolve_plan_source(plan: str, state_dir: str) -> Tuple[str, str, str]:
 
     with open(spec_dest, "w", encoding="utf-8") as f:
         f.write(body + "\n")
+    # Persist the issue identifiers to state.json immediately so a crash
+    # between this point and init_boss_state() doesn't strip them on rescue.
+    patch_state(issue_url=issue_url, issue_num=issue_num)
     log(f"plan source (issue {target_repo}#{issue_ref}): {issue_url} → {spec_dest}")
     return spec_dest, issue_url, issue_num
 
@@ -549,10 +583,11 @@ def _maybe_set_description_from_spec(state_dir: str) -> None:
     if data.get("description_explicit"):
         return
     try:
+        # Read up to 50 lines; .splitlines() stops at EOF, so short specs
+        # still yield their leading lines (the prior list-comprehension
+        # form raised StopIteration on short files and dropped the H1).
         with open(spec_file, encoding="utf-8") as f:
-            head_lines = [next(f) for _ in range(50)]
-    except StopIteration:
-        head_lines = []
+            head_lines = f.read().splitlines()[:50]
     except Exception:
         return
     h1 = ""

--- a/pipeline/orchestrators/boss.py
+++ b/pipeline/orchestrators/boss.py
@@ -17,12 +17,16 @@ import argparse
 import datetime
 import json
 import os
-import pathlib
+import re
+import shutil
 import signal
 import subprocess
 import sys
 import time
-from typing import List
+from typing import List, Tuple
+
+from ..gh_utils import get_repo, parse_issue_ref, view_issue
+from ..state import patch_state
 
 STATE_ROOT = os.path.join(
     os.environ.get("XDG_STATE_HOME", os.path.join(os.path.expanduser("~"), ".local", "state")),
@@ -177,7 +181,8 @@ def get_remote_branch_sha(project_root: str, branch: str) -> str:
 
 
 def init_boss_state(spec_path: str, chain_kind: str, chain_base_ref: str,
-                    target_branch: str, state_dir: str) -> dict:
+                    target_branch: str, state_dir: str,
+                    issue_url: str = "", issue_num: str = "") -> dict:
     boss_state = {
         "spec_path": spec_path,
         "chain_kind": chain_kind,
@@ -188,6 +193,11 @@ def init_boss_state(spec_path: str, chain_kind: str, chain_base_ref: str,
         "current_child_id": None,
         "children": [],
         "handoff_records": [],
+        # Source of the spec: empty for local-file inputs, populated when
+        # --plan was a GitHub issue reference. Persisted so `/gremlins`
+        # status can show the issue link and so resume never re-fetches.
+        "issue_url": issue_url,
+        "issue_num": issue_num,
         # Latest operator_followups list reported by handoff. Each handoff
         # rewrites this with the conservative carry-forward set the handoff
         # agent produced, so by chain-done it holds the final list of
@@ -462,6 +472,99 @@ def _parse_boss_args(argv: List[str]) -> argparse.Namespace:
     return args
 
 
+def _resolve_plan_source(plan: str, state_dir: str) -> Tuple[str, str, str]:
+    """Resolve --plan into a snapshot under ``<state_dir>/spec.md``.
+
+    Accepts the same forms as ghgremlin's --plan: a local file path, ``42`` /
+    ``#42``, ``owner/name#42``, or a full ``https://github.com/.../issues/N``
+    URL. The returned ``spec_path`` is always the snapshot — boss handoffs
+    only ever read the snapshot, never the original input.
+
+    Idempotent: if ``spec.md`` already exists with non-zero size, it is
+    treated as authoritative and no re-fetch is performed. This handles the
+    rescue edge case where a previous run wrote the snapshot but crashed
+    before persisting boss_state.json.
+
+    Returns ``(spec_path, issue_url, issue_num)``. ``issue_url`` /
+    ``issue_num`` are empty strings for local-file inputs.
+    """
+    spec_dest = os.path.join(state_dir, "spec.md")
+
+    if os.path.isfile(spec_dest) and os.path.getsize(spec_dest) > 0:
+        log(f"reusing existing spec snapshot: {spec_dest}")
+        return spec_dest, "", ""
+
+    if os.path.isfile(plan):
+        if os.path.getsize(plan) == 0:
+            die(f"--plan: file is empty: {plan}")
+        shutil.copyfile(plan, spec_dest)
+        log(f"plan source (file): {plan} → {spec_dest}")
+        return spec_dest, "", ""
+
+    if shutil.which("gh") is None:
+        die(f"--plan: gh CLI not found; required to resolve issue reference {plan!r}")
+
+    try:
+        repo = get_repo()
+    except RuntimeError as exc:
+        die(f"--plan: {exc}")
+
+    target_repo, issue_ref = parse_issue_ref(plan, repo)
+    if target_repo is None:
+        die(f"--plan: not a readable file or recognized issue reference: {plan}")
+
+    try:
+        issue_data = view_issue(issue_ref, target_repo)
+    except RuntimeError as exc:
+        die(f"--plan: {exc}")
+
+    body = issue_data.get("body") or ""
+    if not body:
+        die(f"--plan: issue {plan} has an empty body")
+
+    issue_url = issue_data.get("url") or ""
+    issue_num = str(issue_data.get("number") or "")
+
+    with open(spec_dest, "w", encoding="utf-8") as f:
+        f.write(body + "\n")
+    log(f"plan source (issue {target_repo}#{issue_ref}): {issue_url} → {spec_dest}")
+    return spec_dest, issue_url, issue_num
+
+
+def _maybe_set_description_from_spec(state_dir: str) -> None:
+    """If state.json's description wasn't set explicitly, fill it from the
+    spec snapshot's first heading. Mirrors gh's _update_description_from_plan.
+
+    A no-op when state.json is missing or already has description_explicit=true,
+    or when the snapshot has no recognizable heading.
+    """
+    state_file = os.path.join(state_dir, "state.json")
+    spec_file = os.path.join(state_dir, "spec.md")
+    if not os.path.isfile(state_file) or not os.path.isfile(spec_file):
+        return
+    try:
+        data = load_json(state_file)
+    except Exception:
+        return
+    if data.get("description_explicit"):
+        return
+    try:
+        with open(spec_file, encoding="utf-8") as f:
+            head_lines = [next(f) for _ in range(50)]
+    except StopIteration:
+        head_lines = []
+    except Exception:
+        return
+    h1 = ""
+    for line in head_lines:
+        m = re.match(r"^#+\s+(.+)", line)
+        if m:
+            h1 = m.group(1).strip()[:60]
+            break
+    if h1:
+        patch_state(description=h1)
+
+
 def boss_main(argv: List[str]) -> int:
     args = _parse_boss_args(argv)
 
@@ -482,13 +585,22 @@ def boss_main(argv: List[str]) -> int:
         die(f"project_root not usable: {project_root!r}")
     boss_workdir = gremlin_state.get("workdir", "")
 
-    spec_path = str(pathlib.Path(args.plan).resolve())
     chain_kind = args.chain_kind
     launch_kind = {"local": "localgremlin", "gh": "ghgremlin"}[chain_kind]
 
     boss_state_file = os.path.join(state_dir, "boss_state.json")
     if not os.path.isfile(boss_state_file):
-        log(f"chain start: kind={chain_kind}, spec={spec_path}")
+        # Chain start: snapshot --plan into the state dir. The handoff agent
+        # only ever reads the snapshot, so a deleted-or-modified original
+        # input cannot perturb later handoffs. For issue refs, the fetch
+        # happens here (after launch.sh has detached) so a transient GitHub
+        # outage is reported in the boss log instead of failing the launch.
+        spec_path, issue_url, issue_num = _resolve_plan_source(args.plan, state_dir)
+        if issue_url:
+            log(f"chain start: kind={chain_kind}, spec={spec_path}, issue={issue_url}")
+        else:
+            log(f"chain start: kind={chain_kind}, spec={spec_path}")
+        _maybe_set_description_from_spec(state_dir)
         if chain_kind == "gh":
             # gh children open PRs from the repo's default branch and land
             # there, regardless of where the user happens to be. Anchor the
@@ -506,6 +618,8 @@ def boss_main(argv: List[str]) -> int:
             chain_base_ref=chain_base_ref,
             target_branch=target_branch,
             state_dir=state_dir,
+            issue_url=issue_url,
+            issue_num=issue_num,
         )
     else:
         boss_state = load_boss_state(state_dir)

--- a/pipeline/orchestrators/gh.py
+++ b/pipeline/orchestrators/gh.py
@@ -25,7 +25,7 @@ import sys
 from typing import Dict, List, Optional
 
 from ..clients.claude import ClaudeClient, SubprocessClaudeClient
-from ..gh_utils import extract_gh_url, get_repo
+from ..gh_utils import extract_gh_url, get_repo, parse_issue_ref, view_issue
 from ..runner import install_signal_handlers, run_stages
 from ..stages.commit_pr import run_commit_pr_stage
 from ..stages.ghaddress import run_ghaddress_stage
@@ -131,21 +131,11 @@ def _read_state_field(sf: Optional[pathlib.Path], field: str) -> str:
         return ""
 
 
-def _parse_issue_ref(plan_source: str, repo: str):
-    """Parse an issue reference and return (target_repo, issue_ref_number) or (None, None)."""
-    m = re.match(r"^#?([0-9]+)$", plan_source)
-    if m:
-        return repo, m.group(1)
-    m = re.match(r"^([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#([0-9]+)$", plan_source)
-    if m:
-        return m.group(1), m.group(2)
-    m = re.match(
-        r"^https://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/([0-9]+)(#.*)?$",
-        plan_source,
-    )
-    if m:
-        return m.group(1), m.group(2)
-    return None, None
+# Test compatibility shim — tests import _parse_issue_ref from this module
+# directly (and patch _fetch_issue_body below). The canonical implementation
+# lives in pipeline.gh_utils.parse_issue_ref so the boss orchestrator can
+# share it.
+_parse_issue_ref = parse_issue_ref
 
 
 def _fetch_issue_body(issue_num: str, repo: str) -> str:
@@ -260,22 +250,10 @@ def _resolve_plan_source(
         if target_repo is None:
             die(f"--plan: not a readable file or recognized issue reference: {plan_source}")
 
-        r = subprocess.run(
-            [
-                "gh", "issue", "view", issue_ref, "--repo", target_repo,
-                "--json", "number,url,body",
-            ],
-            capture_output=True, text=True, check=False,
-        )
-        if r.returncode != 0:
-            die(f"--plan: could not resolve issue {plan_source}: {r.stderr.strip()}")
         try:
-            issue_data = json.loads(r.stdout)
-        except json.JSONDecodeError:
-            die(
-                f"--plan: gh issue view returned invalid JSON for {plan_source}. "
-                f"stdout: {r.stdout.strip()} stderr: {r.stderr.strip()}"
-            )
+            issue_data = view_issue(issue_ref, target_repo)
+        except RuntimeError as exc:
+            die(f"--plan: {exc}")
         issue_body = issue_data.get("body") or ""
         if not issue_body:
             die(f"--plan: issue {plan_source} has an empty body")

--- a/pipeline/orchestrators/gh.py
+++ b/pipeline/orchestrators/gh.py
@@ -139,13 +139,11 @@ _parse_issue_ref = parse_issue_ref
 
 
 def _fetch_issue_body(issue_num: str, repo: str) -> str:
-    r = subprocess.run(
-        ["gh", "issue", "view", issue_num, "--repo", repo, "--json", "body", "--jq", ".body"],
-        capture_output=True, text=True, check=False,
-    )
-    if r.returncode != 0:
-        die(f"could not fetch issue #{issue_num} body: {r.stderr.strip()}")
-    body = r.stdout.strip()
+    try:
+        issue_data = view_issue(issue_num, repo)
+    except RuntimeError as exc:
+        die(f"could not fetch issue #{issue_num} body: {exc}")
+    body = (issue_data.get("body") or "").strip()
     if not body:
         die(f"issue #{issue_num} has an empty body")
     return body

--- a/pipeline/tests/test_orchestrator_boss.py
+++ b/pipeline/tests/test_orchestrator_boss.py
@@ -9,6 +9,7 @@ import pytest
 
 import pipeline.orchestrators.boss as boss_mod
 from pipeline.orchestrators.boss import (
+    _resolve_plan_source,
     _summarize_for_log,
     boss_main,
     get_child_bail_detail,
@@ -721,3 +722,181 @@ def test_bail_after_rescue_refused(tmp_path, monkeypatch):
     assert child_entry["id"] == child_id
     assert "bailed" in child_entry["outcome"]
     assert final_state["current_child_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_plan_source: file path, issue ref, idempotent rescue
+# ---------------------------------------------------------------------------
+
+def test_resolve_plan_source_file(tmp_path):
+    """File path inputs are copied verbatim into <state-dir>/spec.md."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    src = tmp_path / "in.md"
+    src.write_text("# Spec\nContent.\n")
+
+    spec_path, issue_url, issue_num = _resolve_plan_source(str(src), str(state_dir))
+
+    assert spec_path == str(state_dir / "spec.md")
+    assert (state_dir / "spec.md").read_text() == "# Spec\nContent.\n"
+    assert issue_url == ""
+    assert issue_num == ""
+
+
+def test_resolve_plan_source_empty_file(tmp_path):
+    """Empty file inputs are rejected."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    src = tmp_path / "empty.md"
+    src.write_text("")
+
+    with pytest.raises(SystemExit):
+        _resolve_plan_source(str(src), str(state_dir))
+
+
+def test_resolve_plan_source_issue_ref(tmp_path, monkeypatch):
+    """Issue refs fetch the body via gh and snapshot it to spec.md."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    monkeypatch.setattr(boss_mod, "get_repo", lambda: "owner/repo")
+    monkeypatch.setattr(
+        boss_mod, "view_issue",
+        lambda ref, repo: {
+            "number": 42,
+            "url": "https://github.com/owner/repo/issues/42",
+            "body": "# Issue Spec\nFetched from gh.\n",
+        },
+    )
+    import shutil as _shutil
+    monkeypatch.setattr(_shutil, "which", lambda n: "/fake/gh" if n == "gh" else None)
+
+    spec_path, issue_url, issue_num = _resolve_plan_source("42", str(state_dir))
+
+    assert spec_path == str(state_dir / "spec.md")
+    body = (state_dir / "spec.md").read_text()
+    assert "# Issue Spec" in body
+    assert "Fetched from gh." in body
+    assert issue_url == "https://github.com/owner/repo/issues/42"
+    assert issue_num == "42"
+
+
+def test_resolve_plan_source_cross_repo_issue_ref(tmp_path, monkeypatch):
+    """``owner/repo#42`` resolves against the named repo, not get_repo()."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    captured = {}
+
+    def fake_view_issue(ref, repo):
+        captured["ref"] = ref
+        captured["repo"] = repo
+        return {
+            "number": 7,
+            "url": "https://github.com/other/proj/issues/7",
+            "body": "# Cross-repo\nspec.\n",
+        }
+
+    monkeypatch.setattr(boss_mod, "get_repo", lambda: "owner/repo")
+    monkeypatch.setattr(boss_mod, "view_issue", fake_view_issue)
+    import shutil as _shutil
+    monkeypatch.setattr(_shutil, "which", lambda n: "/fake/gh" if n == "gh" else None)
+
+    spec_path, issue_url, issue_num = _resolve_plan_source(
+        "other/proj#7", str(state_dir)
+    )
+
+    assert captured == {"ref": "7", "repo": "other/proj"}
+    assert issue_url == "https://github.com/other/proj/issues/7"
+    assert issue_num == "7"
+    assert (state_dir / "spec.md").read_text().startswith("# Cross-repo")
+
+
+def test_resolve_plan_source_unknown_shape(tmp_path, monkeypatch):
+    """Non-file, non-issue-ref inputs fail fast."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    monkeypatch.setattr(boss_mod, "get_repo", lambda: "owner/repo")
+    import shutil as _shutil
+    monkeypatch.setattr(_shutil, "which", lambda n: "/fake/gh" if n == "gh" else None)
+
+    with pytest.raises(SystemExit):
+        _resolve_plan_source("not-a-ref", str(state_dir))
+
+
+def test_resolve_plan_source_idempotent(tmp_path, monkeypatch):
+    """A pre-existing non-empty spec.md is reused without re-fetching."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "spec.md").write_text("# Already snapshotted\n")
+
+    fetch_called = []
+
+    def boom(*a, **kw):
+        fetch_called.append(True)
+        raise AssertionError("view_issue should not be called when snapshot exists")
+
+    monkeypatch.setattr(boss_mod, "view_issue", boom)
+    monkeypatch.setattr(boss_mod, "get_repo", lambda: (_ for _ in ()).throw(AssertionError("get_repo should not be called")))
+
+    spec_path, issue_url, issue_num = _resolve_plan_source("42", str(state_dir))
+
+    assert spec_path == str(state_dir / "spec.md")
+    assert (state_dir / "spec.md").read_text() == "# Already snapshotted\n"
+    assert fetch_called == []
+
+
+# ---------------------------------------------------------------------------
+# boss_main smoke test: --plan <issue-ref> end-to-end snapshot
+# ---------------------------------------------------------------------------
+
+def test_boss_main_plan_issue_ref_snapshots_spec(tmp_path, monkeypatch):
+    """boss_main with --plan <issue-ref> fetches the issue and snapshots spec.md."""
+    gr_id = "test-boss-issue-aabb12"
+    state_dir, project_root, workdir = _make_gremlin_state(tmp_path, gr_id)
+    _common_boss_patches(monkeypatch, tmp_path, gr_id)
+
+    monkeypatch.setattr(boss_mod, "get_repo", lambda: "owner/repo")
+    monkeypatch.setattr(
+        boss_mod, "view_issue",
+        lambda ref, repo: {
+            "number": 80,
+            "url": "https://github.com/owner/repo/issues/80",
+            "body": "# Plan from issue\nDo a thing.\n",
+        },
+    )
+    import shutil as _shutil
+    monkeypatch.setattr(_shutil, "which", lambda n: "/fake/gh" if n == "gh" else None)
+
+    # Short-circuit handoff at the very first step so we don't have to mock
+    # an entire chain — we just want to verify spec.md and boss_state.json.
+    def fake_run_handoff(gr_id, state_dir, boss_state, project_root, boss_workdir, model):
+        n = boss_state["handoff_count"] + 1
+        out_path = os.path.join(state_dir, f"handoff-{n:03d}.md")
+        pathlib.Path(out_path).write_text("# Handoff\n")
+        boss_state["handoff_count"] = n
+        boss_state["current_plan"] = out_path
+        boss_state["operator_followups"] = []
+        boss_state["handoff_records"].append({
+            "timestamp": "2026-01-01T00:00:00Z", "n": n,
+            "plan_in": boss_state["spec_path"], "plan_out": out_path,
+            "signal_file": "", "exit_state": "chain-done",
+            "child_plan": None, "bail_reason": None, "operator_followups": [],
+        })
+        return "chain-done", {"exit_state": "chain-done", "operator_followups": []}
+
+    monkeypatch.setattr(boss_mod, "run_handoff", fake_run_handoff)
+
+    result = boss_main(["--plan", "80", "--chain-kind", "local"])
+    assert result == 0
+
+    snapshot = state_dir / "spec.md"
+    assert snapshot.exists()
+    body = snapshot.read_text()
+    assert "Plan from issue" in body
+    assert "Do a thing." in body
+
+    final_state = load_boss_state(str(state_dir))
+    assert final_state["spec_path"] == str(snapshot)
+    assert final_state["issue_url"] == "https://github.com/owner/repo/issues/80"
+    assert final_state["issue_num"] == "80"

--- a/pipeline/tests/test_orchestrator_boss.py
+++ b/pipeline/tests/test_orchestrator_boss.py
@@ -846,6 +846,65 @@ def test_resolve_plan_source_idempotent(tmp_path, monkeypatch):
     assert fetch_called == []
 
 
+def test_resolve_plan_source_idempotent_recovers_issue_metadata(tmp_path, monkeypatch):
+    """On rescue, issue_url / issue_num are recovered from state.json so the
+    issue link survives the snapshot-already-exists short-circuit. Regression
+    for the bug where the idempotent path always returned empty strings."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "spec.md").write_text("# Already snapshotted\n")
+    (state_dir / "state.json").write_text(json.dumps({
+        "issue_url": "https://github.com/owner/repo/issues/77",
+        "issue_num": "77",
+    }))
+
+    monkeypatch.setattr(
+        boss_mod, "view_issue",
+        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("should not refetch")),
+    )
+
+    spec_path, issue_url, issue_num = _resolve_plan_source("77", str(state_dir))
+
+    assert spec_path == str(state_dir / "spec.md")
+    assert issue_url == "https://github.com/owner/repo/issues/77"
+    assert issue_num == "77"
+
+
+def test_resolve_plan_source_persists_issue_metadata_on_first_fetch(
+    tmp_path, monkeypatch
+):
+    """First-run issue-ref path persists issue_url / issue_num to state.json
+    so a crash before init_boss_state still leaves the rescue path able to
+    recover the link."""
+    xdg_home = tmp_path / "xdg"
+    state_root = xdg_home / "claude-gremlins"
+    state_dir = state_root / "test-boss-persist-aa1122"
+    state_dir.mkdir(parents=True)
+    (state_dir / "state.json").write_text(json.dumps({"id": "test-boss-persist-aa1122"}))
+    monkeypatch.setenv("XDG_STATE_HOME", str(xdg_home))
+    monkeypatch.setenv("GR_ID", "test-boss-persist-aa1122")
+
+    monkeypatch.setattr(boss_mod, "get_repo", lambda: "owner/repo")
+    monkeypatch.setattr(
+        boss_mod, "view_issue",
+        lambda ref, repo: {
+            "number": 99,
+            "url": "https://github.com/owner/repo/issues/99",
+            "body": "# Spec\nbody.\n",
+        },
+    )
+    import shutil as _shutil
+    monkeypatch.setattr(_shutil, "which", lambda n: "/fake/gh" if n == "gh" else None)
+
+    spec_path, issue_url, issue_num = _resolve_plan_source("99", str(state_dir))
+
+    assert issue_url == "https://github.com/owner/repo/issues/99"
+    assert issue_num == "99"
+    state_data = json.loads((state_dir / "state.json").read_text())
+    assert state_data.get("issue_url") == "https://github.com/owner/repo/issues/99"
+    assert state_data.get("issue_num") == "99"
+
+
 # ---------------------------------------------------------------------------
 # boss_main smoke test: --plan <issue-ref> end-to-end snapshot
 # ---------------------------------------------------------------------------
@@ -853,8 +912,16 @@ def test_resolve_plan_source_idempotent(tmp_path, monkeypatch):
 def test_boss_main_plan_issue_ref_snapshots_spec(tmp_path, monkeypatch):
     """boss_main with --plan <issue-ref> fetches the issue and snapshots spec.md."""
     gr_id = "test-boss-issue-aabb12"
-    state_dir, project_root, workdir = _make_gremlin_state(tmp_path, gr_id)
-    _common_boss_patches(monkeypatch, tmp_path, gr_id)
+    # Arrange XDG_STATE_HOME so boss_mod.STATE_ROOT and patch_state's
+    # XDG-derived state file path agree, otherwise the description fill
+    # would silently no-op and the assertion below would always pass.
+    xdg_home = tmp_path / "xdg"
+    state_root = xdg_home / "claude-gremlins"
+    state_root.mkdir(parents=True)
+    monkeypatch.setenv("XDG_STATE_HOME", str(xdg_home))
+
+    state_dir, project_root, workdir = _make_gremlin_state(state_root, gr_id)
+    _common_boss_patches(monkeypatch, state_root, gr_id)
 
     monkeypatch.setattr(boss_mod, "get_repo", lambda: "owner/repo")
     monkeypatch.setattr(
@@ -900,3 +967,9 @@ def test_boss_main_plan_issue_ref_snapshots_spec(tmp_path, monkeypatch):
     assert final_state["spec_path"] == str(snapshot)
     assert final_state["issue_url"] == "https://github.com/owner/repo/issues/80"
     assert final_state["issue_num"] == "80"
+
+    # _maybe_set_description_from_spec should have filled state.json's
+    # description from the snapshot's first H1 — this confirms the H1 read
+    # works for short specs (regression coverage for the StopIteration bug).
+    state_data = json.loads((state_dir / "state.json").read_text())
+    assert state_data.get("description") == "Plan from issue"

--- a/skills/_bg/launch.sh
+++ b/skills/_bg/launch.sh
@@ -417,9 +417,10 @@ fi
 # Early validation for localgremlin --plan <path>: the arg is always a local
 # file path (localgremlin has no issue-ref form), so we can fail fast here
 # (before state dir creation) on missing/empty files instead of deferring to
-# localgremlin.py. ghgremlin's --plan accepts issue refs whose validity
-# depends on the network, so its validation stays inside ghgremlin.sh.
-if [[ ( "$KIND" == "localgremlin" || "$KIND" == "bossgremlin" ) && -n "$_plan_arg" ]]; then
+# localgremlin.py. ghgremlin's and bossgremlin's --plan accept issue refs
+# whose validity depends on the network, so their validation stays inside
+# the orchestrators (which can also snapshot the issue body).
+if [[ "$KIND" == "localgremlin" && -n "$_plan_arg" ]]; then
     if [[ ! -f "$_plan_arg" ]]; then
         die "--plan: file not found: $_plan_arg"
     fi
@@ -500,19 +501,20 @@ SLUG=$(slugify "$SLUG_SOURCE")
 # Description fallback: explicit --description wins; otherwise prefer the
 # --plan file's H1 (when the plan arg is a local file), and finally fall back
 # to a truncated slice of the raw instructions. For a --plan issue-ref where
-# launch.sh can't see the issue body, DESCRIPTION stays empty so ghgremlin.sh
-# can fill it in after resolving the issue (INSTR_RAW would be just the
-# flag echo "--plan 42" which is not a useful description).
-# The empty-description issue-ref branch is guarded to KIND=ghgremlin: only
-# ghgremlin has an issue-body fill-in step later in the pipeline, and its
-# --plan accepts non-file refs. localgremlin's --plan is always a file (and
-# the earlier early-validation block dies on a non-file value), so a
-# non-file _plan_arg reaching this block under localgremlin is structurally
-# impossible — but the guard makes the assumption explicit and future-proof.
+# launch.sh can't see the issue body, DESCRIPTION stays empty so the
+# orchestrator can fill it in after resolving the issue (INSTR_RAW would be
+# just the flag echo "--plan 42 --chain-kind gh" which is not a useful
+# description).
+# The empty-description issue-ref branch is guarded to ghgremlin/bossgremlin:
+# both have an issue-body fill-in step later in the pipeline, and both --plan
+# variants accept non-file refs. localgremlin's --plan is always a file (and
+# the earlier early-validation block dies on a non-file value), so a non-file
+# _plan_arg reaching this block under localgremlin is structurally impossible
+# — but the guard makes the assumption explicit and future-proof.
 if [[ -z "$DESCRIPTION" ]]; then
     if [[ -n "$_plan_h1" ]]; then
         DESCRIPTION="${_plan_h1:0:60}"
-    elif [[ -n "$_plan_arg" && "$KIND" == "ghgremlin" ]]; then
+    elif [[ -n "$_plan_arg" && ( "$KIND" == "ghgremlin" || "$KIND" == "bossgremlin" ) ]]; then
         DESCRIPTION=""
     else
         DESCRIPTION="${INSTR_RAW:0:60}"

--- a/skills/bossgremlin/SKILL.md
+++ b/skills/bossgremlin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bossgremlin
 description: Run the end-to-end chained gremlin workflow in the background by invoking ~/.claude/skills/_bg/launch.sh. Chains multiple child gremlins serially: the handoff agent decides what to implement next, each child runs plan→implement→review→address, and the boss lands each one before proceeding. The launcher returns immediately; you'll be notified when the chain finishes.
-argument-hint: --plan <spec-path> --chain-kind local|gh [--model <model>]
+argument-hint: --plan <spec-path|issue-ref> --chain-kind local|gh [--model <model>]
 allowed-tools: Bash(~/.claude/skills/_bg/launch.sh:*)
 ---
 
@@ -27,18 +27,25 @@ Before invoking the launcher, compose a short (≤60 characters) human-readable 
 Pass it as `--description "<phrase>"` before the `bossgremlin` kind argument:
 
 ```
-~/.claude/skills/_bg/launch.sh --description "<phrase>" bossgremlin --plan <spec-path> --chain-kind <local|gh> [--model <model>]
+~/.claude/skills/_bg/launch.sh --description "<phrase>" bossgremlin --plan <spec-path|issue-ref> --chain-kind <local|gh> [--model <model>]
 ```
 
 Flags:
 
-- `--plan <spec-path>` — (required) absolute path to the top-level spec file describing the overall multi-step goal. Must be a non-empty file. This file is immutable for the life of the chain — the boss passes it to the first handoff agent and never reads it.
+- `--plan <spec-path|issue-ref>` — (required) the top-level spec describing the overall multi-step goal. Four forms, mirroring `/ghgremlin --plan`:
+    - **Local file path** — an absolute path to a non-empty spec file.
+    - **`42` or `#42`** — issue #42 in the current repo.
+    - **`owner/repo#42`** — issue #42 in a different repo (cross-repo spec source; the chain still runs against the current repo's `main`).
+    - **Full URL `https://github.com/owner/repo/issues/42`** — same cross-repo semantics. `github.com` only.
+
+  At chain start, the boss snapshots the spec into `<state-dir>/spec.md` and reads only the snapshot for the rest of the chain. The original input is never re-read, so a deleted file or mutated GitHub issue cannot perturb a running chain. On rescue, the snapshot is authoritative — no re-fetch.
 - `--chain-kind local|gh` — (required) whether children are `localgremlin` (local branch, squash-merged) or `ghgremlin` (GitHub PR, squash-merged to main). A chain is homogeneous — all children are the same kind.
 - `--model <model>` — model to use for handoff agent calls (default: `sonnet`).
 
 ## Where artifacts go
 
-- `~/.local/state/claude-gremlins/<boss-id>/boss_state.json` — ordered list of child ids with outcomes, per-handoff records (timestamps, plan paths, exit states), chain base ref.
+- `~/.local/state/claude-gremlins/<boss-id>/spec.md` — chain-start snapshot of the spec (file copy or fetched issue body). The handoff agent reads this; the original `--plan` input is never re-read.
+- `~/.local/state/claude-gremlins/<boss-id>/boss_state.json` — ordered list of child ids with outcomes, per-handoff records (timestamps, plan paths, exit states), chain base ref, plus `issue_url` / `issue_num` when `--plan` was an issue reference.
 - `~/.local/state/claude-gremlins/<boss-id>/handoff-001.md`, `handoff-002.md`, … — rolling plan documents produced by each handoff invocation, each containing only the work still remaining at that point. The sequence of files is the audit trail of progression.
 - `~/.local/state/claude-gremlins/<boss-id>/handoff-001-child.md`, … — child plans passed to each child gremlin.
 - `~/.local/state/claude-gremlins/<boss-id>/handoff-001.state.json`, … — handoff signal files recording exit_state and reason.

--- a/skills/bossgremlin/SKILL.md
+++ b/skills/bossgremlin/SKILL.md
@@ -33,7 +33,7 @@ Pass it as `--description "<phrase>"` before the `bossgremlin` kind argument:
 Flags:
 
 - `--plan <spec-path|issue-ref>` — (required) the top-level spec describing the overall multi-step goal. Four forms, mirroring `/ghgremlin --plan`:
-    - **Local file path** — an absolute path to a non-empty spec file.
+    - **Local file path** — an absolute or relative path to a non-empty spec file.
     - **`42` or `#42`** — issue #42 in the current repo.
     - **`owner/repo#42`** — issue #42 in a different repo (cross-repo spec source; the chain still runs against the current repo's `main`).
     - **Full URL `https://github.com/owner/repo/issues/42`** — same cross-repo semantics. `github.com` only.


### PR DESCRIPTION
## Summary

- Mirror ghgremlin's `--plan` dual file-or-issue-ref form for bossgremlin: `42`, `#42`, `owner/repo#42`, and full GitHub issue URLs are now accepted alongside local file paths. Removes the manual `gh issue view <n> > /tmp/spec.md` dance.
- At chain start the boss snapshots the spec into `<state-dir>/spec.md`; every handoff reads the snapshot, never the original input. On rescue the snapshot is authoritative — no re-fetch. `issue_url` / `issue_num` are persisted into `boss_state.json`.
- The issue-ref parser and `gh issue view --json …` wrapper move into `pipeline/gh_utils.py` so both orchestrators share one implementation.
- `launch.sh`'s file-existence pre-check is narrowed to `localgremlin` (which has no issue-ref form). For bossgremlin, the network fetch runs inside the orchestrator after launch detaches, so a transient GitHub outage surfaces as a bail in the boss log instead of failing the launch.
- `skills/bossgremlin/SKILL.md` updated: `argument-hint` → `<spec-path|issue-ref>`, `--plan` blurb documents all four shapes and the snapshot semantics, and `spec.md` is added to the artifacts list.

## Test plan

- [x] Six new unit tests for `_resolve_plan_source` (file path, empty file, single-repo issue ref, cross-repo issue ref, unknown shape, idempotent rescue).
- [x] New `boss_main` smoke test launches with `--plan 80` and verifies `spec.md` lands in the state dir with the issue body and `issue_url` / `issue_num` are persisted into `boss_state.json`.
- [x] Full pipeline test suite: 62 passed.
- [ ] Manual: launch a real boss against a live GitHub issue (`bossgremlin --plan <issue-ref> --chain-kind gh`) and verify `spec.md` is written before the first handoff.
- [ ] Manual: rescue a chain mid-flight and confirm no second `gh issue view` call.

Closes #82