### PR TITLE
fix: land boss children into boss worktree, not project_root

### DIFF
--- a/gremlins/fleet/cli.py
+++ b/gremlins/fleet/cli.py
@@ -143,6 +143,9 @@ def _dispatch_subcommand(argv: List[str]):
             into_idx = raw.index("--into")
             if into_idx + 1 < len(raw):
                 into_dir = raw[into_idx + 1]
+            else:
+                print("error: --into requires a directory argument")
+                sys.exit(1)
         ok = do_land(target, force=force, mode=mode, into_dir=into_dir)
     else:
         headless = "--headless" in raw

--- a/gremlins/fleet/cli.py
+++ b/gremlins/fleet/cli.py
@@ -138,7 +138,12 @@ def _dispatch_subcommand(argv: List[str]):
             print("error: --squash and --ff are mutually exclusive")
             sys.exit(1)
         mode = "squash" if squash_flag else ("ff" if ff_flag else None)
-        ok = do_land(target, force=force, mode=mode)
+        into_dir = ""
+        if "--into" in raw:
+            into_idx = raw.index("--into")
+            if into_idx + 1 < len(raw):
+                into_dir = raw[into_idx + 1]
+        ok = do_land(target, force=force, mode=mode, into_dir=into_dir)
     else:
         headless = "--headless" in raw
         ok = do_rescue(target, headless=headless)

--- a/gremlins/fleet/land.py
+++ b/gremlins/fleet/land.py
@@ -544,7 +544,7 @@ def _ff_land(gr_id: str, sf: str, wdir: str, state: dict, cwd,
     return True
 
 
-def _land_local(gr_id: str, sf: str, wdir: str, state: dict, mode: str) -> bool:
+def _land_local(gr_id: str, sf: str, wdir: str, state: dict, mode: str, into_dir: str = "") -> bool:
     """Land a local gremlin branch onto the current branch (mode: 'squash' or 'ff')."""
     setup_kind = state.get("setup_kind", "")
     if setup_kind != "worktree-branch":
@@ -557,7 +557,13 @@ def _land_local(gr_id: str, sf: str, wdir: str, state: dict, mode: str) -> bool:
         return False
 
     project_root = state.get("project_root") or ""
-    cwd = project_root if project_root and os.path.isdir(project_root) else None
+    if into_dir:
+        if not os.path.isdir(into_dir):
+            print(f"error: --into directory does not exist: {into_dir!r}")
+            return False
+        cwd = into_dir
+    else:
+        cwd = project_root if project_root and os.path.isdir(project_root) else None
 
     r = subprocess.run(
         ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
@@ -735,7 +741,7 @@ def _land_gh(gr_id: str, sf: str, wdir: str, state: dict, force: bool = False) -
     return True
 
 
-def do_land(target: str, force: bool = False, mode: str = None) -> bool:
+def do_land(target: str, force: bool = False, mode: str = None, into_dir: str = "") -> bool:
     match = resolve_gremlin(target)
     if match is None:
         return False
@@ -756,7 +762,7 @@ def do_land(target: str, force: bool = False, mode: str = None) -> bool:
         if live != "dead:finished":
             print(f"gremlin {gr_id} is not finished (liveness: {live})")
             return False
-        return _land_local(gr_id, sf, wdir, state, mode or "squash")
+        return _land_local(gr_id, sf, wdir, state, mode or "squash", into_dir=into_dir)
     elif kind == "bossgremlin":
         if live != "dead:finished":
             print(f"gremlin {gr_id} is not finished (liveness: {live})")

--- a/gremlins/fleet/land.py
+++ b/gremlins/fleet/land.py
@@ -545,7 +545,7 @@ def _ff_land(gr_id: str, sf: str, wdir: str, state: dict, cwd,
 
 
 def _land_local(gr_id: str, sf: str, wdir: str, state: dict, mode: str, into_dir: str = "") -> bool:
-    """Land a local gremlin branch onto the current branch (mode: 'squash' or 'ff')."""
+    """Land a local gremlin branch (mode: 'squash' or 'ff'). If into_dir is given, land there instead of project_root."""
     setup_kind = state.get("setup_kind", "")
     if setup_kind != "worktree-branch":
         print(f"gremlin {gr_id} has setup_kind={setup_kind!r} — only worktree-branch gremlins support local landing")

--- a/gremlins/orchestrators/boss.py
+++ b/gremlins/orchestrators/boss.py
@@ -467,28 +467,12 @@ def _summarize_for_log(text: str, limit: int = 240) -> str:
     return one_line
 
 
-def land_child(child_id: str) -> bool:
+def land_child(child_id: str, into_dir: str = "") -> bool:
     log(f"landing child {child_id}")
-    return run_proc(
-        _gremlins_cli_cmd("fleet", "land", child_id),
-        env=_gremlins_cli_env(),
-    ) == 0
-
-
-def advance_boss_workdir(boss_workdir: str, new_head: str) -> None:
-    """Reset the boss worktree's HEAD to match project_root after a local land.
-
-    Local child gremlins squash-land into project_root, leaving the boss's
-    own worktree frozen at the chain-start SHA. Resetting here ensures each
-    subsequent handoff sees the full accumulated diff instead of an empty one.
-    """
-    r = subprocess.run(
-        ["git", "reset", "--hard", new_head],
-        capture_output=True, text=True, cwd=boss_workdir,
-    )
-    if r.returncode != 0:
-        die(f"git reset --hard {new_head[:12]} failed in boss workdir {boss_workdir}: {r.stderr.strip()}")
-    log(f"advanced boss workdir HEAD to {new_head[:12]}")
+    cmd = _gremlins_cli_cmd("fleet", "land", child_id)
+    if into_dir:
+        cmd += ["--into", into_dir]
+    return run_proc(cmd, env=_gremlins_cli_env()) == 0
 
 
 def rescue_child(child_id: str) -> bool:
@@ -820,11 +804,12 @@ def boss_main(argv: List[str]) -> int:
 
             if success:
                 set_stage(gr_id, "landing")
-                if land_child(current_child_id):
-                    if chain_kind == "local":
-                        if not boss_workdir or not os.path.isdir(boss_workdir):
-                            die(f"boss workdir not usable after local land: {boss_workdir!r}")
-                        advance_boss_workdir(boss_workdir, get_head_ref(project_root))
+                into_dir = ""
+                if chain_kind == "local":
+                    if not boss_workdir or not os.path.isdir(boss_workdir):
+                        die(f"boss workdir not usable for local land: {boss_workdir!r}")
+                    into_dir = boss_workdir
+                if land_child(current_child_id, into_dir=into_dir):
                     outcome = "rescued-then-landed" if was_rescued else "landed"
                     log(f"child {current_child_id} {outcome}")
                     boss_state["children"].append({"id": current_child_id, "outcome": outcome})

--- a/gremlins/tests/test_fleet.py
+++ b/gremlins/tests/test_fleet.py
@@ -519,6 +519,81 @@ def test_land_local_refuses_when_branch_missing_from_state(tmp_path, monkeypatch
     assert "no branch field" in capsys.readouterr().out
 
 
+def test_land_local_into_dir_nonexistent_fails(tmp_path, monkeypatch, capsys):
+    """_land_local returns False and prints an error when into_dir does not exist."""
+    state = {
+        "id": "x",
+        "kind": "localgremlin",
+        "setup_kind": "worktree-branch",
+        "branch": "bg/localgremlin/x",
+        "project_root": str(tmp_path / "project"),
+    }
+    ok = gremlins._land_local("x", "/sf", "/wdir", state, mode="squash",
+                               into_dir=str(tmp_path / "nonexistent"))
+    assert ok is False
+    assert "--into directory does not exist" in capsys.readouterr().out
+
+
+def test_land_local_into_dir_lands_in_worktree(tmp_path, monkeypatch, capsys):
+    """When into_dir is provided, the squash commit lands there instead of project_root."""
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _init_git_repo(project_root)
+
+    gr_id = "land-into-wt-12345678"
+    branch = f"bg/localgremlin/{gr_id}"
+
+    # Create feature branch with a commit.
+    subprocess.run(["git", "checkout", "-b", branch], cwd=project_root,
+                   check=True, capture_output=True)
+    (project_root / "wt_feature.txt").write_text("from worktree\n")
+    subprocess.run(["git", "add", "wt_feature.txt"], cwd=project_root,
+                   check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "add wt_feature.txt"], cwd=project_root,
+                   check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "main"], cwd=project_root,
+                   check=True, capture_output=True)
+
+    # Create a detached worktree from main (simulating the boss worktree).
+    into_dir = tmp_path / "boss_worktree"
+    subprocess.run(["git", "worktree", "add", "--detach", str(into_dir), "HEAD"],
+                   cwd=project_root, check=True, capture_output=True)
+
+    state_root = tmp_path / "state-root"
+    gr_dir = state_root / gr_id
+    artifacts_dir = gr_dir / "artifacts"
+    artifacts_dir.mkdir(parents=True)
+    (artifacts_dir / "plan.md").write_text("# Add wt_feature\n\n## Context\nAdd wt_feature.txt.\n")
+    workdir = tmp_path / "child_worktree"
+    workdir.mkdir()
+    state = {
+        "id": gr_id,
+        "kind": "localgremlin",
+        "status": "dead",
+        "exit_code": 0,
+        "setup_kind": "worktree-branch",
+        "branch": branch,
+        "workdir": str(workdir),
+        "project_root": str(project_root),
+        "total_cost_usd": 1.0,
+    }
+    sf = str(gr_dir / "state.json")
+    pathlib.Path(sf).write_text(json.dumps(state))
+
+    monkeypatch.setattr(gremlins, "STATE_ROOT", str(state_root))
+    monkeypatch.setattr(gremlins, "_synthesize_commit_message_ai",
+                        lambda inputs: ("Add wt_feature.txt", "", 0.0))
+    monkeypatch.chdir(into_dir)
+
+    ok = gremlins._land_local(gr_id, sf, str(gr_dir), state, mode="squash",
+                               into_dir=str(into_dir))
+    assert ok is True
+
+    # Feature must appear in the boss worktree, not in project_root.
+    assert (into_dir / "wt_feature.txt").exists()
+    assert not (project_root / "wt_feature.txt").exists()
+
+
 def test_land_proceeds_with_untracked_files_present(tmp_path, monkeypatch, capsys):
     """Untracked files must not block land (they can't be clobbered by squash merge)."""
     project_root = tmp_path / "project"

--- a/gremlins/tests/test_orchestrator_boss.py
+++ b/gremlins/tests/test_orchestrator_boss.py
@@ -11,7 +11,6 @@ import gremlins.orchestrators.boss as boss_mod
 from gremlins.orchestrators.boss import (
     _resolve_plan_source,
     _summarize_for_log,
-    advance_boss_workdir,
     boss_main,
     get_child_bail_detail,
     get_child_bail_reason,
@@ -53,7 +52,6 @@ def _common_boss_patches(monkeypatch, tmp_path, gr_id):
     monkeypatch.setattr(boss_mod, "set_stage", lambda *a: None)
     monkeypatch.setattr(boss_mod, "get_head_ref", lambda p: "abc123def456abc1")
     monkeypatch.setattr(boss_mod, "get_current_branch", lambda p: "main")
-    monkeypatch.setattr(boss_mod, "advance_boss_workdir", lambda *a: None)
 
 
 # ---------------------------------------------------------------------------
@@ -279,7 +277,7 @@ def test_chain_done_after_one_child(tmp_path, monkeypatch):
         (child_dir / "finished").write_text("")
         return child_id
 
-    def fake_land_child(child_id):
+    def fake_land_child(child_id, into_dir=""):
         calls.append(("land", child_id))
         return True
 
@@ -349,7 +347,7 @@ def test_chain_uses_ghgremlin_for_gh_kind(tmp_path, monkeypatch):
 
     monkeypatch.setattr(boss_mod, "run_handoff", fake_run_handoff)
     monkeypatch.setattr(boss_mod, "launch_child", fake_launch_child)
-    monkeypatch.setattr(boss_mod, "land_child", lambda cid: True)
+    monkeypatch.setattr(boss_mod, "land_child", lambda cid, into_dir="": True)
 
     result = boss_main(["--plan", str(spec), "--chain-kind", "gh"])
     assert result == 0
@@ -449,7 +447,7 @@ def test_operator_followups_stored_in_boss_state(tmp_path, monkeypatch):
 
     monkeypatch.setattr(boss_mod, "run_handoff", fake_run_handoff)
     monkeypatch.setattr(boss_mod, "launch_child", fake_launch_child)
-    monkeypatch.setattr(boss_mod, "land_child", lambda cid: True)
+    monkeypatch.setattr(boss_mod, "land_child", lambda cid, into_dir="": True)
 
     result = boss_main(["--plan", str(spec), "--chain-kind", "local"])
     assert result == 0
@@ -516,7 +514,7 @@ def test_resume_picks_up_in_flight_child(tmp_path, monkeypatch):
         calls.append("handoff")
         return "chain-done", {"exit_state": "chain-done", "operator_followups": []}
 
-    def fake_land_child(cid):
+    def fake_land_child(cid, into_dir=""):
         calls.append(("land", cid))
         return True
 
@@ -574,7 +572,7 @@ def test_resume_fixture_in_boss_main(tmp_path, monkeypatch):
         calls.append("handoff")
         return "chain-done", {"exit_state": "chain-done", "operator_followups": []}
 
-    def fake_land_child(cid):
+    def fake_land_child(cid, into_dir=""):
         calls.append(("land", cid))
         return True
 
@@ -652,7 +650,7 @@ def test_rescue_then_land(tmp_path, monkeypatch):
         (child_dir / "state.json").write_text(json.dumps({"exit_code": 0}))
         return True
 
-    def fake_land_child(cid):
+    def fake_land_child(cid, into_dir=""):
         calls.append(("land", cid))
         return True
 
@@ -978,27 +976,22 @@ def test_boss_main_plan_issue_ref_snapshots_spec(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# advance_boss_workdir: called after local child lands
+# land_child: boss worktree as landing target for local chains
 # ---------------------------------------------------------------------------
 
-def test_advance_boss_workdir_called_after_local_land(tmp_path, monkeypatch):
-    """After a local child lands, advance_boss_workdir is called with the new project_root HEAD."""
-    gr_id = "test-boss-advance-aabb12"
+def test_land_child_uses_boss_workdir_for_local_chain(tmp_path, monkeypatch):
+    """For local chains, land_child is called with into_dir=boss_workdir so children
+    land into the boss's isolated worktree rather than the user's project_root."""
+    gr_id = "test-boss-into-aabb12"
     state_dir, project_root, workdir = _make_gremlin_state(tmp_path, gr_id)
     _common_boss_patches(monkeypatch, tmp_path, gr_id)
-
-    new_head = "newhead1234567890newhead12345678"
-    monkeypatch.setattr(boss_mod, "get_head_ref", lambda p: new_head)
 
     spec = tmp_path / "spec.md"
     spec.write_text("# Spec\n")
     child_plan = tmp_path / "child-plan.md"
     child_plan.write_text("# Child plan\n")
 
-    advance_calls = []
-
-    def fake_advance_boss_workdir(boss_workdir, head):
-        advance_calls.append((boss_workdir, head))
+    land_calls = []
 
     handoff_results = iter([
         ("next-plan", {"exit_state": "next-plan", "child_plan": str(child_plan), "operator_followups": []}),
@@ -1014,43 +1007,44 @@ def test_advance_boss_workdir_called_after_local_land(tmp_path, monkeypatch):
         boss_state["current_plan"] = out_path
         boss_state["operator_followups"] = sig.get("operator_followups", [])
         boss_state["handoff_records"].append({
-            "timestamp": "2026-01-01T00:00:00Z",
-            "n": n,
-            "plan_in": boss_state["spec_path"],
-            "plan_out": out_path,
-            "signal_file": out_path.replace(".md", ".state.json"),
-            "exit_state": exit_state,
-            "child_plan": sig.get("child_plan"),
-            "bail_reason": None,
+            "timestamp": "2026-01-01T00:00:00Z", "n": n,
+            "plan_in": boss_state["spec_path"], "plan_out": out_path,
+            "signal_file": "", "exit_state": exit_state,
+            "child_plan": sig.get("child_plan"), "bail_reason": None,
             "operator_followups": sig.get("operator_followups", []),
         })
         return exit_state, sig
 
     def fake_launch_child(gr_id, launch_kind, child_plan_path):
-        child_id = "child-advance-test-112233"
+        child_id = "child-into-test-bb3344"
         child_dir = tmp_path / child_id
         child_dir.mkdir(exist_ok=True)
         (child_dir / "state.json").write_text(json.dumps({"exit_code": 0}))
         (child_dir / "finished").write_text("")
         return child_id
 
+    def fake_land_child(child_id, into_dir=""):
+        land_calls.append((child_id, into_dir))
+        return True
+
     monkeypatch.setattr(boss_mod, "run_handoff", fake_run_handoff)
     monkeypatch.setattr(boss_mod, "launch_child", fake_launch_child)
-    monkeypatch.setattr(boss_mod, "land_child", lambda cid: True)
-    monkeypatch.setattr(boss_mod, "advance_boss_workdir", fake_advance_boss_workdir)
+    monkeypatch.setattr(boss_mod, "land_child", fake_land_child)
 
     result = boss_main(["--plan", str(spec), "--chain-kind", "local"])
     assert result == 0
 
-    assert len(advance_calls) == 1
-    called_workdir, called_head = advance_calls[0]
-    assert called_workdir == str(workdir)
-    assert called_head == new_head
+    assert len(land_calls) == 1
+    landed_child_id, landed_into = land_calls[0]
+    assert landed_child_id == "child-into-test-bb3344"
+    # Must land into the boss worktree, not project_root
+    assert landed_into == str(workdir)
+    assert landed_into != str(project_root)
 
 
-def test_advance_boss_workdir_not_called_for_gh_chain(tmp_path, monkeypatch):
-    """advance_boss_workdir is NOT called for gh chains (they use origin/<branch> instead)."""
-    gr_id = "test-boss-advance-gh-cc3344"
+def test_land_child_no_into_dir_for_gh_chain(tmp_path, monkeypatch):
+    """For gh chains, land_child is called without into_dir (gh landing goes via PR merge)."""
+    gr_id = "test-boss-gh-into-cc5566"
     state_dir, project_root, workdir = _make_gremlin_state(tmp_path, gr_id)
     _common_boss_patches(monkeypatch, tmp_path, gr_id)
     monkeypatch.setattr(boss_mod, "get_default_branch", lambda p: "main")
@@ -1061,7 +1055,7 @@ def test_advance_boss_workdir_not_called_for_gh_chain(tmp_path, monkeypatch):
     child_plan = tmp_path / "child-plan.md"
     child_plan.write_text("# Child plan\n")
 
-    advance_calls = []
+    land_calls = []
 
     handoff_results = iter([
         ("next-plan", {"exit_state": "next-plan", "child_plan": str(child_plan), "operator_followups": []}),
@@ -1077,31 +1071,33 @@ def test_advance_boss_workdir_not_called_for_gh_chain(tmp_path, monkeypatch):
         boss_state["current_plan"] = out_path
         boss_state["operator_followups"] = sig.get("operator_followups", [])
         boss_state["handoff_records"].append({
-            "timestamp": "2026-01-01T00:00:00Z",
-            "n": n,
-            "plan_in": boss_state["spec_path"],
-            "plan_out": out_path,
-            "signal_file": "",
-            "exit_state": exit_state,
-            "child_plan": sig.get("child_plan"),
-            "bail_reason": None,
+            "timestamp": "2026-01-01T00:00:00Z", "n": n,
+            "plan_in": boss_state["spec_path"], "plan_out": out_path,
+            "signal_file": "", "exit_state": exit_state,
+            "child_plan": sig.get("child_plan"), "bail_reason": None,
             "operator_followups": sig.get("operator_followups", []),
         })
         return exit_state, sig
 
     def fake_launch_child(gr_id, launch_kind, child_plan_path):
-        child_id = "child-gh-advance-dd5566"
+        child_id = "child-gh-into-test-dd7788"
         child_dir = tmp_path / child_id
         child_dir.mkdir(exist_ok=True)
         (child_dir / "state.json").write_text(json.dumps({"exit_code": 0}))
         (child_dir / "finished").write_text("")
         return child_id
 
+    def fake_land_child(child_id, into_dir=""):
+        land_calls.append((child_id, into_dir))
+        return True
+
     monkeypatch.setattr(boss_mod, "run_handoff", fake_run_handoff)
     monkeypatch.setattr(boss_mod, "launch_child", fake_launch_child)
-    monkeypatch.setattr(boss_mod, "land_child", lambda cid: True)
-    monkeypatch.setattr(boss_mod, "advance_boss_workdir", lambda *a: advance_calls.append(a))
+    monkeypatch.setattr(boss_mod, "land_child", fake_land_child)
 
     result = boss_main(["--plan", str(spec), "--chain-kind", "gh"])
     assert result == 0
-    assert advance_calls == []
+
+    assert len(land_calls) == 1
+    _, landed_into = land_calls[0]
+    assert landed_into == ""


### PR DESCRIPTION
## Summary

- Local child gremlins launched by a boss chain were squash-landing onto the user's checked-out branch in `project_root`, blocking the user from switching branches or keeping uncommitted edits during a chain run.
- Threads `--into <path>` through `fleet land` → `_land_local` so the boss directs each child's squash-merge into its own isolated detached-HEAD worktree instead.
- Removes `advance_boss_workdir`, which existed only to mirror `project_root`'s HEAD back into the boss worktree — no longer needed since children land there directly.

## Test plan

- [ ] `python -m pytest gremlins/tests/` — 194 tests pass
- [ ] `test_land_child_uses_boss_workdir_for_local_chain` — verifies `land_child` receives `into_dir=boss_workdir` for local chains
- [ ] `test_land_child_no_into_dir_for_gh_chain` — verifies `into_dir=""` for gh chains
- [ ] `test_land_local_into_dir_lands_in_worktree` — end-to-end: squash commit lands in boss worktree, not `project_root`
- [ ] `test_land_local_into_dir_nonexistent_fails` — error path when `--into` dir is missing

Closes #170