### PR TITLE
feat: add sanitize pass to handoff rolling plan output

### DIFF
--- a/gremlins/handoff.py
+++ b/gremlins/handoff.py
@@ -245,7 +245,7 @@ def build_sanitize_prompt(rolling_plan_text: str, out_path: pathlib.Path) -> str
 
 ## What to keep
 
-Keep all remaining task lists (`- [ ] ...`), open questions, context relevant to what is still to be done, and operator follow-ups. Do not add any content that was not in the original.
+Keep all remaining task lists (`- [ ] ...`), open questions, context relevant to what is still to be done, and operator follow-ups. You may make minimal wording changes only when needed to satisfy the rules above, such as replacing a too-broad H1 with one scoped to the remaining work or rephrasing surrounding context so it refers only to unfinished work. Do not invent new tasks, requirements, decisions, or factual claims that are not supported by the original.
 
 ## Output
 
@@ -268,16 +268,37 @@ def sanitize_rolling_plan(out_path: pathlib.Path, timeout: Optional[int]) -> Non
     except OSError as exc:
         sys.stderr.write(f"warning: sanitize skipped — could not read rolling plan: {exc}\n")
         return
+    def restore_original(reason: str) -> None:
+        try:
+            out_path.write_text(plan_text, encoding="utf-8")
+        except OSError as exc:
+            sys.stderr.write(
+                f"warning: {reason} — failed to restore original rolling plan: {exc}\n"
+            )
+            return
+        sys.stderr.write(f"warning: {reason} — restored original rolling plan\n")
+
+    sanitize_timeout = min(timeout, 60) if timeout is not None else 60
     prompt = build_sanitize_prompt(plan_text, out_path)
     cmd = ["claude", "-p", "--model", "haiku", *CLAUDE_FLAGS, prompt]
     print("==> sanitizing rolling plan", flush=True)
     try:
-        result = subprocess.run(cmd, timeout=timeout)
+        result = subprocess.run(cmd, timeout=sanitize_timeout, capture_output=True, text=True)
     except subprocess.TimeoutExpired:
-        sys.stderr.write("warning: sanitize pass timed out — keeping original\n")
+        restore_original("sanitize pass timed out")
         return
+    if result.stderr:
+        sys.stderr.write(f"warning: sanitize stderr:\n{result.stderr}")
     if result.returncode != 0:
-        sys.stderr.write(f"warning: sanitize pass exited {result.returncode} — keeping original\n")
+        restore_original(f"sanitize pass exited {result.returncode}")
+        return
+    try:
+        sanitized_text = out_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        restore_original(f"sanitize pass completed but output could not be read: {exc}")
+        return
+    if not sanitized_text.strip():
+        restore_original("sanitize pass completed but output was empty")
 
 
 def parse_args(argv: List[str]) -> argparse.Namespace:
@@ -290,7 +311,7 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     parser.add_argument("--base", dest="base", default=None)
     parser.add_argument("--model", dest="model", default="sonnet")
     parser.add_argument("--timeout", dest="timeout", type=int, default=None,
-                        help="timeout in seconds for the inner claude agent (default: no timeout)")
+                        help="timeout in seconds for the main handoff agent (default: no timeout); the sanitize pass is capped at min(timeout, 60)s")
     parser.add_argument("--rev", dest="rev", default=None,
                         help="inspect this ref instead of HEAD (e.g. a target branch name)")
     return parser.parse_args(argv)

--- a/gremlins/handoff.py
+++ b/gremlins/handoff.py
@@ -182,7 +182,14 @@ If the spec author wrote operator-flavoured language inline with implementation 
 
 5. Write an **updated plan document** (the "rolling plan") to: `{out_path}`
 
-   The rolling plan describes only **remaining** work. Completed tasks are removed entirely — no `[x]` markers, no struck-through entries, no "completed" appendix. The chain of versioned plan files plus git history is the audit trail; the rolling plan does not repeat it. Do not propagate the overarching goal of the chain forward into the rolling plan — that lives upstream, in the original spec.
+   The rolling plan describes only **remaining** work. These forms are **never** allowed anywhere in the document, at any position:
+   - Prose statements about what has landed, shipped, merged, or been completed — e.g. "Phases 0–3 have landed", "X was merged in PR #N", "the following work is complete", "all tasks in this phase are done"
+   - Bullet lists enumerating completed phases or items
+   - `[x]` checkboxes or checked markers of any kind
+   - Struck-through entries (~~text~~)
+   - An H1 title (`# ...`) that names the overall chain goal or summarizes the completed chain — scope the H1 to the remaining work only; e.g. use `# Add sanitize pass` not `# Implement Full Feature X`
+
+   The chain of versioned plan files plus git history is the audit trail; the rolling plan does not repeat it. Do not propagate the overarching goal of the chain forward into the rolling plan — that lives upstream, in the original spec.
 
    - **`next-plan`**: include only the implementation tasks that are not yet implemented (still `[ ]`). Prune the surrounding sections (`## Context`, `## Approach`, `## Open questions`, etc.) to match: drop sections whose reason for existing was a now-completed task; keep or trim the rest so the document stays a coherent description of the remaining work.
      - Under `## Open questions`, carry forward unresolved entries; drop entries tied to completed tasks.
@@ -223,6 +230,54 @@ If the spec author wrote operator-flavoured language inline with implementation 
    - `operator_followups`: an array of one-line strings describing every pending operator task, mirroring the rolling plan's `## Operator follow-ups` section. Empty array `[]` if there are none. Required on every exit state — including `chain-done`, where this is how the boss orchestrator learns about operator tasks the human still owes after the rolling plan has been pruned to a "chain complete" note.
 
 Write all required files before finishing. Do not explain your reasoning in stdout — the files are the output."""
+
+
+def build_sanitize_prompt(rolling_plan_text: str, out_path: pathlib.Path) -> str:
+    return f"""You are a format-enforcement agent. Rewrite the rolling plan below to remove every violation of the rules listed here, then write ONLY the rewritten document to: {out_path}
+
+## Rules — these patterns are NEVER allowed anywhere in the document
+
+1. Prose statements about what has landed, shipped, merged, or been completed at any document position — e.g. "Phases 0–3 have landed", "X was merged in PR #N", "the following work is complete", "all tasks in this phase are done". Remove such sentences entirely.
+2. Bullet lists enumerating completed phases or items — any bullet that describes something already done. Remove them.
+3. `[x]` checkboxes or checked markers of any kind. Remove the entire line.
+4. Struck-through entries (~~text~~). Remove the entire line.
+5. An H1 title (`# ...`) that names the overall chain goal or summarizes the completed chain — e.g. `# Implement Feature X` or `# Claude Config Personal Setup`. Replace it with a short H1 scoped only to the remaining work.
+
+## What to keep
+
+Keep all remaining task lists (`- [ ] ...`), open questions, context relevant to what is still to be done, and operator follow-ups. Do not add any content that was not in the original.
+
+## Output
+
+Write ONLY the rewritten document to: {out_path}
+Do not print the document to stdout. Do not explain what you changed.
+
+## Rolling plan to rewrite
+
+~~~~
+{rolling_plan_text}
+~~~~"""
+
+
+def sanitize_rolling_plan(out_path: pathlib.Path, timeout: Optional[int]) -> None:
+    if not out_path.exists():
+        sys.stderr.write(f"warning: sanitize skipped — rolling plan not found: {out_path}\n")
+        return
+    try:
+        plan_text = out_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        sys.stderr.write(f"warning: sanitize skipped — could not read rolling plan: {exc}\n")
+        return
+    prompt = build_sanitize_prompt(plan_text, out_path)
+    cmd = ["claude", "-p", "--model", "haiku", *CLAUDE_FLAGS, prompt]
+    print("==> sanitizing rolling plan", flush=True)
+    try:
+        result = subprocess.run(cmd, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("warning: sanitize pass timed out — keeping original\n")
+        return
+    if result.returncode != 0:
+        sys.stderr.write(f"warning: sanitize pass exited {result.returncode} — keeping original\n")
 
 
 def parse_args(argv: List[str]) -> argparse.Namespace:
@@ -367,6 +422,7 @@ def main(argv: List[str]) -> int:
         for item in followups:
             print(f"      - {item}", flush=True)
 
+    sanitize_rolling_plan(out_path, args.timeout)
     return 0
 
 

--- a/gremlins/tests/fixtures/handoff_bad_chain_done.md
+++ b/gremlins/tests/fixtures/handoff_bad_chain_done.md
@@ -1,0 +1,12 @@
+# Claude Config Personal Setup
+
+Chain complete. All six phases of the implementation have been merged:
+
+- Phase 0: Initial sync script and tracked-path inventory
+- Phase 1: Skill directory structure and shim entrypoints
+- Phase 2: Gremlins package extraction from monolithic skills
+- Phase 3: Fleet manager package refactor
+- Phase 4: Boss gremlin chained workflow
+- Phase 5: Handoff agent sanitize pass
+
+The rolling plan is now closed. No further implementation tasks remain.

--- a/gremlins/tests/fixtures/handoff_bad_next_plan.md
+++ b/gremlins/tests/fixtures/handoff_bad_next_plan.md
@@ -1,0 +1,21 @@
+# Claude Config Personal Setup
+
+Phases 0–3 have landed. The sync script, skill structure, and initial gremlins package are all in place. The fleet manager and boss gremlin are merged and working.
+
+## Context
+
+The remaining work is to add the sanitize pass and test coverage for the handoff agent's rolling plan output.
+
+## Approach
+
+Add `build_sanitize_prompt` and `sanitize_rolling_plan` to `gremlins/handoff.py`. After the main agent writes the rolling plan, run a second `claude -p --model haiku` pass that enforces format rules mechanically and overwrites the file in-place. Failure is non-fatal.
+
+## Tasks
+
+- [ ] Task 5: Add `build_sanitize_prompt` and `sanitize_rolling_plan` helpers
+- [ ] Task 6: Call `sanitize_rolling_plan` from `main()` for all exit states
+- [ ] Task 7: Add tests and fixture files
+
+## Open questions
+
+(none)

--- a/gremlins/tests/test_handoff.py
+++ b/gremlins/tests/test_handoff.py
@@ -281,13 +281,20 @@ def test_main_next_plan_signal(monkeypatch, tmp_path, capsys):
         "reason": None,
         "operator_followups": [],
     }
+    out_path = handoff.auto_name_out(plan_path)
+    call_count2 = [0]
+
+    def fake_run2(cmd, **kw):
+        call_count2[0] += 1
+        if call_count2[0] == 1:
+            sig_path.write_text(json.dumps(payload))
+            child_path.write_text("# Child\n")
+            out_path.write_text("# Rolling plan\n")
+        return subprocess.CompletedProcess(args=cmd, returncode=0)
+
     monkeypatch.setattr(handoff, "collect_git_context",
                         lambda base_ref, rev=None: ("b", "", ""))
-    monkeypatch.setattr(handoff.subprocess, "run", lambda cmd, **kw: (
-        sig_path.write_text(json.dumps(payload)),
-        child_path.write_text("# Child\n"),
-        subprocess.CompletedProcess(args=cmd, returncode=0),
-    )[-1])
+    monkeypatch.setattr(handoff.subprocess, "run", fake_run2)
 
     rc = handoff.main(["--plan", str(plan_path)])
     assert rc == 0

--- a/gremlins/tests/test_handoff.py
+++ b/gremlins/tests/test_handoff.py
@@ -8,6 +8,8 @@ import pytest
 
 from gremlins import handoff
 
+FIXTURES = pathlib.Path(__file__).parent / "fixtures"
+
 
 # ---------------------------------------------------------------------------
 # auto_name_out — naming convention
@@ -211,6 +213,9 @@ def _stub_happy_main(monkeypatch, tmp_path, signal_payload, *,
     If `child_plan_text` is given, the fake claude run also writes the
     child plan file to whatever path the prompt says it should go to.
     Returns the plan path so the caller can pass it to handoff.main.
+
+    The first subprocess.run call is the main agent (writes sig_path and
+    out_path); the second call is the sanitize pass (treated as a no-op).
     """
     plan_path = tmp_path / "plan.md"
     plan_path.write_text("# Plan\nTasks\n- [ ] thing\n")
@@ -223,14 +228,22 @@ def _stub_happy_main(monkeypatch, tmp_path, signal_payload, *,
     sig_path = out_path.parent / (out_path.stem + ".state.json")
     child_path = out_path.parent / (out_path.stem + "-child" + out_path.suffix)
 
+    call_count = [0]
+
     def fake_run(cmd, **kwargs):
         if claude_timeout:
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout") or 1)
-        if claude_returncode == 0:
-            sig_path.write_text(json.dumps(signal_payload))
-            if child_plan_text is not None:
-                child_path.write_text(child_plan_text)
-        return subprocess.CompletedProcess(args=cmd, returncode=claude_returncode)
+        call_count[0] += 1
+        if call_count[0] == 1:
+            # Main agent call
+            if claude_returncode == 0:
+                sig_path.write_text(json.dumps(signal_payload))
+                out_path.write_text("# Rolling plan (stub)\n")
+                if child_plan_text is not None:
+                    child_path.write_text(child_plan_text)
+            return subprocess.CompletedProcess(args=cmd, returncode=claude_returncode)
+        # Second call is the sanitize pass — no-op
+        return subprocess.CompletedProcess(args=cmd, returncode=0)
 
     monkeypatch.setattr(handoff.subprocess, "run", fake_run)
     return plan_path, sig_path, child_path
@@ -414,3 +427,93 @@ def test_main_missing_spec_warns_and_continues(monkeypatch, tmp_path, capsys):
     err = capsys.readouterr().err
     assert "warning" in err.lower()
     assert "spec" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# build_sanitize_prompt — rule coverage
+# ---------------------------------------------------------------------------
+
+def test_build_sanitize_prompt_rules(tmp_path):
+    out_path = tmp_path / "rolling.md"
+    prompt = handoff.build_sanitize_prompt("# Plan\n- [ ] do thing\n", out_path)
+    # Each prohibited pattern must be explicitly named
+    assert "[x]" in prompt
+    assert "~~" in prompt or "struck-through" in prompt.lower()
+    assert "H1" in prompt or "# ..." in prompt
+    assert str(out_path) in prompt
+    # Prose-about-landing and bullet-of-completed-items
+    assert any(word in prompt.lower() for word in ("landed", "shipped", "merged", "completed"))
+    assert "bullet" in prompt.lower()
+
+
+# ---------------------------------------------------------------------------
+# sanitize_rolling_plan — behaviour
+# ---------------------------------------------------------------------------
+
+def test_sanitize_rolling_plan_rewrites_file(monkeypatch, tmp_path):
+    out_path = tmp_path / "rolling.md"
+    out_path.write_text("# Bad Plan\nPhases 0–3 have landed.\n- [ ] remaining task\n")
+    cleaned = "# Remaining Work\n- [ ] remaining task\n"
+
+    def fake_run(cmd, **kwargs):
+        out_path.write_text(cleaned)
+        return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+    monkeypatch.setattr(handoff.subprocess, "run", fake_run)
+    handoff.sanitize_rolling_plan(out_path, timeout=None)
+    assert out_path.read_text() == cleaned
+
+
+def test_sanitize_rolling_plan_nonzero_is_nonfatal(monkeypatch, tmp_path, capsys):
+    plan_path = tmp_path / "plan.md"
+    plan_path.write_text("# Plan\n- [ ] task\n")
+    monkeypatch.setattr(handoff.shutil, "which", lambda n: "/fake/claude")
+    monkeypatch.setattr(handoff, "collect_git_context",
+                        lambda base_ref, rev=None: ("b", "", ""))
+
+    out_path = handoff.auto_name_out(plan_path)
+    sig_path = out_path.parent / (out_path.stem + ".state.json")
+    payload = {
+        "exit_state": "chain-done",
+        "child_plan": None,
+        "reason": None,
+        "operator_followups": [],
+    }
+
+    call_count = [0]
+
+    def fake_run(cmd, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            sig_path.write_text(json.dumps(payload))
+            out_path.write_text("# Rolling plan\n")
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+        # Sanitize pass — return non-zero
+        return subprocess.CompletedProcess(args=cmd, returncode=1)
+
+    monkeypatch.setattr(handoff.subprocess, "run", fake_run)
+    rc = handoff.main(["--plan", str(plan_path)])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "warning" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# sanitize regression — fixture violations
+# ---------------------------------------------------------------------------
+
+def test_sanitize_prompt_rejects_phases_preamble():
+    bad = (FIXTURES / "handoff_bad_next_plan.md").read_text()
+    prompt = handoff.build_sanitize_prompt(bad, pathlib.Path("/tmp/out.md"))
+    # Prompt must contain a rule covering "Phases 0–3 have landed"-style prose
+    assert any(word in prompt.lower() for word in ("landed", "shipped", "merged", "completed"))
+    # The bad content is present for the agent to rewrite
+    assert bad in prompt
+
+
+def test_sanitize_prompt_rejects_chain_complete_enumeration():
+    bad = (FIXTURES / "handoff_bad_chain_done.md").read_text()
+    prompt = handoff.build_sanitize_prompt(bad, pathlib.Path("/tmp/out.md"))
+    # Prompt must contain a rule covering bullet enumerations of completed items
+    assert "bullet" in prompt.lower()
+    assert bad in prompt


### PR DESCRIPTION
## Summary

- Adds `build_sanitize_prompt` and `sanitize_rolling_plan` to `gremlins/handoff.py`: after the main agent writes the rolling plan, a second `claude -p --model haiku` call strips prose-about-landing, bullet lists of completed items, `[x]` markers, struck-through entries, and goal-naming H1 titles
- Sanitize failure is non-fatal — logs a warning and keeps the original
- Tightens `build_prompt` format rules from three exemplary prohibited forms to an exhaustive five-point list
- Adds 7 new tests and two fixture files reproducing the real violation patterns from #169

## Test plan

- [ ] `cd gremlins && PYTHONPATH=. python -m pytest tests/test_handoff.py` — all 34 tests pass

Closes #171