### PR TITLE
feat: detect and recover from host-terminated gremlins

### DIFF
--- a/gremlins/fleet/__init__.py
+++ b/gremlins/fleet/__init__.py
@@ -42,6 +42,7 @@ from gremlins.fleet.rescue import (
     write_rescue_report,
     _read_rescue_marker,
     _run_headless_diagnosis,
+    _recreate_worktree,
     do_rescue,
 )
 from gremlins.fleet.log import do_log
@@ -105,6 +106,7 @@ __all__ = [
     "write_rescue_report",
     "_read_rescue_marker",
     "_run_headless_diagnosis",
+    "_recreate_worktree",
     "do_rescue",
     # log
     "do_log",
@@ -160,6 +162,7 @@ class _FleetModule(types.ModuleType):
         "BG_STALL_SECS": "gremlins.fleet.constants",
         "STATE_ROOT": "gremlins.fleet.constants",
         "_run_headless_diagnosis": "gremlins.fleet.rescue",
+        "_recreate_worktree": "gremlins.fleet.rescue",
         "_synthesize_commit_message_ai": "gremlins.fleet.land",
     }
 

--- a/gremlins/fleet/rescue.py
+++ b/gremlins/fleet/rescue.py
@@ -447,6 +447,13 @@ def _recreate_worktree(state: dict) -> tuple:
     if not os.path.isdir(project_root):
         return False, f"project_root {project_root!r} does not exist"
 
+    # Prune stale worktree entries so that git worktree add doesn't fail
+    # with "is already registered" when the directory was deleted by the host.
+    subprocess.run(
+        ["git", "worktree", "prune"],
+        capture_output=True, cwd=project_root,
+    )
+
     if branch:
         r = subprocess.run(
             ["git", "worktree", "add", workdir, branch],

--- a/gremlins/fleet/rescue.py
+++ b/gremlins/fleet/rescue.py
@@ -430,6 +430,49 @@ def _run_headless_diagnosis(workdir: str, prompt: str, marker_path: str):
     return _read_rescue_marker(marker_path)
 
 
+def _recreate_worktree(state: dict) -> tuple:
+    """Attempt to recreate a missing worktree from the gremlin's branch or base ref.
+
+    Tries the named branch first (preserves in-progress commits for localgremlin),
+    then falls back to a detached checkout of worktree_base or HEAD.
+    Returns (success: bool, detail: str).
+    """
+    workdir = state.get("workdir") or ""
+    branch = state.get("branch") or ""
+    worktree_base = state.get("worktree_base") or ""
+    project_root = state.get("project_root") or ""
+
+    if not workdir or not project_root:
+        return False, "workdir or project_root not recorded in state"
+    if not os.path.isdir(project_root):
+        return False, f"project_root {project_root!r} does not exist"
+
+    if branch:
+        r = subprocess.run(
+            ["git", "worktree", "add", workdir, branch],
+            capture_output=True, text=True, cwd=project_root,
+        )
+        if r.returncode == 0:
+            return True, f"recreated from branch {branch!r}"
+        branch_err = r.stderr.strip()
+    else:
+        branch_err = ""
+
+    ref = worktree_base or "HEAD"
+    r = subprocess.run(
+        ["git", "worktree", "add", "--detach", workdir, ref],
+        capture_output=True, text=True, cwd=project_root,
+    )
+    if r.returncode == 0:
+        suffix = f" (branch {branch!r} was gone)" if branch_err else ""
+        return True, f"recreated detached at {ref!r}{suffix}"
+    fallback_err = r.stderr.strip()
+
+    if branch_err:
+        return False, f"branch {branch!r}: {branch_err}; fallback {ref!r}: {fallback_err}"
+    return False, f"worktree add --detach {ref!r}: {fallback_err}"
+
+
 def do_rescue(target: str, headless: bool = False) -> bool:
     match = resolve_gremlin(target)
     if match is None:
@@ -464,6 +507,30 @@ def do_rescue(target: str, headless: bool = False) -> bool:
     if not workdir:
         print(f"error: no workdir recorded in state for {gr_id} — cannot rescue")
         return False
+
+    if live == "dead:host-terminated":
+        project_root_check = state.get("project_root") or ""
+        print(f"gremlin {gr_id}: worktree is gone (host likely terminated externally)")
+        if not project_root_check or not os.path.isdir(project_root_check):
+            detail = (
+                f"project_root {project_root_check!r} is also gone — "
+                "worktree cannot be recreated; use 'gremlins rm' to clean up"
+            )
+            print(f"  {detail}")
+            if headless:
+                _write_bail(sf, wdir, "host_terminated_unrecoverable", detail)
+            return False
+        print(f"  attempting to recreate worktree at {workdir}...")
+        recreated, detail = _recreate_worktree(state)
+        if not recreated:
+            msg = f"worktree recreation failed: {detail}"
+            print(f"  {msg}")
+            print(f"  use 'gremlins rm {gr_id}' to clean up")
+            if headless:
+                _write_bail(sf, wdir, "host_terminated_unrecoverable", msg)
+            return False
+        print(f"  worktree recreated: {detail}; resuming rescue...")
+        live = liveness_of_state_file(sf, state)
 
     rescue_count_raw = state.get("rescue_count") or 0
     try:

--- a/gremlins/fleet/state.py
+++ b/gremlins/fleet/state.py
@@ -94,6 +94,9 @@ def liveness_of_state_file(sf: str, state=None) -> str:
             try:
                 os.kill(int(gr_pid), 0)
             except (OSError, ValueError):
+                workdir = state.get("workdir") or ""
+                if workdir and not os.path.exists(workdir):
+                    return "dead:host-terminated"
                 return f"dead:crashed (pid {gr_pid} gone)"
 
         # Stall heuristic: log file hasn't moved in BG_STALL_SECS.

--- a/gremlins/fleet/state.py
+++ b/gremlins/fleet/state.py
@@ -95,7 +95,7 @@ def liveness_of_state_file(sf: str, state=None) -> str:
                 os.kill(int(gr_pid), 0)
             except (OSError, ValueError):
                 workdir = state.get("workdir") or ""
-                if workdir and not os.path.exists(workdir):
+                if workdir and not os.path.isdir(workdir):
                     return "dead:host-terminated"
                 return f"dead:crashed (pid {gr_pid} gone)"
 

--- a/gremlins/tests/test_fleet.py
+++ b/gremlins/tests/test_fleet.py
@@ -718,3 +718,142 @@ def test_parse_duration_invalid():
         gremlins.parse_duration("5x")
     with pytest.raises(ValueError):
         gremlins.parse_duration("abc")
+
+
+# ---------------------------------------------------------------------------
+# liveness — dead:host-terminated (pid gone + workdir missing)
+# ---------------------------------------------------------------------------
+
+def test_liveness_host_terminated_when_pid_gone_and_workdir_missing(tmp_path):
+    workdir = tmp_path / "workdir"
+    # workdir is NOT created — simulates host-terminated teardown
+    sf = _write_state(
+        tmp_path / "g",
+        {"status": "running", "pid": 999999, "workdir": str(workdir)},
+    )
+    assert gremlins.liveness_of_state_file(sf) == "dead:host-terminated"
+
+
+def test_liveness_crashed_when_pid_gone_but_workdir_exists(tmp_path):
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    sf = _write_state(
+        tmp_path / "g",
+        {"status": "running", "pid": 999999, "workdir": str(workdir)},
+    )
+    live = gremlins.liveness_of_state_file(sf)
+    assert live.startswith("dead:crashed")
+
+
+def test_liveness_crashed_when_pid_gone_and_no_workdir_in_state(tmp_path):
+    sf = _write_state(
+        tmp_path / "g",
+        {"status": "running", "pid": 999999},
+    )
+    live = gremlins.liveness_of_state_file(sf)
+    assert live.startswith("dead:crashed")
+
+
+# ---------------------------------------------------------------------------
+# rescue — dead:host-terminated handling
+# ---------------------------------------------------------------------------
+
+def test_rescue_host_terminated_project_root_gone_bails_headless(tmp_path, monkeypatch, capsys):
+    """When project_root is also missing, headless rescue should bail with host_terminated_unrecoverable."""
+    state_root = tmp_path / "state-root"
+    state_root.mkdir()
+    gr_id = "test-id-htbb12"
+    gr_dir = state_root / gr_id
+    workdir = tmp_path / "workdir"
+    # workdir is NOT created — simulates host teardown
+    state = {
+        "id": gr_id,
+        "kind": "localgremlin",
+        "stage": "implement",
+        "status": "running",
+        "pid": 999999,  # dead pid
+        "workdir": str(workdir),
+        "project_root": str(tmp_path / "gone-project"),  # also gone
+        "rescue_count": 0,
+    }
+    _write_state(gr_dir, state)
+    monkeypatch.setattr(gremlins, "STATE_ROOT", str(state_root))
+
+    ok = gremlins.do_rescue(gr_id, headless=True)
+    assert ok is False
+    new = json.loads((gr_dir / "state.json").read_text())
+    assert new["bail_reason"] == "host_terminated_unrecoverable"
+    assert (gr_dir / "finished").exists()
+    out = capsys.readouterr().out
+    assert "host" in out.lower() or "terminated" in out.lower() or "gone" in out.lower()
+
+
+def test_rescue_host_terminated_worktree_recreation_failure_bails_headless(tmp_path, monkeypatch, capsys):
+    """When worktree recreation fails, headless rescue should bail with host_terminated_unrecoverable."""
+    state_root = tmp_path / "state-root"
+    state_root.mkdir()
+    gr_id = "test-id-htcc12"
+    gr_dir = state_root / gr_id
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    workdir = tmp_path / "workdir"
+    # workdir NOT created
+    state = {
+        "id": gr_id,
+        "kind": "localgremlin",
+        "stage": "implement",
+        "status": "running",
+        "pid": 999999,
+        "workdir": str(workdir),
+        "project_root": str(project_root),
+        "rescue_count": 0,
+    }
+    _write_state(gr_dir, state)
+    monkeypatch.setattr(gremlins, "STATE_ROOT", str(state_root))
+    monkeypatch.setattr(gremlins, "_recreate_worktree", lambda s: (False, "git not a repo"))
+
+    ok = gremlins.do_rescue(gr_id, headless=True)
+    assert ok is False
+    new = json.loads((gr_dir / "state.json").read_text())
+    assert new["bail_reason"] == "host_terminated_unrecoverable"
+    assert (gr_dir / "finished").exists()
+
+
+def test_rescue_host_terminated_recreates_worktree_and_proceeds(tmp_path, monkeypatch, capsys):
+    """When worktree recreation succeeds, rescue continues to the diagnosis step."""
+    state_root = tmp_path / "state-root"
+    state_root.mkdir()
+    gr_id = "test-id-htdd12"
+    gr_dir = state_root / gr_id
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    workdir = tmp_path / "workdir"
+    # workdir NOT created initially
+    state = {
+        "id": gr_id,
+        "kind": "localgremlin",
+        "stage": "implement",
+        "status": "running",
+        "pid": 999999,
+        "workdir": str(workdir),
+        "project_root": str(project_root),
+        "rescue_count": 0,
+    }
+    _write_state(gr_dir, state)
+    monkeypatch.setattr(gremlins, "STATE_ROOT", str(state_root))
+
+    def fake_recreate(s):
+        workdir.mkdir(exist_ok=True)
+        return True, "recreated from branch 'bg/localgremlin/test-id-htdd12'"
+
+    monkeypatch.setattr(gremlins, "_recreate_worktree", fake_recreate)
+    monkeypatch.setattr(gremlins, "_run_headless_diagnosis",
+                        lambda *a, **kw: ("structural", "fake structural"))
+
+    ok = gremlins.do_rescue(gr_id, headless=True)
+    assert ok is False  # structural bail, not host-terminated
+    new = json.loads((gr_dir / "state.json").read_text())
+    # Should have bailed with "structural", not "host_terminated_unrecoverable"
+    assert new["bail_reason"] == "structural"
+    out = capsys.readouterr().out
+    assert "recreated" in out

--- a/skills/_bg/liveness.sh
+++ b/skills/_bg/liveness.sh
@@ -37,13 +37,13 @@ liveness_of_state_file() {
 
     # US (\x1f) separator, matching session-summary.sh and pipeline/fleet.py:
     # bash treats tab as IFS-whitespace and collapses consecutive empty
-    # columns, so a future 5th field could silently lose a value. US is
+    # columns, so a future 6th field could silently lose a value. US is
     # non-whitespace.
     IFS=$'\x1f' read -r gr_status gr_pid gr_exit_code gr_bail_reason gr_workdir < <(
         jq -r '[.status, (.pid // "" | tostring),
                 (.exit_code // "" | tostring),
                 (.bail_reason // ""),
-                (.workdir // "")] | join("")' "$sf" 2>/dev/null || true
+                (.workdir // "")] | join("\^_")' "$sf" 2>/dev/null || true
     )
 
     # Terminal: finish.sh (or headless rescue's bail path) wrote the

--- a/skills/_bg/liveness.sh
+++ b/skills/_bg/liveness.sh
@@ -32,17 +32,18 @@ liveness_of_state_file() {
     [[ -f "$sf" ]] || return 0
     # Note: avoid `status` as a local name — it's a special/readonly in zsh,
     # and this file is intended to be sourced from either bash or zsh hooks.
-    local wdir gr_status gr_pid gr_exit_code gr_bail_reason
+    local wdir gr_status gr_pid gr_exit_code gr_bail_reason gr_workdir
     wdir=$(dirname "$sf")
 
     # US (\x1f) separator, matching session-summary.sh and pipeline/fleet.py:
     # bash treats tab as IFS-whitespace and collapses consecutive empty
     # columns, so a future 5th field could silently lose a value. US is
     # non-whitespace.
-    IFS=$'\x1f' read -r gr_status gr_pid gr_exit_code gr_bail_reason < <(
+    IFS=$'\x1f' read -r gr_status gr_pid gr_exit_code gr_bail_reason gr_workdir < <(
         jq -r '[.status, (.pid // "" | tostring),
                 (.exit_code // "" | tostring),
-                (.bail_reason // "")] | join("\u001f")' "$sf" 2>/dev/null || true
+                (.bail_reason // ""),
+                (.workdir // "")] | join("")' "$sf" 2>/dev/null || true
     )
 
     # Terminal: finish.sh (or headless rescue's bail path) wrote the
@@ -63,7 +64,11 @@ liveness_of_state_file() {
     if [[ "$gr_status" == "running" ]]; then
         # PID gone but no finish marker → crashed silently.
         if [[ -n "$gr_pid" && "$gr_pid" != "null" ]] && ! kill -0 "$gr_pid" 2>/dev/null; then
-            echo "dead:crashed (pid $gr_pid gone)"
+            if [[ -n "$gr_workdir" && ! -d "$gr_workdir" ]]; then
+                echo "dead:host-terminated"
+            else
+                echo "dead:crashed (pid $gr_pid gone)"
+            fi
             return 0
         fi
 


### PR DESCRIPTION
## Summary

- Adds `dead:host-terminated` liveness label when pid is gone and the worktree directory no longer exists, distinguishing external host termination from a normal in-process crash
- Adds `_recreate_worktree` helper that reconstructs a missing worktree from the gremlin's recorded branch (preserving in-progress commits) or falls back to a detached checkout of `worktree_base`/HEAD
- `do_rescue` now handles `dead:host-terminated` by attempting worktree recreation before proceeding with normal diagnosis/relaunch; headless rescue bails with `host_terminated_unrecoverable` when recovery isn't possible
- Both the Python (`fleet/state.py`) and bash (`liveness.sh`) classifiers are updated in lockstep per their documented invariant

## Test plan

- [ ] `liveness_of_state_file` returns `dead:host-terminated` when pid is gone and workdir doesn't exist
- [ ] Returns `dead:crashed` when pid is gone but workdir exists (no regression)
- [ ] Headless rescue bails with `host_terminated_unrecoverable` when project_root is also gone
- [ ] Headless rescue bails with `host_terminated_unrecoverable` when worktree recreation fails
- [ ] Rescue proceeds to diagnosis step when worktree recreation succeeds
- [ ] Full test suite: 190 passed

Closes #160