### PR TITLE
pipeline/gh: default --model to sonnet

### DIFF
--- a/pipeline/orchestrators/gh.py
+++ b/pipeline/orchestrators/gh.py
@@ -296,10 +296,13 @@ def gh_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int:
 
     print(f"==> session: {session_dir}", flush=True)
 
-    # Restore model from state.json when --model not supplied (resume path).
+    # Restore model from state.json when --model not supplied (resume path),
+    # then fall back to "sonnet" for fresh launches without an explicit --model.
+    # Argparse keeps default=None so the resume-restore step can detect "user
+    # didn't pass --model" and prefer the persisted value over the fresh default.
     model = args.model
     if model is None:
-        model = _read_state_field(state_file, "model") or None
+        model = _read_state_field(state_file, "model") or "sonnet"
     if model:
         patch_state(model=model)
 

--- a/pipeline/tests/test_orchestrator_gh.py
+++ b/pipeline/tests/test_orchestrator_gh.py
@@ -464,6 +464,48 @@ def test_model_forwarded_to_all_stages(tmp_path, monkeypatch):
         assert call.model == "claude-opus-4-7", f"stage {call.label!r} got model={call.model!r}"
 
 
+def test_gh_main_defaults_model_to_sonnet(tmp_path, monkeypatch):
+    """Regression: ghgremlin must default --model to sonnet, not fall through
+    to claude's runtime default (which inherits the calling session's model
+    and silently runs every stage on opus when launched from an opus session).
+    """
+    _init_git_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    session_dir, state_file = _patch_common(monkeypatch, tmp_path)
+
+    monkeypatch.setattr(
+        subprocess, "run",
+        _make_gh_subprocess(issue_body="# Plan\nDo stuff.\n"),
+    )
+    monkeypatch.setattr("pipeline.orchestrators.gh.run_ghreview_stage", lambda **kw: None)
+    monkeypatch.setattr("pipeline.orchestrators.gh.run_wait_copilot_stage", lambda **kw: "APPROVED")
+    monkeypatch.setattr("pipeline.orchestrators.gh.run_request_copilot_stage", lambda **kw: None)
+    monkeypatch.setattr("pipeline.orchestrators.gh.run_ghaddress_stage", lambda **kw: None)
+
+    client = _CommittingClient(
+        git_dir=tmp_path,
+        fixtures={
+            "implement": IMPL_EVENTS,
+            "commit-pr": _pr_events(),
+        },
+    )
+
+    # Invoke with NO --model.
+    result = gh_main(["--plan", "42"], client=client)
+    assert result == 0
+
+    # Every recorded run must have model == "sonnet". Asserting on every call
+    # (not just calls[0]) catches the case where one stage is fixed but
+    # another is overlooked.
+    assert client.calls, "expected at least one client call"
+    bad = [c for c in client.calls if c.model != "sonnet"]
+    assert not bad, (
+        f"{len(bad)} stage(s) ran on a non-sonnet model: "
+        f"{[(c.label, c.model) for c in bad]}"
+    )
+
+
 def test_resume_from_implement(tmp_path, monkeypatch):
     """--resume-from implement reloads issue_url from state.json and runs implement onward."""
     _init_git_repo(tmp_path)

--- a/pipeline/tests/test_orchestrator_gh.py
+++ b/pipeline/tests/test_orchestrator_gh.py
@@ -506,6 +506,67 @@ def test_gh_main_defaults_model_to_sonnet(tmp_path, monkeypatch):
     )
 
 
+def test_gh_main_resume_prefers_persisted_model_over_sonnet_default(tmp_path, monkeypatch):
+    """Regression: on resume with no --model, a persisted state.json.model must
+    win over the fresh-launch "sonnet" fallback. Locks in the other half of the
+    invariant called out in gh.py — a future refactor that switched argparse to
+    default="sonnet" would silently break this precedence and only the
+    fresh-launch test would still pass.
+    """
+    _init_git_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    state_data = {
+        "issue_url": "https://github.com/owner/repo/issues/99",
+        "issue_num": "99",
+        "model": "claude-opus-4-7",
+    }
+    session_dir, state_file = _patch_common(monkeypatch, tmp_path, state_data=state_data)
+
+    monkeypatch.setattr(
+        subprocess, "run",
+        _make_gh_subprocess(issue_body="# Resumed Plan\nDo more stuff.\n"),
+    )
+    monkeypatch.setattr("pipeline.orchestrators.gh.run_ghreview_stage", lambda **kw: None)
+    monkeypatch.setattr("pipeline.orchestrators.gh.run_wait_copilot_stage", lambda **kw: "APPROVED")
+    monkeypatch.setattr("pipeline.orchestrators.gh.run_request_copilot_stage", lambda **kw: None)
+    monkeypatch.setattr("pipeline.orchestrators.gh.run_ghaddress_stage", lambda **kw: None)
+
+    client = _CommittingClient(
+        git_dir=tmp_path,
+        fixtures={
+            "implement": IMPL_EVENTS,
+            "commit-pr": _pr_events(),
+        },
+    )
+
+    import pipeline.orchestrators.gh as _gh_mod
+
+    def _fake_read(sf, field):
+        if field == "issue_url":
+            return "https://github.com/owner/repo/issues/99"
+        if field == "issue_num":
+            return "99"
+        if field == "model":
+            return "claude-opus-4-7"
+        return ""
+
+    monkeypatch.setattr(_gh_mod, "_read_state_field", _fake_read)
+    monkeypatch.setattr(_gh_mod, "_fetch_issue_body", lambda num, repo: "# Resumed Plan\nDo stuff.\n")
+
+    # Invoke with NO --model — resume path should restore "claude-opus-4-7"
+    # from state.json rather than falling through to the "sonnet" default.
+    result = gh_main(["--plan", "99", "--resume-from", "implement"], client=client)
+    assert result == 0
+
+    assert client.calls, "expected at least one client call"
+    bad = [c for c in client.calls if c.model != "claude-opus-4-7"]
+    assert not bad, (
+        f"{len(bad)} stage(s) ignored persisted state.json model: "
+        f"{[(c.label, c.model) for c in bad]}"
+    )
+
+
 def test_resume_from_implement(tmp_path, monkeypatch):
     """--resume-from implement reloads issue_url from state.json and runs implement onward."""
     _init_git_repo(tmp_path)


### PR DESCRIPTION
## Summary

- `pipeline/orchestrators/gh.py` was the only orchestrator without a `--model` default, so `claude -p` was invoked with no `--model` flag and inherited the calling session's model (typically opus). Every stage of a `ghgremlin` run silently ran on opus, contrary to the sonnet convention used by `localgremlin` and `bossgremlin`.
- Argparse keeps `default=None` so the resume path can still detect "user didn't pass `--model`" and prefer the persisted value over the fresh default; the `"sonnet"` fallback is injected only after the resume-restore step.
- Adds a regression test mirroring the local-orchestrator pattern: invokes `gh_main` without `--model` and asserts every recorded `client.run` call has `model == "sonnet"`. The pre-existing `test_model_forwarded_to_all_stages` already covers the positive companion (explicit `--model` propagates).

## Test plan

- [x] `pytest pipeline/tests/test_orchestrator_gh.py` (20 passed, including the new `test_gh_main_defaults_model_to_sonnet`)
- [x] Full `pipeline/tests/` suite (164 passed)

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)