### PR TITLE
ci: pin actions to full commit SHAs for supply-chain hardening

### DIFF
--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
Pins `actions/checkout` and `actions/setup-python` to full commit SHAs so a compromised upstream tag cannot affect CI runs. Tag names are kept as inline comments for readability.

- `actions/checkout` → `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1)
- `actions/setup-python` → `a26af69be951a213d495a4c3e4e4022e16d87065` (v5.6.0)

Closes #139