### PR TITLE
ci: add GitHub Actions workflow for pipeline tests

### DIFF
--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -7,8 +7,21 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Cancel superseded PR runs; keep main-branch runs independent so push-to-main
+# CI history has no gaps.
+concurrency:
+  group: pipeline-tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Least-privilege: this workflow only checks out code and runs tests.
+permissions:
+  contents: read
+
 jobs:
   pipeline-tests:
+    # Explicit `name:` locks the displayed status-check name to `pipeline-tests`
+    # for branch-protection required-checks wiring, even if the job key is
+    # later renamed.
     name: pipeline-tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -20,7 +33,9 @@ jobs:
           python-version: '3.9'
 
       - name: Install pytest
-        run: python -m pip install --upgrade pip pytest
+        # Pin pytest below 8.4 — pytest 8.4+ drops Python 3.9 support, which
+        # would silently break this workflow once released.
+        run: python -m pip install --upgrade pip "pytest<8.4"
 
       - name: Run pipeline tests
         working-directory: pipeline

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -1,0 +1,27 @@
+name: pipeline-tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  pipeline-tests:
+    name: pipeline-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Install pytest
+        run: python -m pip install --upgrade pip pytest
+
+      - name: Run pipeline tests
+        working-directory: pipeline
+        run: PYTHONPATH=. python -m pytest


### PR DESCRIPTION
## Summary
- Add `.github/workflows/pipeline-tests.yml` that runs `pytest` in `pipeline/` on every PR targeting `main`, every push to `main`, and on manual `workflow_dispatch`.
- Linux runner (`ubuntu-latest`) with Python 3.9, matching `pipeline/pyproject.toml`'s `requires-python`.
- Job name is the stable string `pipeline-tests` so it can be wired into branch-protection required-checks without churn.
- Test command (`cd pipeline && PYTHONPATH=. python -m pytest`) matches what `pipeline/CLAUDE.md` documents; tests provide their own fake `claude`/`gh` binaries, so no secrets or network are required.

## Notes
- `.github/` is not in `scripts/sync.sh`'s `DIR_PAIRS`, so the workflow lives only in this repo and is not mirrored to `~/.claude/`.
- Branch-protection wiring (marking `pipeline-tests` as a required check) is a GitHub UI step and out of scope for this PR — ready to be wired up once this lands.

## Test plan
- [ ] Workflow triggers on this PR and surfaces a `pipeline-tests` status check.
- [ ] Check goes green when tests pass.
- [ ] Verify a deliberately-broken test would fail the check red (manual one-off, not part of this PR).
- [ ] After merge, push to `main` triggers the workflow on the merge commit.
- [ ] `pipeline-tests` appears in branch-protection required-checks picker.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)