### PR TITLE
tests: document writability-restriction as out of scope for shell integration layer

### DIFF
--- a/pipeline/tests/test_rescue_phase_a.py
+++ b/pipeline/tests/test_rescue_phase_a.py
@@ -13,6 +13,18 @@ contract this layer protects:
 - A missing / malformed marker results in a wrapper-level bail
   (``diagnosis_no_marker`` / ``diagnosis_bad_marker``), never silent
   success.
+
+Out of scope for this layer — writability restriction:
+  The plan target "only ``state.json`` is writable, ``unsalvageable``
+  declared for anything outside that" is **not testable here**.  The
+  constraint is enforced by the prompt text sent to Claude (listing
+  "permitted edits"), not by any wrapper-level file-system gate.  In
+  headless mode the wrapper runs with ``--permission-mode
+  bypassPermissions``, so Claude's own permission system doesn't gate
+  writes either.  A fake binary can write anything it likes; nothing in
+  the wrapper observes or reacts to unauthorized writes.  Testing this
+  contract would require either running a real Claude agent or adding
+  a wrapper-level enforcement mechanism — neither of which exists today.
 """
 
 from __future__ import annotations

--- a/pipeline/tests/test_rescue_phase_a.py
+++ b/pipeline/tests/test_rescue_phase_a.py
@@ -16,15 +16,17 @@ contract this layer protects:
 
 Out of scope for this layer — writability restriction:
   The plan target "only ``state.json`` is writable, ``unsalvageable``
-  declared for anything outside that" is **not testable here**.  The
-  constraint is enforced by the prompt text sent to Claude (listing
-  "permitted edits"), not by any wrapper-level file-system gate.  In
-  headless mode the wrapper runs with ``--permission-mode
-  bypassPermissions``, so Claude's own permission system doesn't gate
-  writes either.  A fake binary can write anything it likes; nothing in
-  the wrapper observes or reacts to unauthorized writes.  Testing this
-  contract would require either running a real Claude agent or adding
-  a wrapper-level enforcement mechanism — neither of which exists today.
+  declared for anything outside that" is **not implemented or testable
+  here**.  This wrapper does not enforce any file-system restriction.
+  The rescue prompt's "permitted edits" text is guidance only, and the
+  current prompt wording allows edits to files in the gremlin worktree
+  as well as ``state.json``.  In headless mode the wrapper runs with
+  ``--permission-mode bypassPermissions``, so Claude's own permission
+  system doesn't gate writes either.  A fake binary can write anything
+  it likes; nothing in the wrapper observes or reacts to unauthorized
+  writes.  Testing this contract would require either running a real
+  Claude agent or adding a wrapper-level enforcement mechanism —
+  neither of which exists today.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- Adds an explicit out-of-scope note to the `test_rescue_phase_a.py` module docstring explaining why no test exercises the writability restriction
- The constraint ("only `state.json` is writable, `unsalvageable` declared for anything outside that") lives in the prompt text sent to Claude, not in any wrapper-level filesystem gate
- Headless mode runs with `--permission-mode bypassPermissions`, so Claude's own permission system doesn't enforce it either
- A fake binary can write anywhere; nothing in the wrapper detects or reacts to it — testing this would require a real Claude run or a new enforcement mechanism, neither of which exists

## Test plan

- [ ] Existing `test_rescue_phase_a.py` tests continue to pass
- [ ] Docstring clearly explains why the writability restriction test is absent

Closes #135