### PR TITLE
feat: report total USD cost after each pipeline run

### DIFF
--- a/gremlins/clients/claude.py
+++ b/gremlins/clients/claude.py
@@ -39,13 +39,15 @@ class CompletedRun:
     or runs that crashed before emitting init). ``text_result`` holds the
     captured stdout for ``output_format='text'`` runs and is None otherwise.
     ``events`` is populated only when ``capture_events=True``; each entry is
-    one parsed stream-json event.
+    one parsed stream-json event. ``cost_usd`` is extracted from the
+    stream-json ``result`` event when available.
     """
 
     exit_code: int
     session_id: Optional[str] = None
     text_result: Optional[str] = None
     events: Optional[List[dict]] = None
+    cost_usd: Optional[float] = None
 
 
 class ClaudeClient(Protocol):
@@ -159,6 +161,7 @@ class SubprocessClaudeClient:
         # in that narrow window.
         self._lock = threading.RLock()
         self._children: List[subprocess.Popen] = []
+        self._total_cost_usd: float = 0.0
 
     # --- child-process tracking -------------------------------------------
 
@@ -194,6 +197,10 @@ class SubprocessClaudeClient:
                     p.kill()
                 except Exception:
                     pass
+
+    @property
+    def total_cost_usd(self) -> float:
+        return self._total_cost_usd
 
     # --- main entry point -------------------------------------------------
 
@@ -238,6 +245,7 @@ class SubprocessClaudeClient:
         text_chunks: List[str] = []
         events: Optional[List[dict]] = [] if capture_events else None
         prefix = f"[{label}] " if label else ""
+        cost_usd: Optional[float] = None
 
         try:
             assert p.stdout is not None
@@ -267,6 +275,11 @@ class SubprocessClaudeClient:
                             sid = evt.get("session_id")
                             if isinstance(sid, str):
                                 session_id = sid
+                        if evt.get("type") == "result":
+                            raw_cost = evt.get("total_cost_usd", evt.get("cost_usd"))
+                            if isinstance(raw_cost, (int, float)):
+                                cost_usd = float(raw_cost)
+                                self._total_cost_usd += cost_usd
                         if events is not None:
                             events.append(evt)
                         try:
@@ -303,4 +316,5 @@ class SubprocessClaudeClient:
             session_id=session_id,
             text_result="".join(text_chunks) if output_format != "stream-json" else None,
             events=events,
+            cost_usd=cost_usd,
         )

--- a/gremlins/clients/claude.py
+++ b/gremlins/clients/claude.py
@@ -69,6 +69,10 @@ class ClaudeClient(Protocol):
     def reap_all(self) -> None:
         ...
 
+    @property
+    def total_cost_usd(self) -> float:
+        ...
+
 
 # ---------------------------------------------------------------------------
 # Stream-JSON event tracing
@@ -279,7 +283,8 @@ class SubprocessClaudeClient:
                             raw_cost = evt.get("total_cost_usd", evt.get("cost_usd"))
                             if isinstance(raw_cost, (int, float)):
                                 cost_usd = float(raw_cost)
-                                self._total_cost_usd += cost_usd
+                                with self._lock:
+                                    self._total_cost_usd += cost_usd
                         if events is not None:
                             events.append(evt)
                         try:

--- a/gremlins/clients/fake.py
+++ b/gremlins/clients/fake.py
@@ -49,6 +49,7 @@ class FakeClaudeClient:
         self.calls: List[RecordedCall] = []
         self._fixtures: Dict[str, object] = dict(fixtures or {})
         self._text_results: Dict[str, str] = dict(text_results or {})
+        self.total_cost_usd: float = 0.0
 
     def reap_all(self) -> None:
         # Fake never spawns; nothing to reap.
@@ -115,6 +116,7 @@ class FakeClaudeClient:
                     f.write((json.dumps(evt) + "\n").encode("utf-8"))
 
         session_id: Optional[str] = None
+        cost_usd: Optional[float] = None
         for evt in events:
             if (
                 session_id is None
@@ -123,6 +125,11 @@ class FakeClaudeClient:
                 and isinstance(evt.get("session_id"), str)
             ):
                 session_id = evt["session_id"]
+            if evt.get("type") == "result":
+                raw_cost = evt.get("total_cost_usd", evt.get("cost_usd"))
+                if isinstance(raw_cost, (int, float)):
+                    cost_usd = float(raw_cost)
+                    self.total_cost_usd += cost_usd
             if on_event is not None:
                 try:
                     on_event(evt)
@@ -134,4 +141,5 @@ class FakeClaudeClient:
             session_id=session_id,
             text_result=None,
             events=events if capture_events else None,
+            cost_usd=cost_usd,
         )

--- a/gremlins/fleet.py
+++ b/gremlins/fleet.py
@@ -1283,6 +1283,12 @@ def expected_branch(state: dict, gr_id: str):
     return None
 
 
+def _print_cost(state: dict) -> None:
+    cost = state.get("total_cost_usd")
+    if cost:
+        print(f"total cost: ${cost:.4f}")
+
+
 def _resolve_landing_cwd(state: dict) -> str:
     """Return a project_root suitable as cwd for `gh pr merge --delete-branch`.
 
@@ -1719,6 +1725,7 @@ def _squash_land(gr_id: str, sf: str, wdir: str, state: dict, cwd,
         return False
 
     print(f"Landed {source_label} onto {current}.")
+    _print_cost(state)
     _cleanup_gremlin(gr_id, sf, wdir, state, cwd, delete_branch=delete_branch, remove_state_dir=False)
     return True
 
@@ -1754,6 +1761,7 @@ def _ff_land(gr_id: str, sf: str, wdir: str, state: dict, cwd,
         return False
 
     print(f"Landed {source_label} onto {current}.")
+    _print_cost(state)
     _cleanup_gremlin(gr_id, sf, wdir, state, cwd, delete_branch=delete_branch, remove_state_dir=False)
     return True
 

--- a/gremlins/fleet.py
+++ b/gremlins/fleet.py
@@ -20,6 +20,7 @@ import json
 import os
 import pathlib
 import re
+import secrets
 import shutil
 import signal
 import subprocess
@@ -1285,7 +1286,7 @@ def expected_branch(state: dict, gr_id: str):
 
 def _print_cost(state: dict) -> None:
     cost = state.get("total_cost_usd")
-    if cost is not None and isinstance(cost, (int, float)):
+    if isinstance(cost, (int, float)) and cost > 0:
         print(f"total cost: ${cost:.4f}")
 
 
@@ -1307,7 +1308,7 @@ def _persist_land_cost(sf: str, state: dict, additional_cost: float) -> None:
         existing = float(existing) if isinstance(existing, (int, float)) else 0.0
         new_total = existing + float(additional_cost)
         data["total_cost_usd"] = new_total
-        tmp = f"{sf}.{os.getpid()}.tmp"
+        tmp = f"{sf}.{os.getpid()}.{secrets.token_hex(8)}.tmp"
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(data, f)
         os.replace(tmp, sf)
@@ -1620,7 +1621,7 @@ def _run_claude_p_text(prompt: str, timeout: int = 60) -> tuple:
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"claude -p returned non-JSON output: {exc}")
     text = data.get("result") if isinstance(data.get("result"), str) else ""
-    raw_cost = data.get("total_cost_usd")
+    raw_cost = data.get("total_cost_usd", data.get("cost_usd"))
     cost = float(raw_cost) if isinstance(raw_cost, (int, float)) else 0.0
     return text, cost
 

--- a/gremlins/fleet.py
+++ b/gremlins/fleet.py
@@ -1285,7 +1285,7 @@ def expected_branch(state: dict, gr_id: str):
 
 def _print_cost(state: dict) -> None:
     cost = state.get("total_cost_usd")
-    if cost:
+    if cost is not None and isinstance(cost, (int, float)):
         print(f"total cost: ${cost:.4f}")
 
 

--- a/gremlins/fleet.py
+++ b/gremlins/fleet.py
@@ -1289,6 +1289,33 @@ def _print_cost(state: dict) -> None:
         print(f"total cost: ${cost:.4f}")
 
 
+def _persist_land_cost(sf: str, state: dict, additional_cost: float) -> None:
+    """Fold a land-time `claude -p` cost into state.json's total_cost_usd.
+
+    Writes through to disk so the value `_print_cost` reports — and any later
+    fleet status reader — reflects spend that happened during land. Mutates
+    `state` in place so the immediately-following `_print_cost(state)` sees
+    the updated total. Best-effort: cost accounting must not crash a
+    successful land.
+    """
+    if not isinstance(additional_cost, (int, float)) or additional_cost <= 0:
+        return
+    try:
+        with open(sf, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        existing = data.get("total_cost_usd")
+        existing = float(existing) if isinstance(existing, (int, float)) else 0.0
+        new_total = existing + float(additional_cost)
+        data["total_cost_usd"] = new_total
+        tmp = f"{sf}.{os.getpid()}.tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+        os.replace(tmp, sf)
+        state["total_cost_usd"] = new_total
+    except Exception:
+        pass
+
+
 def _resolve_landing_cwd(state: dict) -> str:
     """Return a project_root suitable as cwd for `gh pr merge --delete-branch`.
 
@@ -1566,8 +1593,14 @@ def _parse_commit_output(text: str) -> tuple:
     return subject, body
 
 
-def _run_claude_p_text(prompt: str, timeout: int = 60) -> str:
-    """Run `claude -p` and return its stdout as plain text.
+def _run_claude_p_text(prompt: str, timeout: int = 60) -> tuple:
+    """Run `claude -p` and return (stdout text, total_cost_usd).
+
+    Uses `--output-format json` so the single result object carries both the
+    assistant's reply text and `total_cost_usd`. The cost is surfaced so the
+    caller can fold land-time `claude -p` spend into the gremlin's reported
+    total — without it, `gremlins land`'s commit-message synthesis would not
+    show up in the "total cost" line printed after a squash-land.
 
     Suppresses the session-summary hook via `GREMLIN_SKIP_SUMMARY=1`; otherwise
     the hook's "surface this verbatim" directive prepends the gremlin status
@@ -1577,12 +1610,19 @@ def _run_claude_p_text(prompt: str, timeout: int = 60) -> str:
     env = os.environ.copy()
     env["GREMLIN_SKIP_SUMMARY"] = "1"
     result = subprocess.run(
-        ["claude", "-p", "--output-format", "text"],
+        ["claude", "-p", "--output-format", "json"],
         input=prompt, capture_output=True, text=True, timeout=timeout, env=env,
     )
     if result.returncode != 0:
         raise RuntimeError(f"claude -p exited {result.returncode}: {result.stderr.strip()}")
-    return result.stdout
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"claude -p returned non-JSON output: {exc}")
+    text = data.get("result") if isinstance(data.get("result"), str) else ""
+    raw_cost = data.get("total_cost_usd")
+    cost = float(raw_cost) if isinstance(raw_cost, (int, float)) else 0.0
+    return text, cost
 
 
 def _synthesize_commit_message_ai(inputs: dict) -> tuple:
@@ -1617,29 +1657,30 @@ Requirements:
 
 Output only the commit message text, nothing else."""
 
-    stdout = _run_claude_p_text(prompt)
+    stdout, cost = _run_claude_p_text(prompt)
     subject, body = _parse_commit_output(stdout)
     if not subject:
         raise RuntimeError("claude -p returned empty subject")
-    return subject, body
+    return subject, body, cost
 
 
 def _build_commit_message(wdir: str, state: dict, branch: str, merge_base: str, cwd) -> tuple:
-    """Return (subject, body) using AI synthesis with fallback to regex extraction."""
+    """Return (subject, body, cost_usd) using AI synthesis with fallback to regex extraction."""
     inputs = _gather_commit_inputs(wdir, state, branch, merge_base, cwd)
 
     print("Composing commit message...", flush=True)
     try:
-        subject, body = _synthesize_commit_message_ai(inputs)
+        subject, body, cost = _synthesize_commit_message_ai(inputs)
         print(f"Commit message: {subject}", flush=True)
-        return subject, body
+        return subject, body, cost
     except Exception as exc:
         print(f"warning: AI commit message synthesis failed ({exc}); falling back to plan.md extraction", flush=True)
         plan_path = os.path.join(wdir, "artifacts", "plan.md")
         if not os.path.isfile(plan_path):
             print(f"error: plan.md not found at {plan_path} — cannot build commit message")
             raise
-        return _compose_commit_message(plan_path)
+        subject, body = _compose_commit_message(plan_path)
+        return subject, body, 0.0
 
 
 def _inside_worktree(workdir: str) -> bool:
@@ -1716,7 +1757,7 @@ def _squash_land(gr_id: str, sf: str, wdir: str, state: dict, cwd,
         print(f"error: git merge --squash failed — {suffix}")
         return False
 
-    subject, body = _build_commit_message(wdir, state, source_ref, merge_base, cwd)
+    subject, body, land_cost = _build_commit_message(wdir, state, source_ref, merge_base, cwd)
     commit_msg = f"{subject}\n\n{body}" if body else subject
 
     r = subprocess.run(["git", "commit", "-m", commit_msg], cwd=cwd)
@@ -1725,6 +1766,7 @@ def _squash_land(gr_id: str, sf: str, wdir: str, state: dict, cwd,
         return False
 
     print(f"Landed {source_label} onto {current}.")
+    _persist_land_cost(sf, state, land_cost)
     _print_cost(state)
     _cleanup_gremlin(gr_id, sf, wdir, state, cwd, delete_branch=delete_branch, remove_state_dir=False)
     return True

--- a/gremlins/orchestrators/gh.py
+++ b/gremlins/orchestrators/gh.py
@@ -470,11 +470,11 @@ def gh_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int:
     run_stages(stages, resume_from=args.resume_from)
 
     total_cost = getattr(client, "total_cost_usd", 0.0)
-    if total_cost:
+    if total_cost is not None and total_cost > 0:
         patch_state(total_cost_usd=total_cost)
 
     print("", flush=True)
     print(f"done. PR: {pr_url_holder.get('url', '(unknown)')}", flush=True)
-    if total_cost:
+    if total_cost is not None and total_cost > 0:
         print(f"total cost: ${total_cost:.4f}", flush=True)
     return 0

--- a/gremlins/orchestrators/gh.py
+++ b/gremlins/orchestrators/gh.py
@@ -469,6 +469,12 @@ def gh_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int:
     ]
     run_stages(stages, resume_from=args.resume_from)
 
+    total_cost = getattr(client, "total_cost_usd", 0.0)
+    if total_cost:
+        patch_state(total_cost_usd=total_cost)
+
     print("", flush=True)
     print(f"done. PR: {pr_url_holder.get('url', '(unknown)')}", flush=True)
+    if total_cost:
+        print(f"total cost: ${total_cost:.4f}", flush=True)
     return 0

--- a/gremlins/orchestrators/local.py
+++ b/gremlins/orchestrators/local.py
@@ -31,7 +31,7 @@ from ..stages.address_code import run_address_code_stage
 from ..stages.implement import run_implement_stage
 from ..stages.plan import run_plan_stage
 from ..stages.review_code import run_review_code_stage
-from ..state import resolve_session_dir, set_stage
+from ..state import patch_state, resolve_session_dir, set_stage
 
 MODEL_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 VALID_RESUME_STAGES = ["plan", "implement", "review-code", "address-code"]
@@ -264,8 +264,14 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
     ]
     run_stages(stages, resume_from=args.resume_from)
 
+    total_cost = getattr(client, "total_cost_usd", 0.0)
+    if total_cost:
+        patch_state(total_cost_usd=total_cost)
+
     print("", flush=True)
     print(f"done. session artifacts in: {session_dir}", flush=True)
+    if total_cost:
+        print(f"total cost: ${total_cost:.4f}", flush=True)
     return 0
 
 

--- a/gremlins/orchestrators/local.py
+++ b/gremlins/orchestrators/local.py
@@ -265,12 +265,12 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
     run_stages(stages, resume_from=args.resume_from)
 
     total_cost = getattr(client, "total_cost_usd", 0.0)
-    if total_cost:
+    if total_cost is not None and total_cost > 0:
         patch_state(total_cost_usd=total_cost)
 
     print("", flush=True)
     print(f"done. session artifacts in: {session_dir}", flush=True)
-    if total_cost:
+    if total_cost is not None and total_cost > 0:
         print(f"total cost: ${total_cost:.4f}", flush=True)
     return 0
 

--- a/gremlins/tests/test_fleet.py
+++ b/gremlins/tests/test_fleet.py
@@ -419,7 +419,8 @@ def test_land_local_squash_lands_branch_and_deletes_it(tmp_path, monkeypatch, ca
     monkeypatch.setattr(gremlins, "STATE_ROOT", str(state_root))
     monkeypatch.setattr(gremlins, "_synthesize_commit_message_ai",
                         lambda inputs: ("Add feature.txt to repo",
-                                         "Adds feature.txt with placeholder content."))
+                                         "Adds feature.txt with placeholder content.",
+                                         0.0))
     monkeypatch.chdir(project_root)
 
     ok = gremlins._land_local(gr_id, str(gr_dir / "state.json"),
@@ -437,6 +438,61 @@ def test_land_local_squash_lands_branch_and_deletes_it(tmp_path, monkeypatch, ca
         capture_output=True, text=True, check=True,
     ).stdout
     assert branches.strip() == ""
+
+
+def test_land_local_squash_folds_commit_synthesis_cost_into_total(tmp_path, monkeypatch, capsys):
+    """Squash-land must add the commit-message `claude -p` cost to total_cost_usd
+    so the printed total — and the persisted state — cover land-time spend."""
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _init_git_repo(project_root)
+
+    branch = "bg/localgremlin/test-id-cost12"
+    subprocess.run(["git", "checkout", "-b", branch], cwd=project_root,
+                   check=True, capture_output=True)
+    (project_root / "feature.txt").write_text("feature work\n")
+    subprocess.run(["git", "add", "."], cwd=project_root,
+                   check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "feat: add feature.txt"],
+                   cwd=project_root, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "main"], cwd=project_root,
+                   check=True, capture_output=True)
+
+    state_root = tmp_path / "state-root"
+    state_root.mkdir()
+    gr_id = "test-id-cost12"
+    gr_dir = state_root / gr_id
+    artifacts_dir = gr_dir / "artifacts"
+    artifacts_dir.mkdir(parents=True)
+    (artifacts_dir / "plan.md").write_text(
+        "# Add feature\n\n## Context\nAdd feature.txt to the repo.\n"
+    )
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    state = {
+        "id": gr_id,
+        "kind": "localgremlin",
+        "status": "dead",
+        "exit_code": 0,
+        "setup_kind": "worktree-branch",
+        "branch": branch,
+        "workdir": str(workdir),
+        "project_root": str(project_root),
+        "total_cost_usd": 1.0,
+    }
+    sf_path = _write_state(gr_dir, state, finished=True)
+
+    monkeypatch.setattr(gremlins, "STATE_ROOT", str(state_root))
+    monkeypatch.setattr(gremlins, "_synthesize_commit_message_ai",
+                        lambda inputs: ("Add feature.txt to repo", "", 0.05))
+    monkeypatch.chdir(project_root)
+
+    ok = gremlins._land_local(gr_id, sf_path, str(gr_dir), state, mode="squash")
+    assert ok is True
+
+    persisted = json.loads(pathlib.Path(sf_path).read_text())
+    assert persisted["total_cost_usd"] == pytest.approx(1.05)
+    assert "total cost: $1.0500" in capsys.readouterr().out
 
 
 def test_land_local_refuses_non_worktree_branch_setup(tmp_path, monkeypatch, capsys):
@@ -508,7 +564,7 @@ def test_land_proceeds_with_untracked_files_present(tmp_path, monkeypatch, capsy
 
     monkeypatch.setattr(gremlins, "STATE_ROOT", str(state_root))
     monkeypatch.setattr(gremlins, "_synthesize_commit_message_ai",
-                        lambda inputs: ("Add feature.txt to repo", ""))
+                        lambda inputs: ("Add feature.txt to repo", "", 0.0))
     monkeypatch.chdir(project_root)
 
     ok = gremlins._land_local(gr_id, str(gr_dir / "state.json"),


### PR DESCRIPTION
## Summary

- Accumulate `total_cost_usd` from stream-json `result` events in `SubprocessClaudeClient` and `FakeClaudeClient`
- Persist cost to `state.json` via `patch_state` after each pipeline run
- Print `total cost: $X.XXXX` in the done block for both local and gh orchestrators
- Add `_print_cost` helper in `fleet.py` to surface cost after squash/ff land

## Test plan

- [ ] 177 existing tests pass (`PYTHONPATH=. python -m pytest`)
- [ ] Run a local gremlin and verify "total cost: $X.XXXX" appears in done output
- [ ] Verify `total_cost_usd` is written to `state.json`

Closes #155