### PR TITLE
fix: advance boss workdir HEAD after each local child lands

### DIFF
--- a/gremlins/orchestrators/boss.py
+++ b/gremlins/orchestrators/boss.py
@@ -475,6 +475,22 @@ def land_child(child_id: str) -> bool:
     ) == 0
 
 
+def advance_boss_workdir(boss_workdir: str, new_head: str) -> None:
+    """Fast-forward the boss worktree's HEAD to match project_root after a local land.
+
+    Local child gremlins squash-land into project_root, leaving the boss's
+    own worktree frozen at the chain-start SHA. Resetting here ensures each
+    subsequent handoff sees the full accumulated diff instead of an empty one.
+    """
+    r = subprocess.run(
+        ["git", "reset", "--hard", new_head],
+        capture_output=True, text=True, cwd=boss_workdir,
+    )
+    if r.returncode != 0:
+        die(f"git reset --hard {new_head[:12]} failed in boss workdir {boss_workdir}: {r.stderr.strip()}")
+    log(f"advanced boss workdir HEAD to {new_head[:12]}")
+
+
 def rescue_child(child_id: str) -> bool:
     log(f"rescuing child {child_id} (headless)")
     return run_proc(
@@ -805,6 +821,8 @@ def boss_main(argv: List[str]) -> int:
             if success:
                 set_stage(gr_id, "landing")
                 if land_child(current_child_id):
+                    if chain_kind == "local" and boss_workdir and os.path.isdir(boss_workdir):
+                        advance_boss_workdir(boss_workdir, get_head_ref(project_root))
                     outcome = "rescued-then-landed" if was_rescued else "landed"
                     log(f"child {current_child_id} {outcome}")
                     boss_state["children"].append({"id": current_child_id, "outcome": outcome})

--- a/gremlins/orchestrators/boss.py
+++ b/gremlins/orchestrators/boss.py
@@ -476,7 +476,7 @@ def land_child(child_id: str) -> bool:
 
 
 def advance_boss_workdir(boss_workdir: str, new_head: str) -> None:
-    """Fast-forward the boss worktree's HEAD to match project_root after a local land.
+    """Reset the boss worktree's HEAD to match project_root after a local land.
 
     Local child gremlins squash-land into project_root, leaving the boss's
     own worktree frozen at the chain-start SHA. Resetting here ensures each
@@ -821,7 +821,9 @@ def boss_main(argv: List[str]) -> int:
             if success:
                 set_stage(gr_id, "landing")
                 if land_child(current_child_id):
-                    if chain_kind == "local" and boss_workdir and os.path.isdir(boss_workdir):
+                    if chain_kind == "local":
+                        if not boss_workdir or not os.path.isdir(boss_workdir):
+                            die(f"boss workdir not usable after local land: {boss_workdir!r}")
                         advance_boss_workdir(boss_workdir, get_head_ref(project_root))
                     outcome = "rescued-then-landed" if was_rescued else "landed"
                     log(f"child {current_child_id} {outcome}")

--- a/gremlins/tests/test_orchestrator_boss.py
+++ b/gremlins/tests/test_orchestrator_boss.py
@@ -11,6 +11,7 @@ import gremlins.orchestrators.boss as boss_mod
 from gremlins.orchestrators.boss import (
     _resolve_plan_source,
     _summarize_for_log,
+    advance_boss_workdir,
     boss_main,
     get_child_bail_detail,
     get_child_bail_reason,
@@ -52,6 +53,7 @@ def _common_boss_patches(monkeypatch, tmp_path, gr_id):
     monkeypatch.setattr(boss_mod, "set_stage", lambda *a: None)
     monkeypatch.setattr(boss_mod, "get_head_ref", lambda p: "abc123def456abc1")
     monkeypatch.setattr(boss_mod, "get_current_branch", lambda p: "main")
+    monkeypatch.setattr(boss_mod, "advance_boss_workdir", lambda *a: None)
 
 
 # ---------------------------------------------------------------------------
@@ -973,3 +975,133 @@ def test_boss_main_plan_issue_ref_snapshots_spec(tmp_path, monkeypatch):
     # works for short specs (regression coverage for the StopIteration bug).
     state_data = json.loads((state_dir / "state.json").read_text())
     assert state_data.get("description") == "Plan from issue"
+
+
+# ---------------------------------------------------------------------------
+# advance_boss_workdir: called after local child lands
+# ---------------------------------------------------------------------------
+
+def test_advance_boss_workdir_called_after_local_land(tmp_path, monkeypatch):
+    """After a local child lands, advance_boss_workdir is called with the new project_root HEAD."""
+    gr_id = "test-boss-advance-aabb12"
+    state_dir, project_root, workdir = _make_gremlin_state(tmp_path, gr_id)
+    _common_boss_patches(monkeypatch, tmp_path, gr_id)
+
+    new_head = "newhead1234567890newhead12345678"
+    monkeypatch.setattr(boss_mod, "get_head_ref", lambda p: new_head)
+
+    spec = tmp_path / "spec.md"
+    spec.write_text("# Spec\n")
+    child_plan = tmp_path / "child-plan.md"
+    child_plan.write_text("# Child plan\n")
+
+    advance_calls = []
+
+    def fake_advance_boss_workdir(boss_workdir, head):
+        advance_calls.append((boss_workdir, head))
+
+    handoff_results = iter([
+        ("next-plan", {"exit_state": "next-plan", "child_plan": str(child_plan), "operator_followups": []}),
+        ("chain-done", {"exit_state": "chain-done", "operator_followups": []}),
+    ])
+
+    def fake_run_handoff(gr_id, state_dir, boss_state, project_root, boss_workdir, model):
+        exit_state, sig = next(handoff_results)
+        n = boss_state["handoff_count"] + 1
+        out_path = os.path.join(state_dir, f"handoff-{n:03d}.md")
+        pathlib.Path(out_path).write_text(f"# Handoff {n}\n")
+        boss_state["handoff_count"] = n
+        boss_state["current_plan"] = out_path
+        boss_state["operator_followups"] = sig.get("operator_followups", [])
+        boss_state["handoff_records"].append({
+            "timestamp": "2026-01-01T00:00:00Z",
+            "n": n,
+            "plan_in": boss_state["spec_path"],
+            "plan_out": out_path,
+            "signal_file": out_path.replace(".md", ".state.json"),
+            "exit_state": exit_state,
+            "child_plan": sig.get("child_plan"),
+            "bail_reason": None,
+            "operator_followups": sig.get("operator_followups", []),
+        })
+        return exit_state, sig
+
+    def fake_launch_child(gr_id, launch_kind, child_plan_path):
+        child_id = "child-advance-test-112233"
+        child_dir = tmp_path / child_id
+        child_dir.mkdir(exist_ok=True)
+        (child_dir / "state.json").write_text(json.dumps({"exit_code": 0}))
+        (child_dir / "finished").write_text("")
+        return child_id
+
+    monkeypatch.setattr(boss_mod, "run_handoff", fake_run_handoff)
+    monkeypatch.setattr(boss_mod, "launch_child", fake_launch_child)
+    monkeypatch.setattr(boss_mod, "land_child", lambda cid: True)
+    monkeypatch.setattr(boss_mod, "advance_boss_workdir", fake_advance_boss_workdir)
+
+    result = boss_main(["--plan", str(spec), "--chain-kind", "local"])
+    assert result == 0
+
+    assert len(advance_calls) == 1
+    called_workdir, called_head = advance_calls[0]
+    assert called_workdir == str(workdir)
+    assert called_head == new_head
+
+
+def test_advance_boss_workdir_not_called_for_gh_chain(tmp_path, monkeypatch):
+    """advance_boss_workdir is NOT called for gh chains (they use origin/<branch> instead)."""
+    gr_id = "test-boss-advance-gh-cc3344"
+    state_dir, project_root, workdir = _make_gremlin_state(tmp_path, gr_id)
+    _common_boss_patches(monkeypatch, tmp_path, gr_id)
+    monkeypatch.setattr(boss_mod, "get_default_branch", lambda p: "main")
+    monkeypatch.setattr(boss_mod, "get_remote_branch_sha", lambda p, b: "deadbeef12345678")
+
+    spec = tmp_path / "spec.md"
+    spec.write_text("# Spec\n")
+    child_plan = tmp_path / "child-plan.md"
+    child_plan.write_text("# Child plan\n")
+
+    advance_calls = []
+
+    handoff_results = iter([
+        ("next-plan", {"exit_state": "next-plan", "child_plan": str(child_plan), "operator_followups": []}),
+        ("chain-done", {"exit_state": "chain-done", "operator_followups": []}),
+    ])
+
+    def fake_run_handoff(gr_id, state_dir, boss_state, project_root, boss_workdir, model):
+        exit_state, sig = next(handoff_results)
+        n = boss_state["handoff_count"] + 1
+        out_path = os.path.join(state_dir, f"handoff-{n:03d}.md")
+        pathlib.Path(out_path).write_text(f"# Handoff {n}\n")
+        boss_state["handoff_count"] = n
+        boss_state["current_plan"] = out_path
+        boss_state["operator_followups"] = sig.get("operator_followups", [])
+        boss_state["handoff_records"].append({
+            "timestamp": "2026-01-01T00:00:00Z",
+            "n": n,
+            "plan_in": boss_state["spec_path"],
+            "plan_out": out_path,
+            "signal_file": "",
+            "exit_state": exit_state,
+            "child_plan": sig.get("child_plan"),
+            "bail_reason": None,
+            "operator_followups": sig.get("operator_followups", []),
+        })
+        return exit_state, sig
+
+    def fake_launch_child(gr_id, launch_kind, child_plan_path):
+        child_id = "child-gh-advance-dd5566"
+        child_dir = tmp_path / child_id
+        child_dir.mkdir(exist_ok=True)
+        (child_dir / "state.json").write_text(json.dumps({"exit_code": 0}))
+        (child_dir / "finished").write_text("")
+        return child_id
+
+    monkeypatch.setattr(boss_mod, "run_handoff", fake_run_handoff)
+    monkeypatch.setattr(boss_mod, "launch_child", fake_launch_child)
+    monkeypatch.setattr(boss_mod, "land_child", lambda cid: True)
+    monkeypatch.setattr(boss_mod, "advance_boss_workdir", lambda *a: advance_calls.append(a))
+
+    result = boss_main(["--plan", str(spec), "--chain-kind", "gh"])
+    assert result == 0
+    assert advance_calls == []


### PR DESCRIPTION
## Summary

- After a local child lands, `fleet land` squash-merges into `project_root` but the boss's own worktree stays frozen at the chain-start SHA — causing every subsequent handoff to see an empty diff and re-plan the same phase
- Add `advance_boss_workdir(boss_workdir, new_head)` helper that runs `git reset --hard` in the boss worktree after each successful local land
- gh chains are unaffected (they use `origin/<target_branch>` with an explicit fetch)
- Regression tests verify the helper is called with the correct args for local chains and skipped for gh chains

## Test plan

- [ ] `cd gremlins && PYTHONPATH=. python -m pytest tests/test_orchestrator_boss.py -v` — all 34 tests pass
- [ ] `test_advance_boss_workdir_called_after_local_land` — verifies helper called with correct workdir and HEAD
- [ ] `test_advance_boss_workdir_not_called_for_gh_chain` — verifies gh chains are unaffected

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)