### PR TITLE
pipeline: add CLAUDE.md orientation doc

### DIFF
--- a/pipeline/CLAUDE.md
+++ b/pipeline/CLAUDE.md
@@ -17,12 +17,12 @@ history.
 - `gh_utils.py` — `gh` CLI wrappers and stream-json URL extractors used by the gh orchestrator.
 - `clients/claude.py` — `ClaudeClient` Protocol + `SubprocessClaudeClient` (production).
 - `clients/fake.py` — `FakeClaudeClient` recording test double; replays canned stream-json from fixtures keyed by `label`.
-- `stages/` — per-stage bodies: `plan`, `implement`, `review_code`, `address_code`, `commit_pr`, `ghreview`, `ghaddress`, `wait_copilot`.
-- `orchestrators/local.py` — `local_main`, `review_main`, `address_main`. Ports `skills/localgremlin/localgremlin.py`.
-- `orchestrators/gh.py` — `gh_main`. Ports `skills/ghgremlin/ghgremlin.sh`.
-- `orchestrators/boss.py` — `boss_main`. Ports `skills/bossgremlin/bossgremlin.py`.
+- `stages/` — per-stage bodies: `plan`, `implement`, `review_code`, `address_code`, `commit_pr`, `ghreview`, `ghaddress`, `wait_copilot`. (The `request-copilot` stage body is inlined as a closure in `orchestrators/gh.py`.)
+- `orchestrators/local.py` — `local_main`, `review_main`, `address_main`. Implements the logic behind shim entrypoint `skills/localgremlin/localgremlin.py`.
+- `orchestrators/gh.py` — `gh_main`. Implements the logic behind shim entrypoint `skills/ghgremlin/ghgremlin.sh`.
+- `orchestrators/boss.py` — `boss_main`. Implements the logic behind shim entrypoint `skills/bossgremlin/bossgremlin.py`.
 - `prompts/` — externalized prompt templates (plan, implement, review lenses, etc).
-- `tests/` — pytest suite; fakes only, no subprocess spawn.
+- `tests/` — pytest suite; `claude` is always faked, but some tests still run local `git` subprocesses and typically stub `gh` at the `subprocess.run` level.
 
 ## Entry points
 
@@ -36,8 +36,9 @@ history.
 
 ## Testability seam: `ClaudeClient`
 
-Every stage takes a `client: ClaudeClient` (Protocol in `clients/claude.py`).
-Production code passes `SubprocessClaudeClient()`; tests pass
+Every stage that invokes `claude` takes an injected `client: ClaudeClient`
+(Protocol in `clients/claude.py`). Production code passes
+`SubprocessClaudeClient()` to those stages; tests pass
 `FakeClaudeClient(fixtures={label: <jsonl-or-list>})`. The fake records each
 `run(...)` call into `self.calls` for assertion. **Never have a stage
 spawn `claude -p` directly** — go through the injected client so tests can
@@ -52,9 +53,11 @@ distinct labels per phase.
 These values are persisted to `state.json` files and read by other
 writers (`session-summary.sh` hook, `liveness.sh` sourced from
 `gremlins.py`, the launcher, the rescue protocol). Renaming any of them
-silently breaks cross-process consumers. Source: constants in
-[`state.py`](state.py) and [`DESIGN.md`](DESIGN.md) §Bail-class
-vocabulary / §Marker-protocol bail reasons.
+silently breaks cross-process consumers. Source of truth: bail-class
+constants live in [`state.py`](state.py); local / gh stage-name vocab
+is defined and validated in the orchestrators; marker-protocol bail
+reasons live in [`DESIGN.md`](DESIGN.md) (§Marker-protocol bail
+reasons) and the `skills/_bg/` scripts.
 
 - **Bail classes** (`state.json.bail_class`): `reviewer_requested_changes`, `security`, `secrets`, `other`.
 - **Local stage names**: `plan`, `implement`, `review-code`, `address-code`.

--- a/pipeline/CLAUDE.md
+++ b/pipeline/CLAUDE.md
@@ -1,0 +1,91 @@
+# `pipeline/`
+
+Shared plan / implement / review / address machinery extracted from
+`skills/{localgremlin,ghgremlin,bossgremlin}/`. The skill scripts under
+`skills/` are thin shims that exec into `python -m pipeline.cli`; this
+package owns the actual orchestration. [`DESIGN.md`](DESIGN.md) is the
+binding migration spec — load it for marker protocol, ghgremlin
+impl-handoff branch lifecycle, launcher contract, and per-phase rollout
+history.
+
+## Module layout
+
+- `cli.py` — `python -m pipeline.cli {local,review,address,gh,boss}` dispatch.
+- `runner.py` — `run_stages` sequencer (with `resume_from`) + SIGINT/SIGTERM handlers that reap `claude -p` children.
+- `state.py` — session-dir resolution, `set_stage` / `emit_bail` / `patch_state` / `check_bail`.
+- `git.py` — `in_git_repo`, `git_head`, branch / worktree helpers.
+- `gh_utils.py` — `gh` CLI wrappers and stream-json URL extractors used by the gh orchestrator.
+- `clients/claude.py` — `ClaudeClient` Protocol + `SubprocessClaudeClient` (production).
+- `clients/fake.py` — `FakeClaudeClient` recording test double; replays canned stream-json from fixtures keyed by `label`.
+- `stages/` — per-stage bodies: `plan`, `implement`, `review_code`, `address_code`, `commit_pr`, `ghreview`, `ghaddress`, `wait_copilot`.
+- `orchestrators/local.py` — `local_main`, `review_main`, `address_main`. Ports `skills/localgremlin/localgremlin.py`.
+- `orchestrators/gh.py` — `gh_main`. Ports `skills/ghgremlin/ghgremlin.sh`.
+- `orchestrators/boss.py` — `boss_main`. Ports `skills/bossgremlin/bossgremlin.py`.
+- `prompts/` — externalized prompt templates (plan, implement, review lenses, etc).
+- `tests/` — pytest suite; fakes only, no subprocess spawn.
+
+## Entry points
+
+| Subcommand | Orchestrator | Replaces |
+|---|---|---|
+| `local` | `orchestrators.local.local_main` | `skills/localgremlin/localgremlin.py` |
+| `review` | `orchestrators.local.review_main` | `localreview.py` |
+| `address` | `orchestrators.local.address_main` | `localaddress.py` |
+| `gh` | `orchestrators.gh.gh_main` | `skills/ghgremlin/ghgremlin.sh` |
+| `boss` | `orchestrators.boss.boss_main` | `skills/bossgremlin/bossgremlin.py` |
+
+## Testability seam: `ClaudeClient`
+
+Every stage takes a `client: ClaudeClient` (Protocol in `clients/claude.py`).
+Production code passes `SubprocessClaudeClient()`; tests pass
+`FakeClaudeClient(fixtures={label: <jsonl-or-list>})`. The fake records each
+`run(...)` call into `self.calls` for assertion. **Never have a stage
+spawn `claude -p` directly** — go through the injected client so tests can
+intercept it.
+
+`FakeClaudeClient` looks fixtures up by `label`. Stages that re-enter the
+same logical step within one process (e.g. resumed implement) must use
+distinct labels per phase.
+
+## Byte-stable strings — DO NOT change
+
+These values are persisted to `state.json` files and read by other
+writers (`session-summary.sh` hook, `liveness.sh` sourced from
+`gremlins.py`, the launcher, the rescue protocol). Renaming any of them
+silently breaks cross-process consumers. Source: constants in
+[`state.py`](state.py) and [`DESIGN.md`](DESIGN.md) §Bail-class
+vocabulary / §Marker-protocol bail reasons.
+
+- **Bail classes** (`state.json.bail_class`): `reviewer_requested_changes`, `security`, `secrets`, `other`.
+- **Local stage names**: `plan`, `implement`, `review-code`, `address-code`.
+- **Gh stage names**: `plan`, `implement`, `commit-pr`, `request-copilot`, `ghreview`, `wait-copilot`, `ghaddress`.
+- **Marker-protocol bail reasons**: `diagnosis_no_marker`, `diagnosis_bad_marker`, `diagnosis_claude_error`, `diagnosis_timeout`, `excluded_class:<class>`, `attempts_exhausted`, `relaunch_launcher_missing`, `relaunch_failed`.
+
+## Bash-script carve-outs
+
+`state.set_stage` and `state.emit_bail` shell out to
+`~/.claude/skills/_bg/set-stage.sh` and `set-bail.sh` rather than
+patching `state.json` in Python. Those scripts are **also** invoked by
+non-pipeline writers (`session-summary.sh` hook; `liveness.sh` sourced by
+`gremlins.py`), so the bash scripts are the single source of truth for
+the on-disk format. Don't reimplement that bookkeeping in pure Python —
+forks would drift.
+
+Both helpers no-op without `GR_ID` and never raise: stage / bail
+bookkeeping must not crash a running gremlin.
+
+## Tests
+
+```
+cd pipeline && PYTHONPATH=. python -m pytest
+```
+
+Equivalently, from `pipeline/tests/`: `PYTHONPATH=$(pwd)/.. python -m pytest`.
+
+## Sync invariant
+
+`pipeline/` is mirrored to `~/.claude/pipeline/` via
+[`scripts/sync.sh`](../scripts/sync.sh) (already in `DIR_PAIRS`). Edit
+files in the repo, then run `scripts/sync.sh push` to propagate. Never
+hand-edit `~/.claude/pipeline/` — the next `pull` will overwrite it, or
+the next `push` will silently revert your changes.


### PR DESCRIPTION
## Summary

- Adds `pipeline/CLAUDE.md` as a concise (~90-line) orientation doc for the `pipeline/` package.
- Covers module layout, CLI entry points, the `ClaudeClient` testability seam, the four byte-stable string sets (bail classes, local/gh stage names, marker bail reasons), the bash-script carve-outs in `state.py`, test invocation, and the `scripts/sync.sh` mirror invariant.
- Points at `DESIGN.md` for rescue marker protocol, ghgremlin impl-handoff branch lifecycle, launcher contract, and per-phase rollout history.

No code or test changes. `pipeline/README.md` left as-is per the open question in the issue (recommendation: keep it as the `gh repo browse` human-reader landing).

## Test plan

- [ ] Skim `pipeline/CLAUDE.md` for accuracy against the current tree (module list, entry points, byte-stable strings).
- [ ] Confirm DESIGN.md / state.py references resolve.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)