### PR TITLE
Shell integration tests: fake claude harness for launch.sh / ghgremlin / localgremlin / rescue

### DIFF
--- a/pipeline/tests/fixtures/fake_claude.py
+++ b/pipeline/tests/fixtures/fake_claude.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python
+"""Drop-in fake `claude` binary for shell integration tests.
+
+Parses `claude -p [flags] <prompt>` argv, classifies the prompt to identify
+which pipeline stage spawned it, performs the side effects that stage's
+post-conditions check for (write plan.md, create a commit, write a review
+file, etc.), and emits minimal valid stream-json (or text) on stdout.
+
+Each invocation appends an entry to ``$FAKE_CLAUDE_LOG`` (one JSON line
+per call) so tests can assert what was invoked, with what model, in what
+cwd. ``$FAKE_CLAUDE_FAIL_AT`` (a stage name) makes the matching invocation
+exit non-zero — used to test rescue / resume paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import time
+import uuid
+
+
+def emit_event(evt: dict) -> None:
+    sys.stdout.write(json.dumps(evt) + "\n")
+    sys.stdout.flush()
+
+
+def emit_minimal_stream(session_id: str, *, extra: list = None) -> None:
+    emit_event({
+        "type": "system", "subtype": "init",
+        "session_id": session_id,
+        "model": "fake", "cwd": os.getcwd(),
+    })
+    for evt in extra or []:
+        emit_event(evt)
+    emit_event({
+        "type": "result", "subtype": "success",
+        "num_turns": 1, "total_cost_usd": 0,
+    })
+
+
+def emit_pr_create_stream(session_id: str, pr_url: str) -> None:
+    tu_id = "tu-" + uuid.uuid4().hex[:8]
+    emit_minimal_stream(
+        session_id,
+        extra=[
+            {"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "id": tu_id, "name": "Bash",
+                 "input": {"command": "gh pr create --base main"}},
+            ]}},
+            {"type": "user", "message": {"content": [
+                {"type": "tool_result", "tool_use_id": tu_id,
+                 "content": pr_url},
+            ]}},
+        ],
+    )
+
+
+def emit_issue_create_stream(session_id: str, issue_url: str) -> None:
+    tu_id = "tu-" + uuid.uuid4().hex[:8]
+    emit_minimal_stream(
+        session_id,
+        extra=[
+            {"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "id": tu_id, "name": "Bash",
+                 "input": {"command": "gh issue create --title foo"}},
+            ]}},
+            {"type": "user", "message": {"content": [
+                {"type": "tool_result", "tool_use_id": tu_id,
+                 "content": issue_url},
+            ]}},
+        ],
+    )
+
+
+def log_invocation(record: dict) -> None:
+    log_path = os.environ.get("FAKE_CLAUDE_LOG")
+    if not log_path:
+        return
+    try:
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+    except OSError:
+        pass
+
+
+def maybe_fail_at(stage: str) -> None:
+    if os.environ.get("FAKE_CLAUDE_FAIL_AT") == stage:
+        sys.stderr.write(f"fake claude: forced failure at {stage}\n")
+        sys.exit(1)
+
+
+def find_path_in_prompt(prompt: str, pattern: str) -> str:
+    m = re.search(pattern, prompt)
+    return m.group(1) if m else ""
+
+
+def git_commit_changes(message: str) -> bool:
+    """Stage all changes and commit. Returns True if a commit was made."""
+    try:
+        subprocess.run(["git", "add", "-A"], check=False, capture_output=True)
+        r = subprocess.run(
+            ["git", "diff", "--cached", "--quiet"],
+            check=False, capture_output=True,
+        )
+        if r.returncode == 0:
+            return False  # nothing staged
+        subprocess.run(
+            ["git", "commit", "-m", message],
+            check=False, capture_output=True,
+        )
+        return True
+    except OSError:
+        return False
+
+
+def handle_plan(prompt: str, session_id: str) -> int:
+    plan_file = find_path_in_prompt(prompt, r"write it to the file `([^`]+)`")
+    if plan_file:
+        pathlib.Path(plan_file).parent.mkdir(parents=True, exist_ok=True)
+        pathlib.Path(plan_file).write_text(
+            "# Test Plan\n\n## Context\nFake claude generated plan.\n\n"
+            "## Tasks\n- [ ] Touch a file\n",
+            encoding="utf-8",
+        )
+    emit_minimal_stream(session_id)
+    return 0
+
+
+def handle_implement(prompt: str, session_id: str) -> int:
+    # Create a new file so review-code's diff is non-empty.
+    target = pathlib.Path("fake_impl.txt")
+    target.write_text("fake implementation\n", encoding="utf-8")
+    in_git = subprocess.run(
+        ["git", "rev-parse", "--git-dir"],
+        capture_output=True, check=False,
+    ).returncode == 0
+    if in_git:
+        # Commit so HEAD advances (post-impl invariant for both local and gh).
+        git_commit_changes("impl: fake implementation")
+    emit_minimal_stream(session_id)
+    return 0
+
+
+def handle_review(prompt: str, session_id: str) -> int:
+    out_file = find_path_in_prompt(prompt, r"`([^`]+\.md)`\s+is the canonical")
+    if out_file:
+        out_path = pathlib.Path(out_file)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            "# Review (fake)\n\n## Summary\nFake review.\n\n"
+            "## Findings\nNo issues.\n",
+            encoding="utf-8",
+        )
+    emit_minimal_stream(session_id)
+    return 0
+
+
+def handle_address(prompt: str, session_id: str) -> int:
+    in_git = subprocess.run(
+        ["git", "rev-parse", "--git-dir"],
+        capture_output=True, check=False,
+    ).returncode == 0
+    if in_git:
+        # Make a no-op edit so address commit lands.
+        target = pathlib.Path("fake_impl.txt")
+        if target.exists():
+            target.write_text("fake implementation (addressed)\n", encoding="utf-8")
+            git_commit_changes("Address review feedback")
+    emit_minimal_stream(session_id)
+    return 0
+
+
+def handle_commit_pr(prompt: str, session_id: str) -> int:
+    pr_url = os.environ.get(
+        "FAKE_CLAUDE_PR_URL", "https://github.com/owner/repo/pull/101"
+    )
+    emit_pr_create_stream(session_id, pr_url)
+    return 0
+
+
+def handle_ghplan(prompt: str, session_id: str) -> int:
+    issue_url = os.environ.get(
+        "FAKE_CLAUDE_ISSUE_URL", "https://github.com/owner/repo/issues/42"
+    )
+    emit_issue_create_stream(session_id, issue_url)
+    return 0
+
+
+def handle_text_title(prompt: str) -> int:
+    # `--plan <file>` flow asks for a one-line GitHub issue title.
+    sys.stdout.write("Test issue title from fake claude\n")
+    sys.stdout.flush()
+    return 0
+
+
+def handle_rescue_diagnosis(prompt: str) -> int:
+    """Rescue diagnosis-step prompt: write the marker file with status from env.
+
+    The marker path is embedded in the prompt; we extract it and write a JSON
+    object. Default verdict is "fixed" — tests override via env to exercise
+    other branches.
+    """
+    m = re.search(r"\b(/[^\s`]+\.done)\b", prompt)
+    marker_path = m.group(1) if m else ""
+    status = os.environ.get("FAKE_CLAUDE_RESCUE_VERDICT", "fixed")
+    summary = os.environ.get("FAKE_CLAUDE_RESCUE_SUMMARY", "fake diagnosis")
+    if marker_path:
+        try:
+            pathlib.Path(marker_path).parent.mkdir(parents=True, exist_ok=True)
+            pathlib.Path(marker_path).write_text(
+                json.dumps({"status": status, "summary": summary}),
+                encoding="utf-8",
+            )
+        except OSError:
+            pass
+    # Probe writability of paths the spec says should be denied. The probe
+    # records observations to FAKE_CLAUDE_LOG so tests can assert what the
+    # diagnosis agent sees from inside the scratch dir.
+    workdir_probe = os.environ.get("FAKE_CLAUDE_RESCUE_WORKDIR_PROBE")
+    if workdir_probe:
+        probe_file = pathlib.Path(workdir_probe) / ".fake_diagnosis_probe"
+        try:
+            probe_file.write_text("probe", encoding="utf-8")
+            log_invocation({
+                "stage": "rescue-probe",
+                "workdir_probe_path": str(probe_file),
+                "workdir_probe_succeeded": True,
+            })
+        except OSError as exc:
+            log_invocation({
+                "stage": "rescue-probe",
+                "workdir_probe_path": str(probe_file),
+                "workdir_probe_succeeded": False,
+                "error": str(exc),
+            })
+    return 0
+
+
+def classify_stage(prompt: str) -> str:
+    """Classify the stage from the prompt string. Order matters — earlier
+    matches win when prompts contain overlapping phrases."""
+    if "diagnosing a failed background gremlin" in prompt:
+        return "rescue-diagnosis"
+    if "Produce a concise GitHub issue title" in prompt:
+        return "plan-title"
+    if "Print ONLY the PR URL on the final line" in prompt:
+        return "commit-pr"
+    if prompt.startswith("/ghreview "):
+        return "ghreview"
+    if prompt.startswith("/ghaddress "):
+        return "ghaddress"
+    if "You are a scope reviewer for a pull request" in prompt:
+        return "scope-review-pr"
+    if prompt.startswith("/ghplan") or "/ghplan" in prompt[:20]:
+        return "ghplan"
+    if "Create a detailed implementation plan" in prompt:
+        return "plan"
+    if "Three independent code reviews" in prompt:
+        return "address"
+    if "is the canonical and required location for your review output" in prompt:
+        return "review"
+    if "Implement every task in the plan above" in prompt:
+        return "implement-local"
+    if "Implement the plan above by making the code changes" in prompt:
+        return "implement-gh"
+    return "unknown"
+
+
+def parse_argv(argv):
+    """Mimic enough of `claude -p`'s flag handling to extract what we care about.
+
+    Returns (output_format, model, prompt, extra_flags).
+    """
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("-p", action="store_true")
+    parser.add_argument("--model", default=None)
+    parser.add_argument("--output-format", default="stream-json")
+    parser.add_argument("--permission-mode", default=None)
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--resume", default=None)
+    args, rest = parser.parse_known_args(argv)
+    # Last positional is the prompt; anything else is extra/unknown.
+    prompt = rest[-1] if rest else ""
+    return args, prompt
+
+
+def main(argv):
+    args, prompt = parse_argv(argv)
+    stage = classify_stage(prompt)
+    session_id = f"sess-{stage}-{uuid.uuid4().hex[:6]}"
+
+    log_invocation({
+        "stage": stage,
+        "model": args.model,
+        "output_format": args.output_format,
+        "resume_session": args.resume,
+        "cwd": os.getcwd(),
+        "prompt_head": prompt[:200],
+    })
+
+    maybe_fail_at(stage)
+
+    if args.output_format == "text":
+        if stage == "plan-title":
+            return handle_text_title(prompt)
+        sys.stdout.write("(fake text output)\n")
+        return 0
+
+    handlers = {
+        "plan": handle_plan,
+        "implement-local": handle_implement,
+        "implement-gh": handle_implement,
+        "review": handle_review,
+        "address": handle_address,
+        "commit-pr": handle_commit_pr,
+        "ghplan": handle_ghplan,
+        "ghreview": lambda p, s: (emit_minimal_stream(s), 0)[1],
+        "ghaddress": lambda p, s: (emit_minimal_stream(s), 0)[1],
+        "scope-review-pr": lambda p, s: (emit_minimal_stream(s), 0)[1],
+        "rescue-diagnosis": lambda p, s: handle_rescue_diagnosis(p),
+    }
+    h = handlers.get(stage)
+    if h is None:
+        sys.stderr.write(f"fake claude: unrecognized stage for prompt head: {prompt[:120]!r}\n")
+        emit_minimal_stream(session_id)
+        return 0
+    if stage == "rescue-diagnosis":
+        return h(prompt, session_id)
+    return h(prompt, session_id)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/pipeline/tests/fixtures/fake_claude.py
+++ b/pipeline/tests/fixtures/fake_claude.py
@@ -21,7 +21,6 @@ import pathlib
 import re
 import subprocess
 import sys
-import time
 import uuid
 
 
@@ -82,11 +81,22 @@ def log_invocation(record: dict) -> None:
     log_path = os.environ.get("FAKE_CLAUDE_LOG")
     if not log_path:
         return
+    # Atomic append: a single os.write() of one bytes payload avoids
+    # interleaved/corrupted lines under the parallel review workers
+    # (3 concurrent claude subprocesses write to this log).
+    payload = (json.dumps(record) + "\n").encode("utf-8")
+    fd = None
     try:
-        with open(log_path, "a", encoding="utf-8") as fh:
-            fh.write(json.dumps(record) + "\n")
+        fd = os.open(log_path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o666)
+        os.write(fd, payload)
     except OSError:
         pass
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
 
 
 def maybe_fail_at(stage: str) -> None:
@@ -206,7 +216,7 @@ def handle_rescue_diagnosis(prompt: str) -> int:
     object. Default verdict is "fixed" — tests override via env to exercise
     other branches.
     """
-    m = re.search(r"\b(/[^\s`]+\.done)\b", prompt)
+    m = re.search(r"(/[^\s`]+\.done)\b", prompt)
     marker_path = m.group(1) if m else ""
     status = os.environ.get("FAKE_CLAUDE_RESCUE_VERDICT", "fixed")
     summary = os.environ.get("FAKE_CLAUDE_RESCUE_SUMMARY", "fake diagnosis")
@@ -219,26 +229,6 @@ def handle_rescue_diagnosis(prompt: str) -> int:
             )
         except OSError:
             pass
-    # Probe writability of paths the spec says should be denied. The probe
-    # records observations to FAKE_CLAUDE_LOG so tests can assert what the
-    # diagnosis agent sees from inside the scratch dir.
-    workdir_probe = os.environ.get("FAKE_CLAUDE_RESCUE_WORKDIR_PROBE")
-    if workdir_probe:
-        probe_file = pathlib.Path(workdir_probe) / ".fake_diagnosis_probe"
-        try:
-            probe_file.write_text("probe", encoding="utf-8")
-            log_invocation({
-                "stage": "rescue-probe",
-                "workdir_probe_path": str(probe_file),
-                "workdir_probe_succeeded": True,
-            })
-        except OSError as exc:
-            log_invocation({
-                "stage": "rescue-probe",
-                "workdir_probe_path": str(probe_file),
-                "workdir_probe_succeeded": False,
-                "error": str(exc),
-            })
     return 0
 
 
@@ -328,10 +318,10 @@ def main(argv):
     h = handlers.get(stage)
     if h is None:
         sys.stderr.write(f"fake claude: unrecognized stage for prompt head: {prompt[:120]!r}\n")
-        emit_minimal_stream(session_id)
-        return 0
-    if stage == "rescue-diagnosis":
-        return h(prompt, session_id)
+        if os.environ.get("FAKE_CLAUDE_ALLOW_UNKNOWN_STAGE") == "1":
+            emit_minimal_stream(session_id)
+            return 0
+        return 1
     return h(prompt, session_id)
 
 

--- a/pipeline/tests/fixtures/fake_gh.py
+++ b/pipeline/tests/fixtures/fake_gh.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+"""Drop-in fake `gh` CLI for shell integration tests.
+
+Stubs the handful of subcommands the gh orchestrator invokes:
+- ``gh repo view --json defaultBranchRef``
+- ``gh repo view --json nameWithOwner -q .nameWithOwner``
+- ``gh issue create``
+- ``gh issue view <ref> [--repo R] --json ...``
+- ``gh pr edit``
+- ``gh pr diff``
+- ``gh api ...`` (review state polling)
+
+Behavior is configurable via env vars:
+- ``FAKE_GH_REPO`` (default ``owner/repo``)
+- ``FAKE_GH_DEFAULT_BRANCH`` (default ``main``)
+- ``FAKE_GH_ISSUE_BODY`` (default ``# Plan\\nDo stuff.\\n``)
+- ``FAKE_GH_ISSUE_URL`` (default ``https://github.com/owner/repo/issues/42``)
+- ``FAKE_GH_COPILOT_STATE`` (default ``APPROVED``)
+
+Each invocation appends one JSON line to ``$FAKE_GH_LOG`` so tests can
+assert what subcommands were called.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+
+def log_invocation(argv) -> None:
+    log_path = os.environ.get("FAKE_GH_LOG")
+    if not log_path:
+        return
+    try:
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"argv": list(argv)}) + "\n")
+    except OSError:
+        pass
+
+
+def main(argv):
+    log_invocation(argv)
+    if not argv:
+        return 0
+    sub = argv[0]
+
+    repo = os.environ.get("FAKE_GH_REPO", "owner/repo")
+    default_branch = os.environ.get("FAKE_GH_DEFAULT_BRANCH", "main")
+
+    if sub == "repo" and len(argv) >= 2 and argv[1] == "view":
+        if "defaultBranchRef" in argv:
+            sys.stdout.write(default_branch + "\n")
+            return 0
+        if "nameWithOwner" in argv:
+            sys.stdout.write(repo + "\n")
+            return 0
+        sys.stdout.write(f"{repo}\n")
+        return 0
+
+    if sub == "issue" and len(argv) >= 2 and argv[1] == "create":
+        url = os.environ.get(
+            "FAKE_GH_ISSUE_URL", "https://github.com/owner/repo/issues/42"
+        )
+        sys.stdout.write(f"Creating issue\n{url}\n")
+        return 0
+
+    if sub == "issue" and len(argv) >= 2 and argv[1] == "view":
+        body = os.environ.get("FAKE_GH_ISSUE_BODY", "# Plan\nDo stuff.\n")
+        if "--jq" in argv:
+            sys.stdout.write(body + "\n")
+            return 0
+        ref = argv[2] if len(argv) > 2 else "42"
+        m = re.match(r"^#?(\d+)$", ref)
+        num = int(m.group(1)) if m else 42
+        url = f"https://github.com/{repo}/issues/{num}"
+        out = json.dumps({"number": num, "url": url, "body": body})
+        sys.stdout.write(out + "\n")
+        return 0
+
+    if sub == "pr" and len(argv) >= 2 and argv[1] == "edit":
+        return 0
+    if sub == "pr" and len(argv) >= 2 and argv[1] == "diff":
+        sys.stdout.write("diff --git a/f b/f\n")
+        return 0
+    if sub == "pr" and len(argv) >= 2 and argv[1] == "merge":
+        return 0
+
+    if sub == "api":
+        state = os.environ.get("FAKE_GH_COPILOT_STATE", "APPROVED")
+        sys.stdout.write(state + "\n")
+        return 0
+
+    # Unknown subcommands: succeed quietly so tests don't fail on tangential calls.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/pipeline/tests/fixtures/fake_gh.py
+++ b/pipeline/tests/fixtures/fake_gh.py
@@ -33,11 +33,21 @@ def log_invocation(argv) -> None:
     log_path = os.environ.get("FAKE_GH_LOG")
     if not log_path:
         return
+    # Atomic append: a single os.write() of one bytes payload avoids
+    # interleaved/corrupted lines if the log is ever shared across processes.
+    payload = (json.dumps({"argv": list(argv)}) + "\n").encode("utf-8")
+    fd = None
     try:
-        with open(log_path, "a", encoding="utf-8") as fh:
-            fh.write(json.dumps({"argv": list(argv)}) + "\n")
+        fd = os.open(log_path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o666)
+        os.write(fd, payload)
     except OSError:
         pass
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
 
 
 def main(argv):
@@ -63,7 +73,9 @@ def main(argv):
         url = os.environ.get(
             "FAKE_GH_ISSUE_URL", "https://github.com/owner/repo/issues/42"
         )
-        sys.stdout.write(f"Creating issue\n{url}\n")
+        # Match real `gh issue create`, which writes only the URL to stdout
+        # so callers can use `URL=$(gh issue create ...)` directly.
+        sys.stdout.write(f"{url}\n")
         return 0
 
     if sub == "issue" and len(argv) >= 2 and argv[1] == "view":

--- a/pipeline/tests/fixtures/shell_env.py
+++ b/pipeline/tests/fixtures/shell_env.py
@@ -8,12 +8,13 @@ paths the test needs to assert against.
 from __future__ import annotations
 
 import dataclasses
+import json
 import os
 import pathlib
+import shlex
 import subprocess
 import sys
 import time
-from typing import Optional
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent.parent
 FIXTURES_DIR = pathlib.Path(__file__).resolve().parent
@@ -35,8 +36,10 @@ class ShellEnv:
 def install_fake_bin(bin_dir: pathlib.Path, name: str, target: pathlib.Path) -> None:
     bin_dir.mkdir(parents=True, exist_ok=True)
     wrapper = bin_dir / name
+    # Quote both paths in case sys.executable or target contains spaces
+    # (e.g. macOS framework Pythons or custom install locations).
     wrapper.write_text(
-        f"#!/usr/bin/env bash\nexec {sys.executable} {target} \"$@\"\n",
+        f"#!/usr/bin/env bash\nexec {shlex.quote(sys.executable)} {shlex.quote(str(target))} \"$@\"\n",
         encoding="utf-8",
     )
     wrapper.chmod(0o755)
@@ -109,7 +112,8 @@ def setup_shell_env(
         # Strip caller's PYTHONPATH; launch.sh will set its own.
     }
     env.pop("PYTHONPATH", None)
-    # Suppress git's hint output so tests get clean stderr.
+    # Disable git's optional locks to reduce lock contention across parallel
+    # test runs (e.g. read-only commands like `git status` skip the index lock).
     env["GIT_OPTIONAL_LOCKS"] = "0"
     return ShellEnv(
         home=home, bin_dir=bin_dir, state_root=state_root, repo=repo,
@@ -138,12 +142,11 @@ def read_fake_claude_log(log_path: pathlib.Path) -> list:
         if not line:
             continue
         try:
-            out.append(__import__("json").loads(line))
+            out.append(json.loads(line))
         except Exception:
             continue
     return out
 
 
 def read_state(state_file: pathlib.Path) -> dict:
-    import json
     return json.loads(state_file.read_text(encoding="utf-8"))

--- a/pipeline/tests/fixtures/shell_env.py
+++ b/pipeline/tests/fixtures/shell_env.py
@@ -1,0 +1,149 @@
+"""Helpers for shell integration tests.
+
+Each test gets its own isolated HOME, XDG_STATE_HOME, PATH, and a real git
+repo. ``setup_shell_env`` returns a populated ``ShellEnv`` dataclass with
+paths the test needs to assert against.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import pathlib
+import subprocess
+import sys
+import time
+from typing import Optional
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent.parent
+FIXTURES_DIR = pathlib.Path(__file__).resolve().parent
+FAKE_CLAUDE = FIXTURES_DIR / "fake_claude.py"
+FAKE_GH = FIXTURES_DIR / "fake_gh.py"
+
+
+@dataclasses.dataclass
+class ShellEnv:
+    home: pathlib.Path
+    bin_dir: pathlib.Path
+    state_root: pathlib.Path
+    repo: pathlib.Path
+    env: dict
+    fake_claude_log: pathlib.Path
+    fake_gh_log: pathlib.Path
+
+
+def install_fake_bin(bin_dir: pathlib.Path, name: str, target: pathlib.Path) -> None:
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    wrapper = bin_dir / name
+    wrapper.write_text(
+        f"#!/usr/bin/env bash\nexec {sys.executable} {target} \"$@\"\n",
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+
+
+def setup_fake_home(home: pathlib.Path) -> None:
+    """Build a minimal ``$HOME/.claude/`` that launch.sh and the pipeline can
+    resolve: skills/, pipeline/, agents/ symlink to the repo's source dirs."""
+    claude_dir = home / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    for name in ("skills", "pipeline", "agents"):
+        link = claude_dir / name
+        if link.is_symlink() or link.exists():
+            continue
+        link.symlink_to(REPO_ROOT / name)
+
+
+def init_git_repo(path: pathlib.Path, *, with_origin: bool = False) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-b", "main"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True, capture_output=True)
+    (path / "README.md").write_text("init\n")
+    subprocess.run(["git", "add", "README.md"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=path, check=True, capture_output=True)
+
+    if with_origin:
+        # Create a bare repo as `origin` and push so ghgremlin's
+        # `git fetch origin <default>` and `worktree add origin/<default>`
+        # have something real to resolve against.
+        bare = path.parent / f"{path.name}.git"
+        subprocess.run(["git", "init", "--bare", "-b", "main", str(bare)], check=True, capture_output=True)
+        subprocess.run(["git", "remote", "add", "origin", str(bare)], cwd=path, check=True, capture_output=True)
+        subprocess.run(["git", "push", "-u", "origin", "main"], cwd=path, check=True, capture_output=True)
+
+
+def setup_shell_env(
+    tmp_path: pathlib.Path,
+    *,
+    with_gh: bool = False,
+    init_repo: bool = True,
+    with_origin: bool = False,
+) -> ShellEnv:
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    setup_fake_home(home)
+
+    bin_dir = tmp_path / "bin"
+    install_fake_bin(bin_dir, "claude", FAKE_CLAUDE)
+    if with_gh:
+        install_fake_bin(bin_dir, "gh", FAKE_GH)
+
+    state_root = tmp_path / "state"
+    state_root.mkdir(parents=True, exist_ok=True)
+
+    repo = tmp_path / "repo"
+    if init_repo:
+        init_git_repo(repo, with_origin=with_origin)
+
+    fake_claude_log = tmp_path / "fake_claude.log"
+    fake_gh_log = tmp_path / "fake_gh.log"
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "XDG_STATE_HOME": str(state_root),
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+        "FAKE_CLAUDE_LOG": str(fake_claude_log),
+        "FAKE_GH_LOG": str(fake_gh_log),
+        # Strip caller's PYTHONPATH; launch.sh will set its own.
+    }
+    env.pop("PYTHONPATH", None)
+    # Suppress git's hint output so tests get clean stderr.
+    env["GIT_OPTIONAL_LOCKS"] = "0"
+    return ShellEnv(
+        home=home, bin_dir=bin_dir, state_root=state_root, repo=repo,
+        env=env, fake_claude_log=fake_claude_log, fake_gh_log=fake_gh_log,
+    )
+
+
+def wait_for_finished(state_dir: pathlib.Path, timeout: float = 60.0) -> bool:
+    """Poll for ``state_dir/finished`` (written by finish.sh on terminal exit).
+    Returns True if found within ``timeout``, False otherwise."""
+    finished = state_dir / "finished"
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if finished.exists():
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def read_fake_claude_log(log_path: pathlib.Path) -> list:
+    if not log_path.exists():
+        return []
+    out = []
+    for line in log_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(__import__("json").loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def read_state(state_file: pathlib.Path) -> dict:
+    import json
+    return json.loads(state_file.read_text(encoding="utf-8"))

--- a/pipeline/tests/test_ghgremlin_shell.py
+++ b/pipeline/tests/test_ghgremlin_shell.py
@@ -1,0 +1,255 @@
+"""Shell integration tests for the ghgremlin shim + pipeline.
+
+Drives the gh pipeline end-to-end with a fake `claude` and `gh` on PATH
+and a real throwaway git repo (with a bare `origin` remote so the
+worktree's `git fetch origin` and `worktree add origin/main` resolve).
+
+Covers the contracts the GitHub issue calls out:
+- ``--plan <file>`` posts the file as a GH issue and runs the chain
+- ``--plan <issue-ref>`` resolves an existing issue and runs the chain
+- ``--model`` reaches every claude invocation
+- ``--resume-from <stage>`` skips earlier stages
+- unknown leading flags abort before any state is created
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+
+import pytest
+
+from fixtures.shell_env import (
+    REPO_ROOT,
+    read_fake_claude_log,
+    read_state,
+    setup_shell_env,
+    wait_for_finished,
+)
+
+LAUNCH_SH = REPO_ROOT / "skills" / "_bg" / "launch.sh"
+SHIM_SH = REPO_ROOT / "skills" / "ghgremlin" / "ghgremlin.sh"
+PIPELINE_PARENT = str(REPO_ROOT)
+
+
+def _launch_gh(sh, *args, timeout=30):
+    return subprocess.run(
+        [str(LAUNCH_SH), "--print-id", "ghgremlin", *args],
+        cwd=str(sh.repo), env=sh.env,
+        capture_output=True, text=True, timeout=timeout,
+    )
+
+
+def _launch_raw(sh, *args, timeout=30):
+    """launch.sh with raw argv (no auto-injected --print-id or kind).
+    Used by the unknown-leading-flag rejection test which depends on argv
+    order in launch.sh's pre-kind flag-parsing loop."""
+    return subprocess.run(
+        [str(LAUNCH_SH), *args],
+        cwd=str(sh.repo), env=sh.env,
+        capture_output=True, text=True, timeout=timeout,
+    )
+
+
+def _run_shim_directly(sh, *args, timeout=30):
+    """Invoke the ghgremlin.sh shim directly (no launch.sh, no background).
+
+    The shim execs `python -m pipeline.cli gh "$@"`, so this exercises the
+    arg-forwarding contract end-to-end without the worktree+state machinery.
+    """
+    env = {
+        **sh.env,
+        "PYTHONPATH": f"{PIPELINE_PARENT}{':' + sh.env['PYTHONPATH'] if 'PYTHONPATH' in sh.env else ''}",
+    }
+    return subprocess.run(
+        [str(SHIM_SH), *args],
+        cwd=str(sh.repo), env=env,
+        capture_output=True, text=True, timeout=timeout,
+    )
+
+
+def test_ghgremlin_unknown_flag_rejected_at_launch_sh(tmp_path):
+    """An unknown flag *before* the kind in launch.sh must error before any state."""
+    sh = setup_shell_env(tmp_path, with_gh=True, with_origin=True)
+    r = _launch_raw(sh, "--bogus", "ghgremlin", "test", timeout=10)
+    assert r.returncode != 0, f"stdout={r.stdout!r} stderr={r.stderr!r}"
+    assert "unknown flag" in (r.stderr.lower() + r.stdout.lower())
+
+
+def test_ghgremlin_unknown_pipeline_flag_rejected(tmp_path):
+    """Unknown flag in ghgremlin's own arg space (after the kind) must abort."""
+    sh = setup_shell_env(tmp_path, with_gh=True, with_origin=True)
+    r = _run_shim_directly(sh, "--no-such-flag", "test", timeout=10)
+    assert r.returncode != 0
+    # argparse emits to stderr; pipeline.cli's die() also goes to stderr.
+    assert "unrecognized" in r.stderr.lower() or "error" in r.stderr.lower()
+
+
+def test_ghgremlin_shim_forwards_to_pipeline_cli(tmp_path):
+    """ghgremlin.sh shim is a thin exec into `python -m pipeline.cli gh`.
+
+    Invoke it with no args and confirm the orchestrator emits its own
+    usage error (proving control reached pipeline.cli gh's argparse).
+    """
+    sh = setup_shell_env(tmp_path, with_gh=True, with_origin=True)
+    r = _run_shim_directly(sh, timeout=10)
+    # No instructions and no --plan → usage failure with non-zero exit.
+    assert r.returncode != 0
+    combined = r.stdout + r.stderr
+    assert "usage" in combined.lower() or "instructions" in combined.lower()
+
+
+def test_ghgremlin_plan_file_full_chain(tmp_path):
+    """`--plan <file>`: file is posted as an issue, plan stage skipped,
+    implement → commit-pr → request-copilot → ghreview → wait-copilot →
+    ghaddress all run."""
+    sh = setup_shell_env(tmp_path, with_gh=True, with_origin=True)
+    plan_file = sh.repo / "spec.md"
+    plan_file.write_text("# Add login\n\n## Tasks\n- [ ] login\n", encoding="utf-8")
+
+    r = _launch_gh(sh, "--plan", str(plan_file))
+    assert r.returncode == 0, r.stderr
+    gr_id = r.stdout.strip()
+    state_dir = sh.state_root / "claude-gremlins" / gr_id
+    assert wait_for_finished(state_dir, timeout=120), \
+        f"pipeline did not finish; log:\n{(state_dir / 'log').read_text(errors='replace')[-3000:]}"
+
+    state = read_state(state_dir / "state.json")
+    assert state["status"] == "done", \
+        f"expected done, got {state.get('status')}; log tail:\n" \
+        f"{(state_dir / 'log').read_text(errors='replace')[-3000:]}"
+    assert state["exit_code"] == 0
+    assert state.get("issue_url", "").startswith("https://github.com/")
+    assert state.get("pr_url", "").startswith("https://github.com/")
+
+    log = read_fake_claude_log(sh.fake_claude_log)
+    stages = [e["stage"] for e in log]
+    # plan-title runs because --plan <file> needs a title via claude text mode.
+    assert "plan-title" in stages
+    # plan stage (the /ghplan one) must NOT run because --plan supplied.
+    assert "ghplan" not in stages
+    assert "implement-gh" in stages
+    assert "commit-pr" in stages
+    assert "ghreview" in stages
+    assert "ghaddress" in stages
+
+
+def test_ghgremlin_plan_issue_ref(tmp_path):
+    """`--plan 42`: resolve issue body via gh, no plan-title call needed."""
+    sh = setup_shell_env(tmp_path, with_gh=True, with_origin=True)
+    sh.env["FAKE_GH_ISSUE_BODY"] = "# Resolve issue 42\n\nDo the thing.\n"
+
+    r = _launch_gh(sh, "--plan", "42")
+    assert r.returncode == 0, r.stderr
+    gr_id = r.stdout.strip()
+    state_dir = sh.state_root / "claude-gremlins" / gr_id
+    assert wait_for_finished(state_dir, timeout=120), \
+        f"pipeline did not finish; log:\n{(state_dir / 'log').read_text(errors='replace')[-3000:]}"
+
+    state = read_state(state_dir / "state.json")
+    assert state["status"] == "done"
+    # Plan body got snapshot to artifacts.
+    plan_md = state_dir / "artifacts" / "plan.md"
+    assert plan_md.exists()
+    assert "Resolve issue 42" in plan_md.read_text(encoding="utf-8")
+
+    log = read_fake_claude_log(sh.fake_claude_log)
+    stages = [e["stage"] for e in log]
+    # No plan-title (no file to title), no /ghplan (--plan supplied).
+    assert "plan-title" not in stages
+    assert "ghplan" not in stages
+    assert "implement-gh" in stages
+
+
+def test_ghgremlin_model_forwarded_to_all_stages(tmp_path):
+    """`--model X` is forwarded as `--model X` to every claude invocation."""
+    sh = setup_shell_env(tmp_path, with_gh=True, with_origin=True)
+    r = _launch_gh(sh, "--plan", "7", "--model", "claude-opus-4-7")
+    assert r.returncode == 0, r.stderr
+    gr_id = r.stdout.strip()
+    state_dir = sh.state_root / "claude-gremlins" / gr_id
+    assert wait_for_finished(state_dir, timeout=120)
+
+    log = read_fake_claude_log(sh.fake_claude_log)
+    # Every recorded claude call must carry the model flag.
+    pipeline_stages = {"implement-gh", "commit-pr", "ghreview", "ghaddress", "scope-review-pr"}
+    for entry in log:
+        if entry["stage"] in pipeline_stages:
+            assert entry["model"] == "claude-opus-4-7", \
+                f"stage {entry['stage']} got model={entry['model']!r}"
+
+
+def test_ghgremlin_resume_from_ghreview(tmp_path):
+    """`--resume-from ghreview` skips plan/implement/commit-pr/request-copilot."""
+    sh = setup_shell_env(tmp_path, with_gh=True, with_origin=True)
+    plan_file = sh.repo / "spec.md"
+    plan_file.write_text("# Plan\n\n## Tasks\n- [ ] foo\n", encoding="utf-8")
+
+    # First, a normal run that gets through commit-pr, so state.json carries
+    # issue_url / pr_url for the resume to pick up.
+    r = _launch_gh(sh, "--plan", str(plan_file))
+    assert r.returncode == 0, r.stderr
+    gr_id = r.stdout.strip()
+    state_dir = sh.state_root / "claude-gremlins" / gr_id
+    assert wait_for_finished(state_dir, timeout=120)
+
+    # Snapshot what was called the first time, then clear the log.
+    initial_calls = read_fake_claude_log(sh.fake_claude_log)
+    sh.fake_claude_log.write_text("", encoding="utf-8")
+
+    # Resume from ghreview. Use launch.sh --resume which re-applies pipeline_args.
+    # But --resume-from isn't part of the original pipeline_args; we need a
+    # second --resume-from passed through. Simplest: re-launch the orchestrator
+    # via the shim with the persisted state pointing to the same artifacts.
+    sh.env["GR_ID"] = gr_id  # so resolve_session_dir picks the same artifacts/
+    r = _run_shim_directly(
+        sh, "--plan", str(plan_file), "--resume-from", "ghreview",
+        timeout=60,
+    )
+    assert r.returncode == 0, f"stderr:\n{r.stderr}\nstdout:\n{r.stdout}"
+
+    log = read_fake_claude_log(sh.fake_claude_log)
+    stages = [e["stage"] for e in log]
+    assert "implement-gh" not in stages, f"resume should skip implement: {stages}"
+    assert "commit-pr" not in stages, f"resume should skip commit-pr: {stages}"
+    # ghreview onward must have run.
+    assert "ghreview" in stages
+    assert "ghaddress" in stages
+
+    # First run also ran the full chain; sanity-check.
+    initial_stages = [e["stage"] for e in initial_calls]
+    assert "implement-gh" in initial_stages
+
+
+def test_ghgremlin_resume_from_implement(tmp_path):
+    """`--resume-from implement`: plan stage skipped (no /ghplan), but the
+    pipeline can still rehydrate issue body from state.json."""
+    sh = setup_shell_env(tmp_path, with_gh=True, with_origin=True)
+    # Pre-seed a state.json + plan.md to simulate a prior run.
+    plan_file = sh.repo / "spec.md"
+    plan_file.write_text("# Plan resume\n", encoding="utf-8")
+
+    # First run gets through implement+commit-pr.
+    r = _launch_gh(sh, "--plan", str(plan_file))
+    assert r.returncode == 0
+    gr_id = r.stdout.strip()
+    state_dir = sh.state_root / "claude-gremlins" / gr_id
+    assert wait_for_finished(state_dir, timeout=120)
+
+    # Clear log; resume from implement.
+    sh.fake_claude_log.write_text("", encoding="utf-8")
+    sh.env["GR_ID"] = gr_id
+    r = _run_shim_directly(
+        sh, "--plan", str(plan_file), "--resume-from", "implement",
+        timeout=60,
+    )
+    assert r.returncode == 0, r.stderr
+
+    log = read_fake_claude_log(sh.fake_claude_log)
+    stages = [e["stage"] for e in log]
+    # No plan-title (plan.md already snapshot, --plan resolves from snapshot).
+    assert "plan-title" not in stages, stages
+    # implement onward.
+    assert "implement-gh" in stages
+    assert "commit-pr" in stages

--- a/pipeline/tests/test_ghgremlin_shell.py
+++ b/pipeline/tests/test_ghgremlin_shell.py
@@ -14,11 +14,8 @@ Covers the contracts the GitHub issue calls out:
 
 from __future__ import annotations
 
-import json
-import pathlib
+import os
 import subprocess
-
-import pytest
 
 from fixtures.shell_env import (
     REPO_ROOT,
@@ -58,10 +55,9 @@ def _run_shim_directly(sh, *args, timeout=30):
     The shim execs `python -m pipeline.cli gh "$@"`, so this exercises the
     arg-forwarding contract end-to-end without the worktree+state machinery.
     """
-    env = {
-        **sh.env,
-        "PYTHONPATH": f"{PIPELINE_PARENT}{':' + sh.env['PYTHONPATH'] if 'PYTHONPATH' in sh.env else ''}",
-    }
+    existing = sh.env.get("PYTHONPATH", "")
+    new_pp = f"{PIPELINE_PARENT}{os.pathsep + existing if existing else ''}"
+    env = {**sh.env, "PYTHONPATH": new_pp}
     return subprocess.run(
         [str(SHIM_SH), *args],
         cwd=str(sh.repo), env=env,
@@ -174,6 +170,11 @@ def test_ghgremlin_model_forwarded_to_all_stages(tmp_path):
     log = read_fake_claude_log(sh.fake_claude_log)
     # Every recorded claude call must carry the model flag.
     pipeline_stages = {"implement-gh", "commit-pr", "ghreview", "ghaddress", "scope-review-pr"}
+    observed_stages = {e["stage"] for e in log}
+    # Fail fast if any expected stage was silently skipped — otherwise the
+    # per-stage loop below would vacuously pass on a missing stage.
+    assert pipeline_stages.issubset(observed_stages), \
+        f"missing expected stages: {pipeline_stages - observed_stages}; observed: {observed_stages}"
     for entry in log:
         if entry["stage"] in pipeline_stages:
             assert entry["model"] == "claude-opus-4-7", \

--- a/pipeline/tests/test_launch_sh.py
+++ b/pipeline/tests/test_launch_sh.py
@@ -1,0 +1,268 @@
+"""Shell integration tests for skills/_bg/launch.sh.
+
+Drives launch.sh as a real subprocess with a fake `claude` (and `gh` where
+needed) on PATH and a real throwaway git repo. Verifies the on-disk
+contracts the bash script owns: state.json layout, pipeline_args
+persistence, instructions sidecar, --resume rehydration, and unknown-flag
+rejection.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import time
+
+import pytest
+
+from fixtures.shell_env import (
+    REPO_ROOT,
+    read_state,
+    setup_shell_env,
+    wait_for_finished,
+)
+
+LAUNCH_SH = REPO_ROOT / "skills" / "_bg" / "launch.sh"
+
+
+def _run_launch(env, *args, cwd=None, timeout=30):
+    return subprocess.run(
+        [str(LAUNCH_SH), *args],
+        cwd=str(cwd) if cwd else None,
+        env=env, capture_output=True, text=True, timeout=timeout,
+    )
+
+
+def test_launch_sh_local_creates_expected_state_layout(tmp_path):
+    """launch.sh localgremlin: state dir layout + state.json shape."""
+    sh = setup_shell_env(tmp_path)
+    r = _run_launch(
+        sh.env, "--print-id", "localgremlin", "-i", "sonnet", "test instructions",
+        cwd=sh.repo,
+    )
+    assert r.returncode == 0, f"launch.sh failed: {r.stderr}"
+    gr_id = r.stdout.strip()
+    assert gr_id, "expected --print-id to print a gremlin id"
+
+    state_dir = sh.state_root / "claude-gremlins" / gr_id
+    assert state_dir.is_dir(), f"state dir missing: {state_dir}"
+
+    state_file = state_dir / "state.json"
+    assert state_file.exists()
+
+    instructions_file = state_dir / "instructions.txt"
+    assert instructions_file.exists()
+    assert instructions_file.read_text(encoding="utf-8") == "-i sonnet test instructions"
+
+    state = read_state(state_file)
+    assert state["id"] == gr_id
+    assert state["kind"] == "localgremlin"
+    assert state["setup_kind"] == "worktree-branch"
+    assert state["branch"] == f"bg/localgremlin/{gr_id}"
+    assert state["pipeline_args"] == ["-i", "sonnet"]
+    assert state["instructions"].endswith("test instructions")
+    assert "workdir" in state and state["workdir"]
+
+    # Wait for the pipeline to terminate so the test doesn't leave
+    # stray subprocesses behind. Don't assert outcome here — that's a
+    # separate test's concern.
+    wait_for_finished(state_dir, timeout=60)
+
+
+def test_launch_sh_writes_worktree(tmp_path):
+    """localgremlin sets up a `git worktree add -b` worktree at the named branch."""
+    sh = setup_shell_env(tmp_path)
+    r = _run_launch(sh.env, "--print-id", "localgremlin", "test", cwd=sh.repo)
+    assert r.returncode == 0
+    gr_id = r.stdout.strip()
+    state = read_state(sh.state_root / "claude-gremlins" / gr_id / "state.json")
+    workdir = pathlib.Path(state["workdir"])
+    # Worktree dir exists and is a real checkout while the gremlin is
+    # still running. After finish.sh removes it on success the
+    # assertion would race, so check immediately.
+    assert workdir.is_dir(), f"worktree should exist immediately after launch: {workdir}"
+    # `git worktree list` from the source repo must mention this workdir.
+    r = subprocess.run(
+        ["git", "-C", str(sh.repo), "worktree", "list"],
+        capture_output=True, text=True, check=True,
+    )
+    assert str(workdir) in r.stdout
+    wait_for_finished(sh.state_root / "claude-gremlins" / gr_id, timeout=60)
+
+
+def test_launch_sh_persists_pipeline_args_with_models(tmp_path):
+    """Pipeline-level model flags before the positional are persisted verbatim."""
+    sh = setup_shell_env(tmp_path)
+    r = _run_launch(
+        sh.env, "--print-id", "localgremlin",
+        "-p", "opus", "-i", "sonnet", "-x", "haiku",
+        "test", cwd=sh.repo,
+    )
+    assert r.returncode == 0
+    gr_id = r.stdout.strip()
+    state = read_state(sh.state_root / "claude-gremlins" / gr_id / "state.json")
+    assert state["pipeline_args"] == ["-p", "opus", "-i", "sonnet", "-x", "haiku"]
+    wait_for_finished(sh.state_root / "claude-gremlins" / gr_id, timeout=60)
+
+
+def test_launch_sh_unknown_flag_rejected(tmp_path):
+    """Unknown leading flags must abort launch.sh non-zero before any state."""
+    sh = setup_shell_env(tmp_path)
+    r = _run_launch(sh.env, "--bogus-flag", "localgremlin", "test", cwd=sh.repo)
+    assert r.returncode != 0
+    assert "unknown flag" in (r.stderr.lower() + r.stdout.lower())
+    # No state dir should have been created.
+    listing = list((sh.state_root / "claude-gremlins").glob("*")) \
+        if (sh.state_root / "claude-gremlins").exists() else []
+    assert listing == [], f"unknown-flag failure must not create state: {listing}"
+
+
+def test_launch_sh_invalid_kind_rejected(tmp_path):
+    """An unrecognized `kind` positional argument must abort with non-zero."""
+    sh = setup_shell_env(tmp_path)
+    r = _run_launch(sh.env, "notakind", "test", cwd=sh.repo)
+    assert r.returncode != 0
+    assert "invalid kind" in (r.stderr.lower() + r.stdout.lower())
+
+
+def test_launch_sh_resume_rehydrates_pipeline_args(tmp_path):
+    """`launch.sh --resume <id>` reloads pipeline_args + bumps rescue_count."""
+    sh = setup_shell_env(tmp_path)
+    # Force the original gremlin to fail at the plan stage so it leaves a
+    # state dir + finished marker for resume to act on.
+    sh.env["FAKE_CLAUDE_FAIL_AT"] = "plan"
+    r = _run_launch(
+        sh.env, "--print-id", "localgremlin", "-i", "sonnet", "test resume",
+        cwd=sh.repo,
+    )
+    assert r.returncode == 0
+    gr_id = r.stdout.strip()
+    state_dir = sh.state_root / "claude-gremlins" / gr_id
+    assert wait_for_finished(state_dir, timeout=30), \
+        "fake-fail gremlin should have terminated quickly"
+
+    pre_state = read_state(state_dir / "state.json")
+    assert pre_state.get("status") in ("stopped", "done", "running"), pre_state
+    pre_rescue_count = pre_state.get("rescue_count", 0)
+
+    # Now flip the failure off and resume; verify pipeline_args replay and
+    # rescue_count increments.
+    sh.env["FAKE_CLAUDE_FAIL_AT"] = ""
+    r = _run_launch(sh.env, "--resume", gr_id, cwd=sh.repo, timeout=10)
+    assert r.returncode == 0, f"resume failed: {r.stderr}"
+
+    # State.json is rewritten by --resume *before* the spawn — read fresh.
+    post_state = read_state(state_dir / "state.json")
+    assert post_state["rescue_count"] == pre_rescue_count + 1
+    assert post_state["status"] == "running"
+    assert post_state["resumed_from_stage"] == "plan"
+    assert post_state["pipeline_args"] == ["-i", "sonnet"]
+    # The `finished` marker must have been cleared so liveness no longer
+    # treats the gremlin as terminal.
+    assert not (state_dir / "finished").exists()
+
+    # Wait for the relaunched run to settle. Don't assert outcome — the
+    # plan/implement/review pipeline may not produce a working tree
+    # diff in test conditions; we only care that bookkeeping is right.
+    wait_for_finished(state_dir, timeout=60)
+
+
+def test_launch_sh_resume_refuses_running_gremlin(tmp_path):
+    """`--resume` must refuse a gremlin whose recorded pid is still alive."""
+    sh = setup_shell_env(tmp_path)
+    state_dir = sh.state_root / "claude-gremlins" / "fake-id-deadbe"
+    state_dir.mkdir(parents=True)
+    # Use our own pid as a known-live process. Status=running + live pid
+    # is the precondition launch.sh's resume guard refuses on.
+    state = {
+        "id": "fake-id-deadbe",
+        "kind": "localgremlin",
+        "workdir": str(sh.repo),
+        "branch": "bg/localgremlin/fake-id-deadbe",
+        "stage": "plan",
+        "status": "running",
+        "pid": os.getpid(),
+        "pipeline_args": [],
+    }
+    (state_dir / "state.json").write_text(json.dumps(state), encoding="utf-8")
+    (state_dir / "instructions.txt").write_text("foo", encoding="utf-8")
+
+    r = _run_launch(sh.env, "--resume", "fake-id-deadbe", cwd=sh.repo, timeout=10)
+    assert r.returncode != 0
+    assert "still running" in (r.stderr + r.stdout)
+
+
+def test_launch_sh_resume_refuses_finished_success(tmp_path):
+    """`--resume` must refuse a gremlin that already finished with exit_code=0."""
+    sh = setup_shell_env(tmp_path)
+    state_dir = sh.state_root / "claude-gremlins" / "fake-id-success"
+    state_dir.mkdir(parents=True)
+    state = {
+        "id": "fake-id-success",
+        "kind": "localgremlin",
+        "workdir": str(sh.repo),
+        "branch": "bg/localgremlin/fake-id-success",
+        "stage": "address-code",
+        "status": "done",
+        "exit_code": 0,
+        "pipeline_args": [],
+    }
+    (state_dir / "state.json").write_text(json.dumps(state), encoding="utf-8")
+    (state_dir / "finished").touch()
+    (state_dir / "instructions.txt").write_text("foo", encoding="utf-8")
+
+    r = _run_launch(sh.env, "--resume", "fake-id-success", cwd=sh.repo, timeout=10)
+    assert r.returncode != 0
+    assert "finished successfully" in (r.stderr + r.stdout)
+
+
+def test_launch_sh_plan_file_resolved_to_absolute(tmp_path):
+    """A relative --plan file path must be normalized to absolute in state.json."""
+    sh = setup_shell_env(tmp_path)
+    plan_file = sh.repo / "my-plan.md"
+    plan_file.write_text("# My Plan Heading\n\nBody.\n", encoding="utf-8")
+
+    r = _run_launch(
+        sh.env, "--print-id", "localgremlin", "--plan", "my-plan.md",
+        cwd=sh.repo, timeout=15,
+    )
+    assert r.returncode == 0, r.stderr
+    gr_id = r.stdout.strip()
+    state = read_state(sh.state_root / "claude-gremlins" / gr_id / "state.json")
+    # pipeline_args contains an absolutized path.
+    assert "--plan" in state["pipeline_args"]
+    idx = state["pipeline_args"].index("--plan")
+    persisted = state["pipeline_args"][idx + 1]
+    assert os.path.isabs(persisted), f"path should be absolute: {persisted}"
+    assert pathlib.Path(persisted).name == "my-plan.md"
+    # H1 from plan file becomes the description.
+    assert state["description"].startswith("My Plan Heading")
+    wait_for_finished(sh.state_root / "claude-gremlins" / gr_id, timeout=60)
+
+
+def test_launch_sh_plan_and_positional_mutex(tmp_path):
+    """`--plan` and positional instructions are mutually exclusive."""
+    sh = setup_shell_env(tmp_path)
+    plan_file = sh.repo / "plan.md"
+    plan_file.write_text("# X\n", encoding="utf-8")
+    r = _run_launch(
+        sh.env, "localgremlin", "--plan", str(plan_file), "extra positional",
+        cwd=sh.repo, timeout=10,
+    )
+    assert r.returncode != 0
+    assert "mutually exclusive" in (r.stderr + r.stdout)
+
+
+def test_launch_sh_localgremlin_empty_plan_file_rejected(tmp_path):
+    """localgremlin's --plan must reject an empty file before creating state."""
+    sh = setup_shell_env(tmp_path)
+    empty = sh.repo / "empty-plan.md"
+    empty.write_text("", encoding="utf-8")
+    r = _run_launch(
+        sh.env, "localgremlin", "--plan", str(empty),
+        cwd=sh.repo, timeout=10,
+    )
+    assert r.returncode != 0
+    assert "empty" in (r.stderr + r.stdout)

--- a/pipeline/tests/test_launch_sh.py
+++ b/pipeline/tests/test_launch_sh.py
@@ -13,9 +13,6 @@ import json
 import os
 import pathlib
 import subprocess
-import time
-
-import pytest
 
 from fixtures.shell_env import (
     REPO_ROOT,

--- a/pipeline/tests/test_localgremlin_shell.py
+++ b/pipeline/tests/test_localgremlin_shell.py
@@ -7,11 +7,7 @@ git repo. Verifies stage ordering and per-stage artifacts on disk.
 
 from __future__ import annotations
 
-import json
-import pathlib
 import subprocess
-
-import pytest
 
 from fixtures.shell_env import (
     REPO_ROOT,

--- a/pipeline/tests/test_localgremlin_shell.py
+++ b/pipeline/tests/test_localgremlin_shell.py
@@ -1,0 +1,103 @@
+"""Shell integration tests for the localgremlin pipeline.
+
+Drives the full plan → implement → review (parallel) → address chain
+via ``launch.sh localgremlin`` with a fake `claude` on PATH and a real
+git repo. Verifies stage ordering and per-stage artifacts on disk.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+
+import pytest
+
+from fixtures.shell_env import (
+    REPO_ROOT,
+    read_fake_claude_log,
+    read_state,
+    setup_shell_env,
+    wait_for_finished,
+)
+
+LAUNCH_SH = REPO_ROOT / "skills" / "_bg" / "launch.sh"
+
+
+def _launch_local(sh, *args, timeout=15):
+    return subprocess.run(
+        [str(LAUNCH_SH), "--print-id", "localgremlin", *args],
+        cwd=str(sh.repo), env=sh.env,
+        capture_output=True, text=True, timeout=timeout,
+    )
+
+
+def test_localgremlin_full_pipeline_via_launch(tmp_path):
+    """plan → implement → review × 3 → address all run, in order, exactly once."""
+    sh = setup_shell_env(tmp_path)
+    r = _launch_local(sh, "test full pipeline")
+    assert r.returncode == 0, r.stderr
+    gr_id = r.stdout.strip()
+
+    state_dir = sh.state_root / "claude-gremlins" / gr_id
+    assert wait_for_finished(state_dir, timeout=120), \
+        f"pipeline did not finish; log:\n{(state_dir / 'log').read_text(errors='replace')[-2000:]}"
+
+    state = read_state(state_dir / "state.json")
+    assert state["status"] == "done", \
+        f"expected done, got {state.get('status')}; log tail:\n" \
+        f"{(state_dir / 'log').read_text(errors='replace')[-2000:]}"
+    assert state["exit_code"] == 0
+
+    # Verify stage ordering from the fake claude log.
+    log = read_fake_claude_log(sh.fake_claude_log)
+    stages = [e["stage"] for e in log]
+    assert stages[0] == "plan", stages
+    assert stages[1] == "implement-local", stages
+    # Three review calls in the middle (any order — they run in parallel).
+    review_count = sum(1 for s in stages if s == "review")
+    assert review_count == 3, f"expected 3 review calls, got {review_count}: {stages}"
+    assert stages[-1] == "address", stages
+
+    # Artifacts exist in the session dir.
+    artifacts = state_dir / "artifacts"
+    assert (artifacts / "plan.md").exists()
+    review_files = list(artifacts.glob("review-code-*.md"))
+    assert len(review_files) == 3, [p.name for p in review_files]
+
+
+def test_localgremlin_model_flags_forwarded(tmp_path):
+    """`-i <model>` reaches the implement stage's claude invocation."""
+    sh = setup_shell_env(tmp_path)
+    r = _launch_local(sh, "-i", "haiku", "test model forwarding")
+    assert r.returncode == 0
+    gr_id = r.stdout.strip()
+    state_dir = sh.state_root / "claude-gremlins" / gr_id
+    assert wait_for_finished(state_dir, timeout=120)
+
+    log = read_fake_claude_log(sh.fake_claude_log)
+    impl_calls = [e for e in log if e["stage"] == "implement-local"]
+    assert len(impl_calls) == 1
+    assert impl_calls[0]["model"] == "haiku", impl_calls[0]
+
+
+def test_localgremlin_plan_mode_skips_plan_stage(tmp_path):
+    """`--plan <path>` copies the plan file and skips the plan claude call."""
+    sh = setup_shell_env(tmp_path)
+    plan = sh.repo / "given-plan.md"
+    plan.write_text("# Provided Plan\n\n## Tasks\n- [ ] Stuff\n", encoding="utf-8")
+
+    r = _launch_local(sh, "--plan", str(plan))
+    assert r.returncode == 0
+    gr_id = r.stdout.strip()
+    state_dir = sh.state_root / "claude-gremlins" / gr_id
+    assert wait_for_finished(state_dir, timeout=120)
+
+    log = read_fake_claude_log(sh.fake_claude_log)
+    stages = [e["stage"] for e in log]
+    assert "plan" not in stages, f"plan stage should have been skipped: {stages}"
+    assert "implement-local" in stages
+    # The supplied plan was snapshot into the artifacts dir.
+    snapshot = state_dir / "artifacts" / "plan.md"
+    assert snapshot.exists()
+    assert snapshot.read_text(encoding="utf-8") == plan.read_text(encoding="utf-8")

--- a/pipeline/tests/test_rescue_phase_a.py
+++ b/pipeline/tests/test_rescue_phase_a.py
@@ -1,0 +1,266 @@
+"""Shell integration tests for `/gremlins rescue` Phase A (the diagnosis step).
+
+The diagnosis step spawns ``claude -p`` with the rescue prompt and reads a
+verdict marker from a known path inside the gremlin's artifacts dir. The
+contract this layer protects:
+
+- The diagnosis agent runs in a *scratch* directory, not the gremlin's
+  worktree. The worktree path is named in the prompt for read access; it
+  must not become the agent's cwd.
+- The agent's verdicts (``fixed`` / ``transient`` / ``structural`` /
+  ``unsalvageable``) drive whether the wrapper writes a bail reason or
+  proceeds to relaunch.
+- A missing / malformed marker results in a wrapper-level bail
+  (``diagnosis_no_marker`` / ``diagnosis_bad_marker``), never silent
+  success.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+from fixtures.shell_env import (
+    REPO_ROOT,
+    install_fake_bin,
+    read_fake_claude_log,
+    setup_shell_env,
+)
+
+
+def _load_gremlins_module():
+    """Load skills/gremlins/gremlins.py as a regular module so do_rescue is callable."""
+    spec = importlib.util.spec_from_file_location(
+        "gremlins_under_test",
+        REPO_ROOT / "skills" / "gremlins" / "gremlins.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_failed_gremlin(state_root: pathlib.Path, workdir: pathlib.Path,
+                         gr_id: str = "victim-abcdef") -> pathlib.Path:
+    """Create the on-disk shape of a gremlin that crashed and is awaiting rescue.
+
+    Returns the state dir path.
+    """
+    state_dir = state_root / "claude-gremlins" / gr_id
+    state_dir.mkdir(parents=True)
+    state = {
+        "id": gr_id,
+        "kind": "localgremlin",
+        "stage": "implement",
+        "status": "stopped",
+        "exit_code": 1,
+        "workdir": str(workdir),
+        "project_root": str(workdir.parent),
+        "description": "test gremlin",
+        "started_at": "2026-04-27T00:00:00Z",
+        "rescue_count": 0,
+    }
+    (state_dir / "state.json").write_text(json.dumps(state), encoding="utf-8")
+    (state_dir / "log").write_text("fake log tail\n", encoding="utf-8")
+    (state_dir / "finished").touch()
+    return state_dir
+
+
+def _patch_state_root(gremlins_mod, state_root: pathlib.Path, monkeypatch):
+    """Point the loaded gremlins module at our test STATE_ROOT."""
+    monkeypatch.setattr(
+        gremlins_mod,
+        "STATE_ROOT",
+        str(state_root / "claude-gremlins"),
+    )
+
+
+def _install_stub_launcher(home: pathlib.Path) -> pathlib.Path:
+    """Replace fake_home/.claude/skills/_bg/launch.sh with a stub that records
+    its argv and exits 0. Returns the path to the recording file.
+
+    The default fake home symlinks ``~/.claude/skills`` straight at the repo's
+    ``skills/`` dir, so writing through that path would clobber the real
+    ``launch.sh`` on disk. Peel the symlink back into a real directory of
+    per-child symlinks so we can replace just ``_bg`` with a stub copy.
+    """
+    skills_dir = home / ".claude" / "skills"
+    if skills_dir.is_symlink():
+        # Peel: replace the symlink with a real directory of per-child links,
+        # then materialize a real `_bg` dir we can safely write into.
+        target = skills_dir.resolve()
+        skills_dir.unlink()
+        skills_dir.mkdir()
+        for child in target.iterdir():
+            (skills_dir / child.name).symlink_to(child)
+    bg = skills_dir / "_bg"
+    if bg.is_symlink():
+        bg.unlink()
+    bg.mkdir(parents=True, exist_ok=True)
+    record_file = home / "stub_launcher_calls.log"
+    record_file.write_text("", encoding="utf-8")
+    launcher = bg / "launch.sh"
+    launcher.write_text(
+        "#!/usr/bin/env bash\n"
+        f"echo \"$@\" >> '{record_file}'\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    launcher.chmod(0o755)
+    return record_file
+
+
+def test_rescue_diagnosis_runs_in_scratch_dir_not_worktree(tmp_path, monkeypatch):
+    """The diagnosis agent's cwd is a /tmp scratch dir, not the gremlin's worktree."""
+    sh = setup_shell_env(tmp_path)
+    state_dir = _make_failed_gremlin(sh.state_root, sh.repo)
+
+    # HOME + PATH already steered by setup_shell_env. Tell our fake claude
+    # to declare unsalvageable so the wrapper bails (no relaunch needed)
+    # — this test only cares about cwd, not the relaunch path.
+    sh.env["FAKE_CLAUDE_RESCUE_VERDICT"] = "unsalvageable"
+    for k, v in sh.env.items():
+        monkeypatch.setenv(k, v)
+
+    gremlins_mod = _load_gremlins_module()
+    _patch_state_root(gremlins_mod, sh.state_root, monkeypatch)
+
+    ok = gremlins_mod.do_rescue("victim-abcdef", headless=False)
+    # unsalvageable verdict returns False (no relaunch). That's expected.
+    assert ok is False
+
+    log = read_fake_claude_log(sh.fake_claude_log)
+    rescue_calls = [e for e in log if e["stage"] == "rescue-diagnosis"]
+    assert len(rescue_calls) == 1, log
+    cwd = rescue_calls[0]["cwd"]
+    # cwd must be a scratch dir, not the worktree.
+    assert pathlib.Path(cwd).resolve() != sh.repo.resolve(), \
+        f"diagnosis must run in scratch, not worktree ({cwd})"
+    assert "gremlin-rescue-" in cwd, \
+        f"expected scratch dir prefix gremlin-rescue-, got {cwd}"
+
+
+def test_rescue_unsalvageable_records_bail(tmp_path, monkeypatch):
+    """An ``unsalvageable`` marker writes ``bail_reason=unsalvageable``."""
+    sh = setup_shell_env(tmp_path)
+    state_dir = _make_failed_gremlin(sh.state_root, sh.repo)
+
+    sh.env["FAKE_CLAUDE_RESCUE_VERDICT"] = "unsalvageable"
+    sh.env["FAKE_CLAUDE_RESCUE_SUMMARY"] = "worktree gone"
+    for k, v in sh.env.items():
+        monkeypatch.setenv(k, v)
+
+    gremlins_mod = _load_gremlins_module()
+    _patch_state_root(gremlins_mod, sh.state_root, monkeypatch)
+
+    gremlins_mod.do_rescue("victim-abcdef", headless=False)
+
+    state = json.loads((state_dir / "state.json").read_text())
+    assert state["bail_reason"] == "unsalvageable"
+    assert "worktree gone" in state.get("bail_detail", "")
+    assert state["status"] == "bailed"
+
+
+def test_rescue_structural_records_bail(tmp_path, monkeypatch):
+    """A ``structural`` marker writes ``bail_reason=structural`` with the agent's summary."""
+    sh = setup_shell_env(tmp_path)
+    state_dir = _make_failed_gremlin(sh.state_root, sh.repo)
+
+    sh.env["FAKE_CLAUDE_RESCUE_VERDICT"] = "structural"
+    sh.env["FAKE_CLAUDE_RESCUE_SUMMARY"] = "pipeline bug in foo.py"
+    for k, v in sh.env.items():
+        monkeypatch.setenv(k, v)
+
+    gremlins_mod = _load_gremlins_module()
+    _patch_state_root(gremlins_mod, sh.state_root, monkeypatch)
+
+    gremlins_mod.do_rescue("victim-abcdef", headless=False)
+
+    state = json.loads((state_dir / "state.json").read_text())
+    assert state["bail_reason"] == "structural"
+    assert "pipeline bug in foo.py" in state.get("bail_detail", "")
+
+
+def test_rescue_no_marker_records_diagnosis_no_marker(tmp_path, monkeypatch):
+    """Agent that returns 0 without writing the marker → diagnosis_no_marker bail."""
+    sh = setup_shell_env(tmp_path)
+    # Override the fake claude with a stub that emits no marker but exits 0.
+    no_marker_claude = tmp_path / "no_marker_claude.py"
+    no_marker_claude.write_text(
+        "#!/usr/bin/env python\nimport sys\nsys.exit(0)\n",
+        encoding="utf-8",
+    )
+    install_fake_bin(sh.bin_dir, "claude", no_marker_claude)
+
+    state_dir = _make_failed_gremlin(sh.state_root, sh.repo)
+
+    for k, v in sh.env.items():
+        monkeypatch.setenv(k, v)
+
+    gremlins_mod = _load_gremlins_module()
+    _patch_state_root(gremlins_mod, sh.state_root, monkeypatch)
+
+    gremlins_mod.do_rescue("victim-abcdef", headless=False)
+
+    state = json.loads((state_dir / "state.json").read_text())
+    assert state["bail_reason"] == "diagnosis_no_marker"
+
+
+def test_rescue_fixed_verdict_invokes_launcher_resume(tmp_path, monkeypatch):
+    """A ``fixed`` marker triggers ``launch.sh --resume <id>``.
+
+    Replaces the launcher with a recording stub so we don't actually fork a
+    background pipeline; the test verifies the wrapper called it with the
+    right argv and reported relaunch_outcome=success.
+    """
+    sh = setup_shell_env(tmp_path)
+    state_dir = _make_failed_gremlin(sh.state_root, sh.repo)
+
+    record_file = _install_stub_launcher(sh.home)
+
+    sh.env["FAKE_CLAUDE_RESCUE_VERDICT"] = "fixed"
+    sh.env["FAKE_CLAUDE_RESCUE_SUMMARY"] = "edited state.json"
+    for k, v in sh.env.items():
+        monkeypatch.setenv(k, v)
+
+    gremlins_mod = _load_gremlins_module()
+    _patch_state_root(gremlins_mod, sh.state_root, monkeypatch)
+
+    ok = gremlins_mod.do_rescue("victim-abcdef", headless=False)
+    assert ok is True
+
+    recorded = record_file.read_text(encoding="utf-8").strip().splitlines()
+    assert len(recorded) == 1, recorded
+    assert "--resume" in recorded[0]
+    assert "victim-abcdef" in recorded[0]
+
+
+def test_rescue_headless_excluded_class_refused(tmp_path, monkeypatch):
+    """Headless rescue refuses gremlins whose bail_class is in the exclusion list."""
+    sh = setup_shell_env(tmp_path)
+    state_dir = _make_failed_gremlin(sh.state_root, sh.repo)
+    # Add an excluded bail_class to the existing victim state.
+    state = json.loads((state_dir / "state.json").read_text())
+    state["bail_class"] = "secrets"
+    state["bail_detail"] = "diff touches secrets"
+    (state_dir / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+    for k, v in sh.env.items():
+        monkeypatch.setenv(k, v)
+
+    gremlins_mod = _load_gremlins_module()
+    _patch_state_root(gremlins_mod, sh.state_root, monkeypatch)
+
+    ok = gremlins_mod.do_rescue("victim-abcdef", headless=True)
+    assert ok is False
+
+    final = json.loads((state_dir / "state.json").read_text())
+    assert final["bail_reason"] == "excluded_class:secrets"
+    # Fake claude must not have been spawned at all.
+    log = read_fake_claude_log(sh.fake_claude_log)
+    assert all(e["stage"] != "rescue-diagnosis" for e in log), log

--- a/pipeline/tests/test_rescue_phase_a.py
+++ b/pipeline/tests/test_rescue_phase_a.py
@@ -17,14 +17,10 @@ contract this layer protects:
 
 from __future__ import annotations
 
+import datetime
 import importlib.util
 import json
-import os
 import pathlib
-import subprocess
-import sys
-
-import pytest
 
 from fixtures.shell_env import (
     REPO_ROOT,
@@ -62,7 +58,7 @@ def _make_failed_gremlin(state_root: pathlib.Path, workdir: pathlib.Path,
         "workdir": str(workdir),
         "project_root": str(workdir.parent),
         "description": "test gremlin",
-        "started_at": "2026-04-27T00:00:00Z",
+        "started_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "rescue_count": 0,
     }
     (state_dir / "state.json").write_text(json.dumps(state), encoding="utf-8")


### PR DESCRIPTION
## Summary

Layer 2 of the test plan from #58: 28 new shell-integration tests that drive the gremlin shell scripts end-to-end with a fake `claude` (and `gh` where needed) on PATH and a real throwaway git repo per test. Catches subprocess-invocation pathway issues (CLAUDE_FLAGS, --output-format, --resume, --model forwarding) that the FakeClaudeClient Python tests can't reach.

### Fixtures (`pipeline/tests/fixtures/`)

- **`fake_claude.py`** — classifies stages by prompt content, performs the on-disk side effects each stage's post-condition checks for (write plan.md, commit, write review file, write rescue marker), and emits valid stream-json or text. Records each invocation to ` ${FAKE_CLAUDE_LOG}` so tests can assert what was called with what model in what cwd. `FAKE_CLAUDE_FAIL_AT=<stage>` forces a non-zero exit.
- **`fake_gh.py`** — stubs `gh repo view`, `gh issue create`/`view`, `gh pr edit`/`diff`/`merge`, `gh api`. Behavior configurable via env.
- **`shell_env.py`** — `setup_shell_env(tmp_path, …)` builds an isolated HOME/PATH/XDG_STATE_HOME, real git repo (with optional bare `origin` remote so ghgremlin's `git fetch origin` resolves), and symlinks `~/.claude/{skills,pipeline,agents}` at the repo so launch.sh's hardcoded `\$HOME/.claude/...` paths resolve.

### Coverage

- **`test_launch_sh.py`** (11) — state dir layout, `pipeline_args` persistence, `--resume` rehydration + `rescue_count` bump, running / finished-success refusals, `--plan` path absolutization, mutex with positional, empty-plan rejection, unknown-flag / invalid-kind rejection.
- **`test_localgremlin_shell.py`** (3) — full plan→implement→review×3→address chain via `launch.sh`, `-i <model>` forwarding, `--plan <file>` skips the plan stage.
- **`test_ghgremlin_shell.py`** (8) — unknown-flag rejection at both launch.sh and pipeline.cli levels, shim forwards to `pipeline.cli gh`, `--plan <file>` posts an issue / `--plan <issue-ref>` resolves an existing one, `--model` forwarded to every claude call, `--resume-from ghreview` / `--resume-from implement`.
- **`test_rescue_phase_a.py`** (6) — diagnosis agent's cwd is the scratch dir not the worktree, `unsalvageable` / `structural` markers write the right `bail_reason`, missing marker → `diagnosis_no_marker`, `fixed` verdict invokes `launch.sh --resume <id>`, headless rescue refuses excluded bail classes without ever spawning claude.

All 92 tests (64 existing + 28 new) pass; full suite runs in ~30s.

Closes #127

## Test plan

- [x] Run `cd pipeline && PYTHONPATH=. python -m pytest tests/` — 92 passed
- [x] Run each new test file in isolation to confirm it passes solo
- [x] Verify launch.sh / pipeline.cli / gremlins.py source files unchanged from main (only test additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)