### PR TITLE
pipeline/fleet: stream rescue diagnosis output via shared renderer

### DIFF
--- a/gremlins/clients/claude.py
+++ b/gremlins/clients/claude.py
@@ -22,7 +22,7 @@ import sys
 import threading
 import time
 from dataclasses import dataclass
-from typing import Callable, List, Optional, Protocol, Sequence
+from typing import IO, Callable, List, Optional, Protocol, Sequence, Tuple
 
 CLAUDE_FLAGS_BASE = [
     "--permission-mode", "bypassPermissions",
@@ -139,6 +139,61 @@ def _emit_event(prefix: str, evt: dict) -> None:
     out.flush()
 
 
+def stream_events(
+    stdout: IO[bytes],
+    *,
+    prefix: str = "",
+    raw_path: Optional[pathlib.Path] = None,
+    capture: bool = False,
+    on_event: Optional[Callable[[dict], None]] = None,
+) -> Tuple[Optional[str], List[dict]]:
+    """Read stream-json lines from stdout, render via _emit_event.
+
+    Returns (session_id, events) where session_id is extracted from the first
+    system.init event (None if not seen) and events is populated only when
+    capture=True.
+    """
+    session_id: Optional[str] = None
+    events: List[dict] = []
+    raw = None
+    if raw_path is not None:
+        raw = open(raw_path, "ab")
+    try:
+        for line in stdout:
+            if raw is not None:
+                raw.write(line)
+                raw.flush()
+            try:
+                evt = json.loads(line.decode("utf-8", errors="replace"))
+            except Exception:
+                continue
+            if not isinstance(evt, dict):
+                continue
+            if (
+                session_id is None
+                and evt.get("type") == "system"
+                and evt.get("subtype") == "init"
+            ):
+                sid = evt.get("session_id")
+                if isinstance(sid, str):
+                    session_id = sid
+            if capture:
+                events.append(evt)
+            try:
+                _emit_event(prefix, evt)
+            except Exception:
+                pass
+            if on_event is not None:
+                try:
+                    on_event(evt)
+                except Exception:
+                    pass
+    finally:
+        if raw is not None:
+            raw.close()
+    return session_id, events
+
+
 # ---------------------------------------------------------------------------
 # SubprocessClaudeClient
 # ---------------------------------------------------------------------------
@@ -236,51 +291,21 @@ class SubprocessClaudeClient:
 
         session_id: Optional[str] = None
         text_chunks: List[str] = []
-        events: Optional[List[dict]] = [] if capture_events else None
+        events: Optional[List[dict]] = None
         prefix = f"[{label}] " if label else ""
 
         try:
             assert p.stdout is not None
             if output_format == "stream-json":
-                if raw_path is not None:
-                    raw = open(raw_path, "ab")
-                else:
-                    raw = None
-                try:
-                    for line in p.stdout:
-                        if raw is not None:
-                            raw.write(line)
-                            raw.flush()
-                        try:
-                            evt = json.loads(line.decode("utf-8", errors="replace"))
-                        except Exception:
-                            # Parity with the bash `jq ... || true`: a truncated
-                            # JSON line from a crashing claude must not abort.
-                            continue
-                        if not isinstance(evt, dict):
-                            continue
-                        if (
-                            session_id is None
-                            and evt.get("type") == "system"
-                            and evt.get("subtype") == "init"
-                        ):
-                            sid = evt.get("session_id")
-                            if isinstance(sid, str):
-                                session_id = sid
-                        if events is not None:
-                            events.append(evt)
-                        try:
-                            _emit_event(prefix, evt)
-                        except Exception:
-                            pass
-                        if on_event is not None:
-                            try:
-                                on_event(evt)
-                            except Exception:
-                                pass
-                finally:
-                    if raw is not None:
-                        raw.close()
+                session_id, collected = stream_events(
+                    p.stdout,
+                    prefix=prefix,
+                    raw_path=raw_path,
+                    capture=capture_events,
+                    on_event=on_event,
+                )
+                if capture_events:
+                    events = collected
             else:
                 # text mode — capture stdout, no per-event trace.
                 data = p.stdout.read()

--- a/gremlins/fleet.py
+++ b/gremlins/fleet.py
@@ -28,6 +28,8 @@ import tempfile
 import time
 from typing import List, Optional
 
+from pipeline.clients.claude import stream_events
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -1079,28 +1081,46 @@ def do_rescue(target: str, headless: bool = False) -> bool:
                 print("Diagnosis: running diagnosis agent inline — Ctrl-C to abort.")
                 print(f"Marker: {marker_path}")
                 print()
+                cmd = [
+                    "claude", "-p",
+                    "--permission-mode", "bypassPermissions",
+                    "--output-format", "stream-json",
+                    "--verbose",
+                    prompt,
+                ]
                 try:
-                    result = subprocess.run(["claude", "-p", prompt], cwd=scratch_dir)
+                    p = subprocess.Popen(cmd, cwd=scratch_dir, stdout=subprocess.PIPE)
                 except FileNotFoundError:
                     print("error: 'claude' CLI not found in PATH")
                     report["verdict"] = "diagnosis_claude_error"
                     report["summary"] = "'claude' CLI not found in PATH"
                     return False
+                try:
+                    stream_events(p.stdout, prefix="[rescue] ")
+                    p.stdout.close()
+                    rc = p.wait()
                 except KeyboardInterrupt:
-                    # Operator's deliberate interrupt — preserve state with no
-                    # bail so they can rerun /gremlins rescue without first
-                    # having to clear a bail_reason. Skip the report too: nothing
-                    # was decided, the gremlin is exactly as it was.
+                    p.stdout.close()
+                    try:
+                        p.terminate()
+                        p.wait(timeout=2)
+                    except subprocess.TimeoutExpired:
+                        pass
+                    if p.poll() is None:
+                        try:
+                            p.kill()
+                        except Exception:
+                            pass
                     print("\nRescue aborted by user. Gremlin state preserved — rerun /gremlins rescue, rm, or close.")
                     aborted[0] = True
                     return False
 
                 print()
 
-                if result.returncode != 0:
-                    detail = f"claude -p exited {result.returncode}"
+                if rc != 0:
+                    detail = f"claude -p exited {rc}"
                     _write_bail(sf, wdir, "diagnosis_claude_error", detail)
-                    print(f"Diagnosis: rescue agent exited with code {result.returncode}.")
+                    print(f"Diagnosis: rescue agent exited with code {rc}.")
                     print(f"Inspect the log at {log_path} and worktree at {workdir} for details.")
                     report["verdict"] = "diagnosis_claude_error"
                     report["summary"] = detail

--- a/gremlins/tests/test_fleet.py
+++ b/gremlins/tests/test_fleet.py
@@ -506,3 +506,90 @@ def test_parse_duration_invalid():
         gremlins.parse_duration("5x")
     with pytest.raises(ValueError):
         gremlins.parse_duration("abc")
+
+
+# ---------------------------------------------------------------------------
+# do_rescue interactive: streaming events via stream_events
+# ---------------------------------------------------------------------------
+
+def test_rescue_interactive_streams_events_to_stderr(tmp_path, monkeypatch, capsys):
+    """Interactive rescue streams [rescue]-prefixed events to stderr."""
+    import os as _os
+
+    gr_dir, workdir = _setup_dead_gremlin(tmp_path, monkeypatch)
+
+    # Fake claude: emits stream-json, writes marker file, exits 0.
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_bin = bin_dir / "claude"
+    fake_bin.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys, json, re, pathlib\n"
+        "prompt = sys.argv[-1]\n"
+        "m = re.search(r'(/[^\\s`]+\\.done)', prompt)\n"
+        "marker = m.group(1) if m else ''\n"
+        "for evt in [\n"
+        "    {'type':'system','subtype':'init','session_id':'r1','model':'fake','cwd':'.'},\n"
+        "    {'type':'assistant','message':{'content':[{'type':'text','text':'diagnosing'}]}},\n"
+        "    {'type':'result','subtype':'success','num_turns':1,'total_cost_usd':0},\n"
+        "]:\n"
+        "    sys.stdout.write(json.dumps(evt) + '\\n')\n"
+        "sys.stdout.flush()\n"
+        "if marker:\n"
+        "    pathlib.Path(marker).parent.mkdir(parents=True, exist_ok=True)\n"
+        "    pathlib.Path(marker).write_text(json.dumps({'status':'fixed','summary':'ok'}))\n"
+    )
+    fake_bin.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{_os.environ.get('PATH', '')}")
+
+    # Prevent relaunch step from executing a real launcher.
+    _real_access = _os.access
+    def _fake_access(path, mode, *args, **kwargs):
+        if isinstance(path, str) and "launch.sh" in path:
+            return False
+        return _real_access(path, mode, *args, **kwargs)
+    monkeypatch.setattr(_os, "access", _fake_access)
+
+    gremlins.do_rescue("test-id-aabb12", headless=False)
+
+    _, err = capsys.readouterr()
+    assert "[rescue] init" in err
+    assert "[rescue] text:" in err
+    assert "[rescue] final:" in err
+
+
+def test_rescue_interactive_nonzero_exit_writes_bail(tmp_path, monkeypatch, capsys):
+    """Interactive rescue with rc != 0 (no marker) returns False and sets diagnosis_claude_error."""
+    import os as _os
+
+    gr_dir, workdir = _setup_dead_gremlin(tmp_path, monkeypatch)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_bin = bin_dir / "claude"
+    fake_bin.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys, json\n"
+        "for evt in [\n"
+        "    {'type':'system','subtype':'init','session_id':'r2','model':'fake','cwd':'.'},\n"
+        "    {'type':'result','subtype':'error','num_turns':1,'total_cost_usd':0},\n"
+        "]:\n"
+        "    sys.stdout.write(json.dumps(evt) + '\\n')\n"
+        "sys.stdout.flush()\n"
+        "sys.exit(1)\n"
+    )
+    fake_bin.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{_os.environ.get('PATH', '')}")
+
+    _real_access = _os.access
+    def _fake_access(path, mode, *args, **kwargs):
+        if isinstance(path, str) and "launch.sh" in path:
+            return False
+        return _real_access(path, mode, *args, **kwargs)
+    monkeypatch.setattr(_os, "access", _fake_access)
+
+    result = gremlins.do_rescue("test-id-aabb12", headless=False)
+
+    assert result is False
+    state = json.loads((gr_dir / "state.json").read_text())
+    assert state.get("bail_reason") == "diagnosis_claude_error"


### PR DESCRIPTION
## Summary
- Replaces the silent `subprocess.run(["claude", "-p", prompt])` in interactive `do_rescue` with a streaming `Popen` that uses `--output-format stream-json --verbose --permission-mode bypassPermissions`.
- Extracts a `stream_events` helper from `SubprocessClaudeClient.run` so both stage runs and the rescue path share the `_emit_event` renderer; rescue lines now appear with `[rescue] tool: …`, `[rescue] result: …`, etc.
- Preserves all six rescue invariants (cwd, marker-protocol verdict source-of-truth, Ctrl-C abort, non-zero-exit bail, FileNotFoundError handling, headless path untouched).

## Test plan
- [x] `cd pipeline && PYTHONPATH=. python -m pytest`
- [ ] Manual: trigger `/gremlins rescue <id>` against a dead gremlin and confirm per-event lines stream live instead of waiting for the final assistant text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)