### PR TITLE
fix: prevent worktree pipeline/ from shadowing HOME/.claude/pipeline/

### DIFF
--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install pytest
         run: python -m pip install --upgrade pip pytest

--- a/pipeline/orchestrators/boss.py
+++ b/pipeline/orchestrators/boss.py
@@ -52,6 +52,7 @@ def _pipeline_cli_env() -> dict:
     env["PYTHONPATH"] = (
         f"{_PIPELINE_PARENT}{os.pathsep}{existing}" if existing else _PIPELINE_PARENT
     )
+    env["PYTHONSAFEPATH"] = "1"
     return env
 
 POLL_INTERVAL = 5  # seconds between finished-marker polls

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -2,7 +2,7 @@
 name = "pipeline"
 version = "0.1.0"
 description = "Shared plan/implement/review/address pipeline for the Claude gremlin skills."
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pipeline/tests/fixtures/fake_claude.py
+++ b/pipeline/tests/fixtures/fake_claude.py
@@ -146,6 +146,10 @@ def handle_implement(prompt: str, session_id: str) -> int:
     # Create a new file so review-code's diff is non-empty.
     target = pathlib.Path("fake_impl.txt")
     target.write_text("fake implementation\n", encoding="utf-8")
+    if os.environ.get("FAKE_CLAUDE_RENAME_PIPELINE") == "1":
+        pd = pathlib.Path("pipeline")
+        if pd.is_dir():
+            pd.rename("gremlins")
     in_git = subprocess.run(
         ["git", "rev-parse", "--git-dir"],
         capture_output=True, check=False,

--- a/pipeline/tests/test_localgremlin_shell.py
+++ b/pipeline/tests/test_localgremlin_shell.py
@@ -7,7 +7,6 @@ git repo. Verifies stage ordering and per-stage artifacts on disk.
 
 from __future__ import annotations
 
-import pathlib
 import subprocess
 
 from fixtures.shell_env import (
@@ -130,13 +129,19 @@ def test_pipeline_survives_worktree_pipeline_rename(tmp_path):
     gr_id = r.stdout.strip()
 
     state_dir = sh.state_root / "claude-gremlins" / gr_id
+    log_path = state_dir / "log"
+    log_tail = (
+        log_path.read_text(errors="replace")[-2000:]
+        if log_path.exists()
+        else "<log file missing>"
+    )
     assert wait_for_finished(state_dir, timeout=120), (
         f"pipeline did not finish; log:\n"
-        f"{(state_dir / 'log').read_text(errors='replace')[-2000:]}"
+        f"{log_tail}"
     )
 
     state = read_state(state_dir / "state.json")
     assert state["exit_code"] == 0, (
         f"expected exit 0; log tail:\n"
-        f"{(state_dir / 'log').read_text(errors='replace')[-2000:]}"
+        f"{log_tail}"
     )

--- a/pipeline/tests/test_localgremlin_shell.py
+++ b/pipeline/tests/test_localgremlin_shell.py
@@ -7,6 +7,7 @@ git repo. Verifies stage ordering and per-stage artifacts on disk.
 
 from __future__ import annotations
 
+import pathlib
 import subprocess
 
 from fixtures.shell_env import (
@@ -97,3 +98,45 @@ def test_localgremlin_plan_mode_skips_plan_stage(tmp_path):
     snapshot = state_dir / "artifacts" / "plan.md"
     assert snapshot.exists()
     assert snapshot.read_text(encoding="utf-8") == plan.read_text(encoding="utf-8")
+
+
+def test_pipeline_survives_worktree_pipeline_rename(tmp_path):
+    """Regression: pipeline completes even when implement renames worktree's pipeline/.
+
+    Without PYTHONSAFEPATH=1, python -m pipeline.cli imports from the worktree
+    (cwd). Renaming pipeline/ during implement then causes FileNotFoundError in
+    later stages because PROMPTS_DIR is __file__-relative and the directory is
+    gone. With the fix, python loads pipeline from HOME/.claude/pipeline/ and the
+    worktree rename is harmless.
+    """
+    sh = setup_shell_env(tmp_path)
+
+    # Add a pipeline/ stub to the repo so the worktree shadows $HOME/.claude/pipeline/.
+    pipeline_stub = sh.repo / "pipeline"
+    pipeline_stub.mkdir()
+    (pipeline_stub / "__init__.py").write_text("# stub\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(sh.repo), "add", "pipeline"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(sh.repo), "commit", "-m", "add pipeline stub"],
+        check=True, capture_output=True,
+    )
+
+    sh.env["FAKE_CLAUDE_RENAME_PIPELINE"] = "1"
+    r = _launch_local(sh, "test pipeline rename regression")
+    assert r.returncode == 0, r.stderr
+    gr_id = r.stdout.strip()
+
+    state_dir = sh.state_root / "claude-gremlins" / gr_id
+    assert wait_for_finished(state_dir, timeout=120), (
+        f"pipeline did not finish; log:\n"
+        f"{(state_dir / 'log').read_text(errors='replace')[-2000:]}"
+    )
+
+    state = read_state(state_dir / "state.json")
+    assert state["exit_code"] == 0, (
+        f"expected exit 0; log tail:\n"
+        f"{(state_dir / 'log').read_text(errors='replace')[-2000:]}"
+    )

--- a/pipeline/tests/test_localgremlin_shell.py
+++ b/pipeline/tests/test_localgremlin_shell.py
@@ -130,18 +130,13 @@ def test_pipeline_survives_worktree_pipeline_rename(tmp_path):
 
     state_dir = sh.state_root / "claude-gremlins" / gr_id
     log_path = state_dir / "log"
-    log_tail = (
-        log_path.read_text(errors="replace")[-2000:]
-        if log_path.exists()
-        else "<log file missing>"
-    )
     assert wait_for_finished(state_dir, timeout=120), (
         f"pipeline did not finish; log:\n"
-        f"{log_tail}"
+        f"{log_path.read_text(errors='replace')[-2000:] if log_path.exists() else '<log file missing>'}"
     )
 
     state = read_state(state_dir / "state.json")
     assert state["exit_code"] == 0, (
         f"expected exit 0; log tail:\n"
-        f"{log_tail}"
+        f"{log_path.read_text(errors='replace')[-2000:] if log_path.exists() else '<log file missing>'}"
     )

--- a/skills/_bg/launch.sh
+++ b/skills/_bg/launch.sh
@@ -253,11 +253,11 @@ if [[ -n "$RESUME_GR_ID" ]]; then
         cd "$WORKDIR"
         if [[ $USE_PIPELINE -eq 1 ]]; then
             if [[ $_has_plan -eq 1 ]]; then
-                PYTHONPATH="$HOME/.claude${PYTHONPATH:+:$PYTHONPATH}" \
+                PYTHONPATH="$HOME/.claude${PYTHONPATH:+:$PYTHONPATH}" PYTHONSAFEPATH=1 \
                 nohup bash -c 'python3 -m pipeline.cli "$@"; EC=$?; "$HOME/.claude/skills/_bg/finish.sh" "$GR_ID" "$EC"' \
                     -- "$KIND_SUBCOMMAND" "${PIPELINE_ARGS[@]}" --resume-from "$STAGE" </dev/null >>"$STATE_DIR/log" 2>&1 &
             else
-                PYTHONPATH="$HOME/.claude${PYTHONPATH:+:$PYTHONPATH}" \
+                PYTHONPATH="$HOME/.claude${PYTHONPATH:+:$PYTHONPATH}" PYTHONSAFEPATH=1 \
                 nohup bash -c 'python3 -m pipeline.cli "$@"; EC=$?; "$HOME/.claude/skills/_bg/finish.sh" "$GR_ID" "$EC"' \
                     -- "$KIND_SUBCOMMAND" "${PIPELINE_ARGS[@]}" --resume-from "$STAGE" "$INSTRUCTIONS" </dev/null >>"$STATE_DIR/log" 2>&1 &
             fi
@@ -653,7 +653,7 @@ export PIPELINE GR_ID
 (
     cd "$WORKDIR"
     if [[ $USE_PIPELINE -eq 1 ]]; then
-        PYTHONPATH="$HOME/.claude${PYTHONPATH:+:$PYTHONPATH}" \
+        PYTHONPATH="$HOME/.claude${PYTHONPATH:+:$PYTHONPATH}" PYTHONSAFEPATH=1 \
         nohup bash -c 'python3 -m pipeline.cli "$@"; EC=$?; "$HOME/.claude/skills/_bg/finish.sh" "$GR_ID" "$EC"' \
             -- "$KIND_SUBCOMMAND" "$@" </dev/null >"$STATE_DIR/log" 2>&1 &
     else


### PR DESCRIPTION
## Summary

- Add `PYTHONSAFEPATH=1` to both `python -m pipeline.cli` invocations in `launch.sh` (initial launch and `--resume`) so Python never inserts the worktree cwd into `sys.path[0]`
- Add `PYTHONSAFEPATH=1` to `_pipeline_cli_env()` in `boss.py` for subprocess calls to `pipeline.cli handoff/fleet`
- Adds regression test: commits a `pipeline/` stub into the test repo, renames it during the implement stage, and asserts the full pipeline completes successfully

## Test plan

- [ ] All 174 existing tests pass (`cd pipeline && PYTHONPATH=. python -m pytest`)
- [ ] New test `test_pipeline_survives_worktree_pipeline_rename` passes and covers the #132 failure case

Closes #149