### PR TITLE
skills: add pytest coverage for gremlins.py and handoff.py

### DIFF
--- a/skills/pyproject.toml
+++ b/skills/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["gremlins", "handoff", "tests"]

--- a/skills/tests/conftest.py
+++ b/skills/tests/conftest.py
@@ -1,0 +1,8 @@
+import pathlib
+import sys
+
+SKILLS_ROOT = pathlib.Path(__file__).resolve().parent.parent
+for sub in ("gremlins", "handoff"):
+    p = str(SKILLS_ROOT / sub)
+    if p not in sys.path:
+        sys.path.insert(0, p)

--- a/skills/tests/test_gremlins.py
+++ b/skills/tests/test_gremlins.py
@@ -1,0 +1,508 @@
+"""Tests for skills/gremlins/gremlins.py."""
+
+import json
+import os
+import pathlib
+import subprocess
+
+import pytest
+
+import gremlins
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_state(state_dir: pathlib.Path, payload: dict, *,
+                 finished: bool = False, log_text: str | None = None) -> str:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    sf = state_dir / "state.json"
+    sf.write_text(json.dumps(payload))
+    if finished:
+        (state_dir / "finished").touch()
+    if log_text is not None:
+        (state_dir / "log").write_text(log_text)
+    return str(sf)
+
+
+def _setup_dead_gremlin(tmp_path, monkeypatch, gr_id="test-id-aabb12",
+                        **state_overrides):
+    """Build a state-root with a single dead gremlin, monkeypatch STATE_ROOT."""
+    state_root = tmp_path / "state-root"
+    state_root.mkdir()
+    gr_dir = state_root / gr_id
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    state = {
+        "id": gr_id,
+        "kind": "localgremlin",
+        "stage": "review-code",
+        "status": "dead",
+        "exit_code": 2,
+        "workdir": str(workdir),
+        "rescue_count": 0,
+    }
+    state.update(state_overrides)
+    _write_state(gr_dir, state, finished=True)
+    monkeypatch.setattr(gremlins, "STATE_ROOT", str(state_root))
+    return gr_dir, workdir
+
+
+def _init_git_repo(path: pathlib.Path) -> None:
+    subprocess.run(["git", "init", "-b", "main"], cwd=path,
+                   check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"],
+                   cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"],
+                   cwd=path, check=True, capture_output=True)
+    (path / "README.md").write_text("init\n")
+    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=path,
+                   check=True, capture_output=True)
+
+
+# ---------------------------------------------------------------------------
+# liveness_of_state_file — state transitions
+# ---------------------------------------------------------------------------
+
+def test_liveness_running_with_live_pid_and_fresh_log(tmp_path):
+    sf = _write_state(
+        tmp_path / "g",
+        {"status": "running", "pid": os.getpid()},
+        log_text="recent",
+    )
+    assert gremlins.liveness_of_state_file(sf) == "running"
+
+
+def test_liveness_dead_finished_zero_exit(tmp_path):
+    sf = _write_state(
+        tmp_path / "g",
+        {"status": "running", "pid": 99999, "exit_code": 0},
+        finished=True,
+    )
+    assert gremlins.liveness_of_state_file(sf) == "dead:finished"
+
+
+def test_liveness_dead_with_nonzero_exit(tmp_path):
+    sf = _write_state(
+        tmp_path / "g",
+        {"status": "running", "pid": 99999, "exit_code": 2},
+        finished=True,
+    )
+    assert gremlins.liveness_of_state_file(sf) == "dead:exit 2"
+
+
+def test_liveness_dead_bailed_includes_reason(tmp_path):
+    sf = _write_state(
+        tmp_path / "g",
+        {"status": "bailed", "exit_code": 2, "bail_reason": "structural"},
+        finished=True,
+    )
+    assert gremlins.liveness_of_state_file(sf) == "dead:bailed:structural"
+
+
+def test_liveness_dead_crashed_when_pid_gone(tmp_path):
+    # PID extremely unlikely to exist
+    sf = _write_state(
+        tmp_path / "g",
+        {"status": "running", "pid": 999999},
+    )
+    assert gremlins.liveness_of_state_file(sf).startswith("dead:crashed")
+
+
+def test_liveness_stalled_when_log_is_old(tmp_path, monkeypatch):
+    sf = _write_state(
+        tmp_path / "g",
+        {"status": "running", "pid": os.getpid()},
+        log_text="old",
+    )
+    log_path = tmp_path / "g" / "log"
+    old = os.path.getmtime(log_path) - 10000
+    os.utime(log_path, (old, old))
+    monkeypatch.setattr(gremlins, "BG_STALL_SECS", 100)
+    assert gremlins.liveness_of_state_file(sf).startswith("stalled:")
+
+
+# ---------------------------------------------------------------------------
+# build_row — rescue marker (state transition: dead → rescued → running)
+# ---------------------------------------------------------------------------
+
+def test_build_row_rescue_suffix_singular():
+    state = {"kind": "localgremlin", "stage": "implement",
+             "rescue_count": 1, "started_at": ""}
+    row = gremlins.build_row("g1", "/sf", "/wdir", state, "running")
+    assert "(rescue)" in row["live"]
+
+
+def test_build_row_rescue_suffix_multiple():
+    state = {"kind": "localgremlin", "stage": "implement",
+             "rescue_count": 3, "started_at": ""}
+    row = gremlins.build_row("g1", "/sf", "/wdir", state, "running")
+    assert "(rescue x3)" in row["live"]
+
+
+def test_build_row_no_rescue_suffix_when_zero():
+    state = {"kind": "localgremlin", "stage": "implement",
+             "rescue_count": 0, "started_at": ""}
+    row = gremlins.build_row("g1", "/sf", "/wdir", state, "running")
+    assert "(rescue" not in row["live"]
+
+
+# ---------------------------------------------------------------------------
+# Phase A marker contract — _read_rescue_marker
+# ---------------------------------------------------------------------------
+
+def _write_marker(path: pathlib.Path, payload) -> str:
+    if isinstance(payload, str):
+        path.write_text(payload)
+    else:
+        path.write_text(json.dumps(payload))
+    return str(path)
+
+
+def test_marker_missing_file(tmp_path):
+    status, msg = gremlins._read_rescue_marker(str(tmp_path / "missing.json"))
+    assert status == "no_marker"
+    assert "did not write" in msg
+
+
+def test_marker_unparseable(tmp_path):
+    p = _write_marker(tmp_path / "m.json", "not json")
+    status, msg = gremlins._read_rescue_marker(p)
+    assert status == "bad_marker"
+    assert "unreadable" in msg
+
+
+def test_marker_not_a_json_object(tmp_path):
+    p = _write_marker(tmp_path / "m.json", [1, 2, 3])
+    status, msg = gremlins._read_rescue_marker(p)
+    assert status == "bad_marker"
+    assert "not a JSON object" in msg
+
+
+def test_marker_invalid_status(tmp_path):
+    p = _write_marker(tmp_path / "m.json", {"status": "bogus"})
+    status, msg = gremlins._read_rescue_marker(p)
+    assert status == "bad_marker"
+    assert "invalid status" in msg
+
+
+def test_marker_summary_must_be_string(tmp_path):
+    p = _write_marker(tmp_path / "m.json", {"status": "fixed", "summary": [1, 2]})
+    status, msg = gremlins._read_rescue_marker(p)
+    assert status == "bad_marker"
+
+
+def test_marker_fixed(tmp_path):
+    p = _write_marker(tmp_path / "m.json",
+                       {"status": "fixed", "summary": "patched state.json"})
+    status, msg = gremlins._read_rescue_marker(p)
+    assert status == "fixed"
+    assert msg == "patched state.json"
+
+
+def test_marker_transient(tmp_path):
+    p = _write_marker(tmp_path / "m.json",
+                       {"status": "transient", "summary": "network flake"})
+    status, msg = gremlins._read_rescue_marker(p)
+    assert status == "transient"
+    assert msg == "network flake"
+
+
+def test_marker_structural_with_summary(tmp_path):
+    p = _write_marker(tmp_path / "m.json",
+                       {"status": "structural", "summary": "bug in foo.sh"})
+    status, msg = gremlins._read_rescue_marker(p)
+    assert status == "structural"
+    assert msg == "bug in foo.sh"
+
+
+def test_marker_structural_without_summary_uses_fallback(tmp_path):
+    p = _write_marker(tmp_path / "m.json", {"status": "structural"})
+    status, msg = gremlins._read_rescue_marker(p)
+    assert status == "structural"
+    assert msg  # non-empty fallback
+    assert "structural" in msg.lower()
+
+
+def test_marker_unsalvageable_without_summary_uses_fallback(tmp_path):
+    p = _write_marker(tmp_path / "m.json", {"status": "unsalvageable"})
+    status, msg = gremlins._read_rescue_marker(p)
+    assert status == "unsalvageable"
+    assert "unsalvageable" in msg.lower()
+
+
+def test_marker_summary_collapses_whitespace(tmp_path):
+    p = _write_marker(tmp_path / "m.json",
+                       {"status": "fixed", "summary": "line one\nline two\t  end"})
+    status, msg = gremlins._read_rescue_marker(p)
+    assert "\n" not in msg
+    assert "line one" in msg and "line two" in msg
+
+
+def test_marker_summary_capped_to_500_chars(tmp_path):
+    p = _write_marker(tmp_path / "m.json",
+                       {"status": "fixed", "summary": "x" * 1000})
+    status, msg = gremlins._read_rescue_marker(p)
+    assert len(msg) <= 500
+    assert msg.endswith("...")
+
+
+# ---------------------------------------------------------------------------
+# rescue --headless: bail-class exclusion
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bail_class", [
+    "reviewer_requested_changes", "security", "secrets",
+])
+def test_rescue_headless_excludes_class(tmp_path, monkeypatch, capsys, bail_class):
+    gr_dir, _ = _setup_dead_gremlin(
+        tmp_path, monkeypatch,
+        bail_class=bail_class,
+        bail_detail="upstream-set detail",
+    )
+    ok = gremlins.do_rescue("test-id-aabb12", headless=True)
+    assert ok is False
+    new = json.loads((gr_dir / "state.json").read_text())
+    assert new["bail_reason"] == f"excluded_class:{bail_class}"
+    assert new["bail_detail"] == "upstream-set detail"
+    assert new["status"] == "bailed"
+    assert (gr_dir / "finished").exists()
+
+
+def test_rescue_headless_does_not_exclude_other_class(tmp_path, monkeypatch):
+    """`other` is the only attempted class — verify it gets past the exclusion check."""
+    gr_dir, _ = _setup_dead_gremlin(tmp_path, monkeypatch, bail_class="other")
+    # Stub the diagnosis step so the rescue terminates without claude.
+    monkeypatch.setattr(gremlins, "_run_headless_diagnosis",
+                        lambda *a, **kw: ("structural", "fake"))
+    ok = gremlins.do_rescue("test-id-aabb12", headless=True)
+    assert ok is False
+    new = json.loads((gr_dir / "state.json").read_text())
+    # Should bail with "structural" (from the stubbed diagnosis), NOT excluded_class
+    assert new["bail_reason"] == "structural"
+
+
+# ---------------------------------------------------------------------------
+# rescue --headless: attempt cap enforcement
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("rescue_count", [3, 4, 10])
+def test_rescue_headless_at_or_above_cap_refuses(tmp_path, monkeypatch, rescue_count):
+    gr_dir, _ = _setup_dead_gremlin(tmp_path, monkeypatch,
+                                      rescue_count=rescue_count)
+    ok = gremlins.do_rescue("test-id-aabb12", headless=True)
+    assert ok is False
+    new = json.loads((gr_dir / "state.json").read_text())
+    assert new["bail_reason"] == "attempts_exhausted"
+    assert f"reached cap of {gremlins.RESCUE_CAP}" in new["bail_detail"]
+
+
+def test_rescue_headless_below_cap_proceeds_past_check(tmp_path, monkeypatch):
+    gr_dir, _ = _setup_dead_gremlin(tmp_path, monkeypatch,
+                                      rescue_count=gremlins.RESCUE_CAP - 1)
+    # Stub diagnosis so we don't actually run claude
+    monkeypatch.setattr(gremlins, "_run_headless_diagnosis",
+                        lambda *a, **kw: ("structural", "agent flagged"))
+    ok = gremlins.do_rescue("test-id-aabb12", headless=True)
+    assert ok is False
+    new = json.loads((gr_dir / "state.json").read_text())
+    # Bails with "structural" from diagnosis, not "attempts_exhausted"
+    assert new["bail_reason"] == "structural"
+
+
+def test_rescue_headless_running_refused(tmp_path, monkeypatch, capsys):
+    gr_dir, _ = _setup_dead_gremlin(tmp_path, monkeypatch)
+    # Mark as running
+    state = json.loads((gr_dir / "state.json").read_text())
+    state["status"] = "running"
+    state["pid"] = os.getpid()
+    state["exit_code"] = None
+    (gr_dir / "state.json").write_text(json.dumps(state))
+    (gr_dir / "finished").unlink()
+    (gr_dir / "log").write_text("recent")
+
+    ok = gremlins.do_rescue("test-id-aabb12", headless=True)
+    assert ok is False
+    out = capsys.readouterr().out
+    assert "still running" in out
+
+
+# ---------------------------------------------------------------------------
+# do_close — close flow
+# ---------------------------------------------------------------------------
+
+def test_close_dead_gremlin_marks_closed(tmp_path, monkeypatch, capsys):
+    gr_dir, _ = _setup_dead_gremlin(tmp_path, monkeypatch)
+    ok = gremlins.do_close("test-id-aabb12")
+    assert ok is True
+    assert (gr_dir / "closed").exists()
+
+
+def test_close_already_closed_is_idempotent(tmp_path, monkeypatch, capsys):
+    gr_dir, _ = _setup_dead_gremlin(tmp_path, monkeypatch)
+    (gr_dir / "closed").touch()
+    ok = gremlins.do_close("test-id-aabb12")
+    assert ok is True
+    assert "already closed" in capsys.readouterr().out
+
+
+def test_close_running_refused(tmp_path, monkeypatch, capsys):
+    gr_dir, _ = _setup_dead_gremlin(tmp_path, monkeypatch)
+    state = json.loads((gr_dir / "state.json").read_text())
+    state["status"] = "running"
+    state["pid"] = os.getpid()
+    state["exit_code"] = None
+    (gr_dir / "state.json").write_text(json.dumps(state))
+    (gr_dir / "finished").unlink()
+    (gr_dir / "log").write_text("recent")
+
+    ok = gremlins.do_close("test-id-aabb12")
+    assert ok is False
+    assert not (gr_dir / "closed").exists()
+    assert "still live" in capsys.readouterr().out
+
+
+def test_close_not_found(tmp_path, monkeypatch, capsys):
+    state_root = tmp_path / "state-root"
+    state_root.mkdir()
+    monkeypatch.setattr(gremlins, "STATE_ROOT", str(state_root))
+    ok = gremlins.do_close("nonexistent-id")
+    assert ok is False
+    assert "no gremlin matched" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# do_land / _land_local — squash path
+# ---------------------------------------------------------------------------
+
+def test_land_local_squash_lands_branch_and_deletes_it(tmp_path, monkeypatch, capsys):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _init_git_repo(project_root)
+
+    branch = "bg/localgremlin/test-id-aabb12"
+    subprocess.run(["git", "checkout", "-b", branch], cwd=project_root,
+                   check=True, capture_output=True)
+    (project_root / "feature.txt").write_text("feature work\n")
+    subprocess.run(["git", "add", "."], cwd=project_root,
+                   check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "feat: add feature.txt"],
+                   cwd=project_root, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "main"], cwd=project_root,
+                   check=True, capture_output=True)
+
+    state_root = tmp_path / "state-root"
+    state_root.mkdir()
+    gr_id = "test-id-aabb12"
+    gr_dir = state_root / gr_id
+    artifacts_dir = gr_dir / "artifacts"
+    artifacts_dir.mkdir(parents=True)
+    (artifacts_dir / "plan.md").write_text(
+        "# Add feature\n\n## Context\nAdd feature.txt to the repo.\n"
+    )
+    workdir = tmp_path / "workdir"  # not actually a worktree; a stand-in
+    workdir.mkdir()
+    state = {
+        "id": gr_id,
+        "kind": "localgremlin",
+        "status": "dead",
+        "exit_code": 0,
+        "setup_kind": "worktree-branch",
+        "branch": branch,
+        "workdir": str(workdir),
+        "project_root": str(project_root),
+    }
+    _write_state(gr_dir, state, finished=True)
+
+    monkeypatch.setattr(gremlins, "STATE_ROOT", str(state_root))
+    monkeypatch.setattr(gremlins, "_synthesize_commit_message_ai",
+                        lambda inputs: ("Add feature.txt to repo",
+                                         "Adds feature.txt with placeholder content."))
+    monkeypatch.chdir(project_root)
+
+    ok = gremlins._land_local(gr_id, str(gr_dir / "state.json"),
+                                str(gr_dir), state, mode="squash")
+    assert ok is True
+
+    log_out = subprocess.run(
+        ["git", "log", "--oneline", "main"], cwd=project_root,
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert "Add feature.txt to repo" in log_out
+
+    branches = subprocess.run(
+        ["git", "branch", "--list", branch], cwd=project_root,
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert branches.strip() == ""
+
+
+def test_land_local_refuses_non_worktree_branch_setup(tmp_path, monkeypatch, capsys):
+    state = {
+        "id": "x",
+        "kind": "localgremlin",
+        "setup_kind": "cp-snapshot",  # not worktree-branch
+        "branch": "bg/localgremlin/x",
+    }
+    ok = gremlins._land_local("x", "/sf", "/wdir", state, mode="squash")
+    assert ok is False
+    assert "only worktree-branch gremlins" in capsys.readouterr().out
+
+
+def test_land_local_refuses_when_branch_missing_from_state(tmp_path, monkeypatch, capsys):
+    state = {
+        "id": "x",
+        "kind": "localgremlin",
+        "setup_kind": "worktree-branch",
+        "branch": "",
+    }
+    ok = gremlins._land_local("x", "/sf", "/wdir", state, mode="squash")
+    assert ok is False
+    assert "no branch field" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Misc small-surface helpers
+# ---------------------------------------------------------------------------
+
+def test_atomic_patch_state_round_trip(tmp_path):
+    sf = tmp_path / "state.json"
+    sf.write_text(json.dumps({"a": 1, "b": 2}))
+    ok = gremlins._atomic_patch_state(str(sf), {"b": 99, "c": 3})
+    assert ok is True
+    new = json.loads(sf.read_text())
+    assert new == {"a": 1, "b": 99, "c": 3}
+
+
+def test_atomic_patch_state_unreadable_file(tmp_path):
+    ok = gremlins._atomic_patch_state(str(tmp_path / "missing.json"), {"a": 1})
+    assert ok is False
+
+
+def test_write_bail_marks_terminal(tmp_path):
+    wdir = tmp_path / "wdir"
+    wdir.mkdir()
+    sf = wdir / "state.json"
+    sf.write_text(json.dumps({"id": "x", "status": "dead", "exit_code": 2}))
+    gremlins._write_bail(str(sf), str(wdir), "structural", "the agent said so")
+    new = json.loads(sf.read_text())
+    assert new["bail_reason"] == "structural"
+    assert new["bail_detail"] == "the agent said so"
+    assert new["status"] == "bailed"
+    assert (wdir / "finished").exists()
+
+
+def test_parse_duration():
+    assert gremlins.parse_duration("30s") == 30
+    assert gremlins.parse_duration("5m") == 300
+    assert gremlins.parse_duration("2h") == 7200
+    assert gremlins.parse_duration("1d") == 86400
+
+
+def test_parse_duration_invalid():
+    with pytest.raises(ValueError):
+        gremlins.parse_duration("5x")
+    with pytest.raises(ValueError):
+        gremlins.parse_duration("abc")

--- a/skills/tests/test_handoff.py
+++ b/skills/tests/test_handoff.py
@@ -1,0 +1,416 @@
+"""Tests for skills/handoff/handoff.py."""
+
+import json
+import pathlib
+import subprocess
+
+import pytest
+
+import handoff
+
+
+# ---------------------------------------------------------------------------
+# auto_name_out — naming convention
+# ---------------------------------------------------------------------------
+
+def test_auto_name_out_default_naming(tmp_path):
+    out = handoff.auto_name_out(tmp_path / "plan.md")
+    assert out == tmp_path / "plan-001.md"
+
+
+def test_auto_name_out_increments_when_taken(tmp_path):
+    (tmp_path / "plan-001.md").touch()
+    (tmp_path / "plan-002.md").touch()
+    out = handoff.auto_name_out(tmp_path / "plan.md")
+    assert out == tmp_path / "plan-003.md"
+
+
+def test_auto_name_out_strips_existing_numeric_suffix(tmp_path):
+    """plan-001.md → plan-002.md (not plan-001-001.md)."""
+    out = handoff.auto_name_out(tmp_path / "plan-001.md")
+    assert out == tmp_path / "plan-001.md"  # next free is 001 since none exist
+    (tmp_path / "plan-001.md").touch()
+    out = handoff.auto_name_out(tmp_path / "plan-001.md")
+    assert out == tmp_path / "plan-002.md"
+
+
+# ---------------------------------------------------------------------------
+# parse_args
+# ---------------------------------------------------------------------------
+
+def test_parse_args_requires_plan():
+    with pytest.raises(SystemExit):
+        handoff.parse_args([])
+
+
+def test_parse_args_defaults():
+    args = handoff.parse_args(["--plan", "/tmp/plan.md"])
+    assert args.plan == "/tmp/plan.md"
+    assert args.spec is None
+    assert args.out is None
+    assert args.base is None
+    assert args.model == "sonnet"
+    assert args.timeout is None
+    assert args.rev is None
+
+
+def test_parse_args_full():
+    args = handoff.parse_args([
+        "--plan", "/p.md", "--spec", "/s.md", "--out", "/o.md",
+        "--base", "develop", "--model", "haiku", "--timeout", "300",
+        "--rev", "feature-branch",
+    ])
+    assert args.plan == "/p.md"
+    assert args.spec == "/s.md"
+    assert args.out == "/o.md"
+    assert args.base == "develop"
+    assert args.model == "haiku"
+    assert args.timeout == 300
+    assert args.rev == "feature-branch"
+
+
+# ---------------------------------------------------------------------------
+# build_prompt — string templating
+# ---------------------------------------------------------------------------
+
+def _prompt_paths(tmp_path):
+    return (
+        tmp_path / "plan-001.md",
+        tmp_path / "plan-001-child.md",
+        tmp_path / "plan-001.state.json",
+    )
+
+
+def test_build_prompt_includes_plan_log_diff_paths(tmp_path):
+    out_p, child_p, sig_p = _prompt_paths(tmp_path)
+    p = handoff.build_prompt(
+        plan_text="# Plan\nDo X.\n",
+        branch="main",
+        git_log="abc msg",
+        git_diff="diff body",
+        out_path=out_p,
+        child_plan_path=child_p,
+        signal_path=sig_p,
+    )
+    assert "Do X." in p
+    assert "abc msg" in p
+    assert "diff body" in p
+    assert str(out_p) in p
+    assert str(child_p) in p
+    assert str(sig_p) in p
+    assert "Branch: main" in p
+
+
+def test_build_prompt_truncates_huge_diff(tmp_path):
+    out_p, child_p, sig_p = _prompt_paths(tmp_path)
+    p = handoff.build_prompt(
+        plan_text="plan", branch="b", git_log="", git_diff="x" * 100000,
+        out_path=out_p, child_plan_path=child_p, signal_path=sig_p,
+    )
+    assert "diff truncated to 50000 chars" in p
+
+
+def test_build_prompt_handles_empty_diff_and_log(tmp_path):
+    out_p, child_p, sig_p = _prompt_paths(tmp_path)
+    p = handoff.build_prompt(
+        plan_text="plan", branch="b", git_log="", git_diff="",
+        out_path=out_p, child_plan_path=child_p, signal_path=sig_p,
+    )
+    assert "(empty — no changes yet)" in p
+    assert "(no commits yet — branch just started)" in p
+
+
+def test_build_prompt_includes_spec_when_given(tmp_path):
+    out_p, child_p, sig_p = _prompt_paths(tmp_path)
+    p = handoff.build_prompt(
+        plan_text="plan", branch="b", git_log="", git_diff="",
+        out_path=out_p, child_plan_path=child_p, signal_path=sig_p,
+        spec_text="Overall north-star context",
+    )
+    assert "Overall north-star context" in p
+    assert "Overarching goal" in p
+
+
+def test_build_prompt_omits_spec_section_by_default(tmp_path):
+    out_p, child_p, sig_p = _prompt_paths(tmp_path)
+    p = handoff.build_prompt(
+        plan_text="plan", branch="b", git_log="", git_diff="",
+        out_path=out_p, child_plan_path=child_p, signal_path=sig_p,
+    )
+    assert "Overarching goal" not in p
+
+
+# ---------------------------------------------------------------------------
+# main — refusal cases
+# ---------------------------------------------------------------------------
+
+def test_main_missing_plan_arg_exits():
+    with pytest.raises(SystemExit):
+        handoff.main([])
+
+
+def test_main_claude_not_in_path(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(handoff.shutil, "which", lambda n: None)
+    with pytest.raises(SystemExit) as exc:
+        handoff.main(["--plan", str(tmp_path / "p.md")])
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "claude CLI not found" in err
+
+
+def test_main_plan_does_not_exist(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(handoff.shutil, "which", lambda n: "/fake/claude")
+    with pytest.raises(SystemExit):
+        handoff.main(["--plan", str(tmp_path / "missing.md")])
+    err = capsys.readouterr().err
+    assert "does not exist" in err
+
+
+def test_main_plan_is_directory(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(handoff.shutil, "which", lambda n: "/fake/claude")
+    d = tmp_path / "plan-dir"
+    d.mkdir()
+    with pytest.raises(SystemExit):
+        handoff.main(["--plan", str(d)])
+    err = capsys.readouterr().err
+    assert "not a file" in err
+
+
+def test_main_plan_is_empty(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(handoff.shutil, "which", lambda n: "/fake/claude")
+    p = tmp_path / "empty.md"
+    p.touch()
+    with pytest.raises(SystemExit):
+        handoff.main(["--plan", str(p)])
+    err = capsys.readouterr().err
+    assert "is empty" in err
+
+
+def test_main_out_parent_does_not_exist(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(handoff.shutil, "which", lambda n: "/fake/claude")
+    p = tmp_path / "plan.md"
+    p.write_text("# Plan\n")
+    with pytest.raises(SystemExit):
+        handoff.main([
+            "--plan", str(p),
+            "--out", str(tmp_path / "missing-dir" / "out.md"),
+        ])
+    err = capsys.readouterr().err
+    assert "parent directory does not exist" in err
+
+
+# ---------------------------------------------------------------------------
+# main — signal parsing (next-plan / chain-done / bail)
+# ---------------------------------------------------------------------------
+
+def _stub_happy_main(monkeypatch, tmp_path, signal_payload, *,
+                      child_plan_text=None, claude_returncode=0,
+                      claude_timeout=False):
+    """Set up a happy-path main() that writes the given signal payload.
+
+    If `child_plan_text` is given, the fake claude run also writes the
+    child plan file to whatever path the prompt says it should go to.
+    Returns the plan path so the caller can pass it to handoff.main.
+    """
+    plan_path = tmp_path / "plan.md"
+    plan_path.write_text("# Plan\nTasks\n- [ ] thing\n")
+
+    monkeypatch.setattr(handoff.shutil, "which", lambda n: "/fake/claude")
+    monkeypatch.setattr(handoff, "collect_git_context",
+                        lambda base_ref, rev=None: ("test-branch", "log line", "diff body"))
+
+    out_path = handoff.auto_name_out(plan_path)
+    sig_path = out_path.parent / (out_path.stem + ".state.json")
+    child_path = out_path.parent / (out_path.stem + "-child" + out_path.suffix)
+
+    def fake_run(cmd, **kwargs):
+        if claude_timeout:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout") or 1)
+        if claude_returncode == 0:
+            sig_path.write_text(json.dumps(signal_payload))
+            if child_plan_text is not None:
+                child_path.write_text(child_plan_text)
+        return subprocess.CompletedProcess(args=cmd, returncode=claude_returncode)
+
+    monkeypatch.setattr(handoff.subprocess, "run", fake_run)
+    return plan_path, sig_path, child_path
+
+
+def test_main_chain_done_signal(monkeypatch, tmp_path, capsys):
+    plan_path, sig_path, _ = _stub_happy_main(monkeypatch, tmp_path, {
+        "exit_state": "chain-done",
+        "child_plan": None,
+        "reason": None,
+        "operator_followups": [],
+    })
+    rc = handoff.main(["--plan", str(plan_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "handoff complete: chain-done" in out
+    assert sig_path.exists()
+
+
+def test_main_next_plan_signal(monkeypatch, tmp_path, capsys):
+    plan_path, sig_path, child_path = _stub_happy_main(
+        monkeypatch, tmp_path,
+        {
+            "exit_state": "next-plan",
+            "child_plan": None,  # filled in by the fake_run write below
+            "reason": None,
+            "operator_followups": [],
+        },
+        child_plan_text="# Next step\n",
+    )
+    # Patch the signal payload to point at the child plan path the wrapper expects.
+    payload = {
+        "exit_state": "next-plan",
+        "child_plan": str(child_path),
+        "reason": None,
+        "operator_followups": [],
+    }
+    monkeypatch.setattr(handoff, "collect_git_context",
+                        lambda base_ref, rev=None: ("b", "", ""))
+    monkeypatch.setattr(handoff.subprocess, "run", lambda cmd, **kw: (
+        sig_path.write_text(json.dumps(payload)),
+        child_path.write_text("# Child\n"),
+        subprocess.CompletedProcess(args=cmd, returncode=0),
+    )[-1])
+
+    rc = handoff.main(["--plan", str(plan_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "handoff complete: next-plan" in out
+    assert "child plan:" in out
+    assert child_path.exists()
+
+
+def test_main_bail_signal(monkeypatch, tmp_path, capsys):
+    plan_path, _, _ = _stub_happy_main(monkeypatch, tmp_path, {
+        "exit_state": "bail",
+        "child_plan": None,
+        "reason": "incoherent state — see plan",
+        "operator_followups": [],
+    })
+    rc = handoff.main(["--plan", str(plan_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "handoff complete: bail" in out
+    assert "incoherent state" in out
+
+
+def test_main_signal_file_not_written(monkeypatch, tmp_path, capsys):
+    plan_path = tmp_path / "plan.md"
+    plan_path.write_text("# Plan\n")
+    monkeypatch.setattr(handoff.shutil, "which", lambda n: "/fake/claude")
+    monkeypatch.setattr(handoff, "collect_git_context",
+                        lambda base_ref, rev=None: ("b", "", ""))
+    # claude returns success but writes no signal file
+    monkeypatch.setattr(handoff.subprocess, "run",
+                        lambda cmd, **kw: subprocess.CompletedProcess(args=cmd, returncode=0))
+    rc = handoff.main(["--plan", str(plan_path)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "signal file not written" in err
+
+
+def test_main_signal_file_invalid_json(monkeypatch, tmp_path, capsys):
+    plan_path, sig_path, _ = _stub_happy_main(monkeypatch, tmp_path, {})
+    # Overwrite with garbage
+    monkeypatch.setattr(handoff.subprocess, "run", lambda cmd, **kw: (
+        sig_path.write_text("not json"),
+        subprocess.CompletedProcess(args=cmd, returncode=0),
+    )[-1])
+    rc = handoff.main(["--plan", str(plan_path)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "could not parse signal file" in err
+
+
+def test_main_signal_unknown_exit_state(monkeypatch, tmp_path, capsys):
+    plan_path, _, _ = _stub_happy_main(monkeypatch, tmp_path, {
+        "exit_state": "bogus",
+    })
+    rc = handoff.main(["--plan", str(plan_path)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "unrecognized exit_state" in err
+
+
+def test_main_next_plan_missing_child_plan(monkeypatch, tmp_path, capsys):
+    plan_path, _, _ = _stub_happy_main(monkeypatch, tmp_path, {
+        "exit_state": "next-plan",
+        "child_plan": None,
+        "reason": None,
+        "operator_followups": [],
+    })
+    rc = handoff.main(["--plan", str(plan_path)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "child_plan is null" in err
+
+
+def test_main_next_plan_child_plan_path_does_not_exist(monkeypatch, tmp_path, capsys):
+    plan_path, _, child_path = _stub_happy_main(monkeypatch, tmp_path, {
+        "exit_state": "next-plan",
+        "child_plan": str(tmp_path / "no-such-child.md"),
+        "reason": None,
+        "operator_followups": [],
+    })
+    rc = handoff.main(["--plan", str(plan_path)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "child plan path in signal file does not exist" in err
+
+
+def test_main_claude_nonzero_exit(monkeypatch, tmp_path, capsys):
+    plan_path, _, _ = _stub_happy_main(monkeypatch, tmp_path, {},
+                                         claude_returncode=2)
+    rc = handoff.main(["--plan", str(plan_path)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "claude -p exited 2" in err
+
+
+def test_main_claude_timeout(monkeypatch, tmp_path, capsys):
+    plan_path, _, _ = _stub_happy_main(monkeypatch, tmp_path, {},
+                                         claude_timeout=True)
+    rc = handoff.main(["--plan", str(plan_path), "--timeout", "5"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "timed out" in err
+
+
+def test_main_operator_followups_printed(monkeypatch, tmp_path, capsys):
+    plan_path, _, _ = _stub_happy_main(monkeypatch, tmp_path, {
+        "exit_state": "chain-done",
+        "child_plan": None,
+        "reason": None,
+        "operator_followups": ["Sync ~/.claude/", "Run smoke test manually"],
+    })
+    rc = handoff.main(["--plan", str(plan_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "operator follow-ups (2):" in out
+    assert "Sync ~/.claude/" in out
+    assert "Run smoke test manually" in out
+
+
+# ---------------------------------------------------------------------------
+# main — spec is best-effort
+# ---------------------------------------------------------------------------
+
+def test_main_missing_spec_warns_and_continues(monkeypatch, tmp_path, capsys):
+    plan_path, _, _ = _stub_happy_main(monkeypatch, tmp_path, {
+        "exit_state": "chain-done",
+        "child_plan": None,
+        "reason": None,
+        "operator_followups": [],
+    })
+    rc = handoff.main([
+        "--plan", str(plan_path),
+        "--spec", str(tmp_path / "no-such-spec.md"),
+    ])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "warning" in err.lower()
+    assert "spec" in err.lower()


### PR DESCRIPTION
## Summary

- Adds `skills/tests/` alongside `pipeline/tests/` with the same shape — mocked `subprocess.run`, real-tmp filesystem fixtures, no live `claude -p` calls.
- 42 tests for `skills/gremlins/gremlins.py` cover liveness state transitions, the rescue marker contract for all four verdicts (`fixed`/`transient`/`structural`/`unsalvageable`) plus missing/unparseable cases, headless-rescue refusals (excluded bail classes, attempt cap parametrized at/above the cap), `do_close` flows, `_land_local` squash end-to-end against a real git repo (with `_synthesize_commit_message_ai` stubbed), and supporting helpers.
- 29 tests for `skills/handoff/handoff.py` cover `auto_name_out` numbering, argparse, `build_prompt` content + diff truncation + optional spec section, all three signal exit states (`next-plan`/`chain-done`/`bail`), and refusal cases (missing/non-file/empty plan, missing claude, bad `--out` parent, signal-file failure modes, claude nonzero/timeout, operator-followups output).
- New `skills/pyproject.toml` configures pytest discovery; `skills/tests/conftest.py` puts `skills/gremlins/` and `skills/handoff/` on `sys.path` so the script-style modules import as plain `import gremlins` / `import handoff`.

## Test plan

- [x] `cd skills && python -m pytest` — 71 passed
- [x] `cd pipeline && python -m pytest` — 64 passed (unchanged, no regression)

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)