### PR TITLE
fix: child gremlins inherit project_root from parent via --parent

### DIFF
--- a/gremlins/tests/test_launch_sh.py
+++ b/gremlins/tests/test_launch_sh.py
@@ -279,16 +279,50 @@ def test_launch_sh_child_inherits_project_root_from_parent(tmp_path):
         encoding="utf-8",
     )
 
+    # Invoke launch.sh from outside the repo so a broken implementation cannot
+    # accidentally match the parent's project_root via cwd-based fallback.
+    launch_cwd = tmp_path / "outside-repo"
+    launch_cwd.mkdir()
+
     r = _run_launch(
         sh.env, "--print-id", "--parent", parent_id,
         "localgremlin", "test child inheritance",
-        cwd=sh.repo, timeout=30,
+        cwd=launch_cwd, timeout=30,
     )
     assert r.returncode == 0, f"launch.sh failed: {r.stderr}"
     gr_id = r.stdout.strip()
 
     state = read_state(sh.state_root / "claude-gremlins" / gr_id / "state.json")
     assert state["project_root"] == str(parent_root)
+
+    wait_for_finished(sh.state_root / "claude-gremlins" / gr_id, timeout=60)
+
+
+def test_launch_sh_child_falls_back_when_parent_root_nonexistent(tmp_path):
+    """Parent state.json has project_root but the path no longer exists; falls back to git rev-parse."""
+    sh = setup_shell_env(tmp_path)
+
+    # Create a parent state with a project_root that points to a deleted directory.
+    parent_id = "fake-parent-gone-aabbcc"
+    parent_state_dir = sh.state_root / "claude-gremlins" / parent_id
+    parent_state_dir.mkdir(parents=True)
+    gone_root = tmp_path / "deleted-repo"  # deliberately never created
+    (parent_state_dir / "state.json").write_text(
+        json.dumps({"id": parent_id, "project_root": str(gone_root)}),
+        encoding="utf-8",
+    )
+
+    r = _run_launch(
+        sh.env, "--print-id", "--parent", parent_id,
+        "localgremlin", "test nonexistent root fallback",
+        cwd=sh.repo, timeout=30,
+    )
+    assert r.returncode == 0, f"launch.sh failed: {r.stderr}"
+    gr_id = r.stdout.strip()
+
+    state = read_state(sh.state_root / "claude-gremlins" / gr_id / "state.json")
+    # Should fall back to git rev-parse of sh.repo (the launch cwd).
+    assert state["project_root"] == str(sh.repo)
 
     wait_for_finished(sh.state_root / "claude-gremlins" / gr_id, timeout=60)
 

--- a/gremlins/tests/test_launch_sh.py
+++ b/gremlins/tests/test_launch_sh.py
@@ -263,3 +263,50 @@ def test_launch_sh_localgremlin_empty_plan_file_rejected(tmp_path):
     )
     assert r.returncode != 0
     assert "empty" in (r.stderr + r.stdout)
+
+
+def test_launch_sh_child_inherits_project_root_from_parent(tmp_path):
+    """--parent causes the child's project_root to come from the parent's state.json."""
+    sh = setup_shell_env(tmp_path)
+
+    # Create a fake parent state directory with a known project_root.
+    parent_id = "fake-parent-aabbcc"
+    parent_state_dir = sh.state_root / "claude-gremlins" / parent_id
+    parent_state_dir.mkdir(parents=True)
+    parent_root = sh.repo  # a real directory so IS_GIT check works
+    (parent_state_dir / "state.json").write_text(
+        json.dumps({"id": parent_id, "project_root": str(parent_root)}),
+        encoding="utf-8",
+    )
+
+    r = _run_launch(
+        sh.env, "--print-id", "--parent", parent_id,
+        "localgremlin", "test child inheritance",
+        cwd=sh.repo, timeout=30,
+    )
+    assert r.returncode == 0, f"launch.sh failed: {r.stderr}"
+    gr_id = r.stdout.strip()
+
+    state = read_state(sh.state_root / "claude-gremlins" / gr_id / "state.json")
+    assert state["project_root"] == str(parent_root)
+
+    wait_for_finished(sh.state_root / "claude-gremlins" / gr_id, timeout=60)
+
+
+def test_launch_sh_child_falls_back_when_parent_state_missing(tmp_path):
+    """--parent with a non-existent parent id falls back to git rev-parse and succeeds."""
+    sh = setup_shell_env(tmp_path)
+
+    r = _run_launch(
+        sh.env, "--print-id", "--parent", "nonexistent-parent-id",
+        "localgremlin", "test fallback",
+        cwd=sh.repo, timeout=30,
+    )
+    assert r.returncode == 0, f"launch.sh failed: {r.stderr}"
+    gr_id = r.stdout.strip()
+
+    state = read_state(sh.state_root / "claude-gremlins" / gr_id / "state.json")
+    # Should fall back to the git toplevel of sh.repo (where launch was invoked from).
+    assert state["project_root"] == str(sh.repo)
+
+    wait_for_finished(sh.state_root / "claude-gremlins" / gr_id, timeout=60)

--- a/skills/_bg/launch.sh
+++ b/skills/_bg/launch.sh
@@ -341,10 +341,25 @@ case "$KIND" in
         ;;
 esac
 
-if PROJECT_ROOT=$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null); then
-    IS_GIT=1
+_parent_root=""
+if [[ -n "$PARENT_ID" ]]; then
+    _parent_state="${XDG_STATE_HOME:-$HOME/.local/state}/claude-gremlins/$PARENT_ID/state.json"
+    if [[ -f "$_parent_state" ]]; then
+        _parent_root=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('project_root',''))" "$_parent_state" 2>/dev/null || true)
+    fi
+fi
+
+if [[ -n "$_parent_root" && -d "$_parent_root" ]]; then
+    PROJECT_ROOT="$_parent_root"
+elif PROJECT_ROOT=$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null); then
+    : # PROJECT_ROOT set
 else
     PROJECT_ROOT=$(pwd)
+fi
+
+if git -C "$PROJECT_ROOT" rev-parse --show-toplevel &>/dev/null; then
+    IS_GIT=1
+else
     IS_GIT=0
 fi
 [[ -n "$PROJECT_ROOT" && -d "$PROJECT_ROOT" ]] || die "could not resolve project root"


### PR DESCRIPTION
## Summary

- When `launch.sh` is given `--parent <id>`, read `project_root` from the parent's `state.json` instead of resolving via `git rev-parse` in the current working directory
- The boss orchestrator runs inside its own worktree, so children were recording the boss's worktree path as `project_root`, causing them to be filtered out by `gremlins --here`
- Falls back to `git rev-parse` when `--parent` is unset, the parent state is missing, or the parent has no `project_root` field

## Test plan

- [ ] New test `test_launch_sh_child_inherits_project_root_from_parent`: verifies child's `project_root` matches parent's when parent state.json is present
- [ ] New test `test_launch_sh_child_falls_back_when_parent_state_missing`: verifies fallback to `git rev-parse` when parent id is non-existent
- [ ] All 13 `test_launch_sh.py` tests pass

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)