### PR TITLE
fix: capture plan-title cost by switching to stream-json mode

### DIFF
--- a/gremlins/clients/claude.py
+++ b/gremlins/clients/claude.py
@@ -37,7 +37,8 @@ class CompletedRun:
     ``exit_code`` is always populated. ``session_id`` is extracted from the
     stream-json ``system.init`` event when available (None for text-mode runs
     or runs that crashed before emitting init). ``text_result`` holds the
-    captured stdout for ``output_format='text'`` runs and is None otherwise.
+    final text output: for stream-json runs this is the ``result`` field from
+    the ``result`` event; for text-mode runs it is the raw captured stdout.
     ``events`` is populated only when ``capture_events=True``; each entry is
     one parsed stream-json event. ``cost_usd`` is extracted from the
     stream-json ``result`` event when available.
@@ -152,13 +153,16 @@ def stream_events(
     raw_path: Optional[pathlib.Path] = None,
     capture: bool = False,
     on_event: Optional[Callable[[dict], None]] = None,
-) -> Tuple[Optional[str], Optional[float], Optional[List[dict]]]:
+) -> Tuple[Optional[str], Optional[float], Optional[str], Optional[List[dict]]]:
     """Read stream-json lines from stdout, render via _emit_event.
 
-    Returns (session_id, cost_usd, events). events is None when capture=False.
+    Returns (session_id, cost_usd, result_text, events).
+    result_text is the ``result`` field from the final result event (the
+    complete text output). events is None when capture=False.
     """
     session_id: Optional[str] = None
     cost_usd: Optional[float] = None
+    result_text: Optional[str] = None
     events: Optional[List[dict]] = [] if capture else None
 
     raw = None
@@ -187,6 +191,9 @@ def stream_events(
                 raw_cost = evt.get("total_cost_usd", evt.get("cost_usd"))
                 if isinstance(raw_cost, (int, float)):
                     cost_usd = float(raw_cost)
+                raw_result = evt.get("result")
+                if isinstance(raw_result, str):
+                    result_text = raw_result
             if events is not None:
                 events.append(evt)
             try:
@@ -201,7 +208,7 @@ def stream_events(
     finally:
         if raw is not None:
             raw.close()
-    return session_id, cost_usd, events
+    return session_id, cost_usd, result_text, events
 
 
 # ---------------------------------------------------------------------------
@@ -309,11 +316,12 @@ class SubprocessClaudeClient:
         events: Optional[List[dict]] = None  # populated only in stream-json mode
         prefix = f"[{label}] " if label else ""
         cost_usd: Optional[float] = None
+        stream_result_text: Optional[str] = None
 
         try:
             assert p.stdout is not None
             if output_format == "stream-json":
-                session_id, cost_usd, events = stream_events(
+                session_id, cost_usd, stream_result_text, events = stream_events(
                     p.stdout,
                     prefix=prefix,
                     raw_path=raw_path,
@@ -340,10 +348,15 @@ class SubprocessClaudeClient:
                 f"claude -p (model={model}, label={label}) exited {rc}"
             )
 
+        if output_format == "stream-json":
+            text_result = stream_result_text
+        else:
+            text_result = "".join(text_chunks)
+
         return CompletedRun(
             exit_code=rc,
             session_id=session_id,
-            text_result="".join(text_chunks) if output_format != "stream-json" else None,
+            text_result=text_result,
             events=events,
             cost_usd=cost_usd,
         )

--- a/gremlins/clients/fake.py
+++ b/gremlins/clients/fake.py
@@ -117,6 +117,7 @@ class FakeClaudeClient:
 
         session_id: Optional[str] = None
         cost_usd: Optional[float] = None
+        result_text: Optional[str] = None
         for evt in events:
             if (
                 session_id is None
@@ -130,6 +131,9 @@ class FakeClaudeClient:
                 if isinstance(raw_cost, (int, float)):
                     cost_usd = float(raw_cost)
                     self.total_cost_usd += cost_usd
+                raw_result = evt.get("result")
+                if isinstance(raw_result, str):
+                    result_text = raw_result
             if on_event is not None:
                 try:
                     on_event(evt)
@@ -139,7 +143,7 @@ class FakeClaudeClient:
         return CompletedRun(
             exit_code=0,
             session_id=session_id,
-            text_result=None,
+            text_result=result_text,
             events=events if capture_events else None,
             cost_usd=cost_usd,
         )

--- a/gremlins/orchestrators/gh.py
+++ b/gremlins/orchestrators/gh.py
@@ -209,7 +209,7 @@ def _resolve_plan_source(
             flush=True,
         )
 
-        # Generate issue title via claude in text mode
+        # Generate issue title via claude
         title_prompt = (
             "Produce a concise GitHub issue title (under 80 characters) "
             "summarizing the spec below. Output ONLY the title, nothing else."
@@ -219,7 +219,6 @@ def _resolve_plan_source(
             title_prompt,
             label="plan-title",
             model=model,
-            output_format="text",
         )
         parts = (completed.text_result or "").strip().splitlines()
         issue_title = parts[0][:80] if parts else ""

--- a/gremlins/tests/fixtures/fake_claude.py
+++ b/gremlins/tests/fixtures/fake_claude.py
@@ -211,7 +211,7 @@ def handle_plan_title(prompt: str, session_id: str) -> int:
     emit_event({"type": "system", "subtype": "init", "session_id": session_id,
                 "model": "fake", "cwd": os.getcwd()})
     emit_event({"type": "result", "subtype": "success", "num_turns": 1,
-                "total_cost_usd": 0, "result": "Test issue title from fake claude"})
+                "total_cost_usd": 0.0, "result": "Test issue title from fake claude"})
     return 0
 
 

--- a/gremlins/tests/fixtures/fake_claude.py
+++ b/gremlins/tests/fixtures/fake_claude.py
@@ -206,10 +206,12 @@ def handle_ghplan(prompt: str, session_id: str) -> int:
     return 0
 
 
-def handle_text_title(prompt: str) -> int:
+def handle_plan_title(prompt: str, session_id: str) -> int:
     # `--plan <file>` flow asks for a one-line GitHub issue title.
-    sys.stdout.write("Test issue title from fake claude\n")
-    sys.stdout.flush()
+    emit_event({"type": "system", "subtype": "init", "session_id": session_id,
+                "model": "fake", "cwd": os.getcwd()})
+    emit_event({"type": "result", "subtype": "success", "num_turns": 1,
+                "total_cost_usd": 0, "result": "Test issue title from fake claude"})
     return 0
 
 
@@ -299,13 +301,12 @@ def main(argv):
     maybe_fail_at(stage)
 
     if args.output_format == "text":
-        if stage == "plan-title":
-            return handle_text_title(prompt)
         sys.stdout.write("(fake text output)\n")
         return 0
 
     handlers = {
         "plan": handle_plan,
+        "plan-title": handle_plan_title,
         "implement-local": handle_implement,
         "implement-gh": handle_implement,
         "review": handle_review,

--- a/gremlins/tests/test_ghgremlin_shell.py
+++ b/gremlins/tests/test_ghgremlin_shell.py
@@ -121,7 +121,7 @@ def test_ghgremlin_plan_file_full_chain(tmp_path):
 
     log = read_fake_claude_log(sh.fake_claude_log)
     stages = [e["stage"] for e in log]
-    # plan-title runs because --plan <file> needs a title via claude text mode.
+    # plan-title runs because --plan <file> needs a title via claude.
     assert "plan-title" in stages
     # plan stage (the /ghplan one) must NOT run because --plan supplied.
     assert "ghplan" not in stages


### PR DESCRIPTION
## Summary

- `stream_events` now extracts and returns `result_text` from the `result` event's `"result"` field (return type expands from 3-tuple to 4-tuple)
- `SubprocessClaudeClient.run()` populates `CompletedRun.text_result` from that value in stream-json mode, so callers get the text output regardless of format
- The plan-title call in `gh.py` drops `output_format="text"`, defaulting to stream-json — cost now flows into `_total_cost_usd` and appears in the reported/persisted pipeline total
- `FakeClaudeClient` and `fake_claude.py` updated to match the new stream-json shape for plan-title

## Test plan

- [ ] All 190 existing tests pass (`cd gremlins && PYTHONPATH=. python -m pytest`)
- [ ] `test_ghgremlin_plan_file` asserts `"plan-title" in stages` — still passes with stream-json fixture

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)