### PR TITLE
feat: rewrite state.set_stage and emit_bail as pure Python

### DIFF
--- a/gremlins/CLAUDE.md
+++ b/gremlins/CLAUDE.md
@@ -70,18 +70,15 @@ validated in the orchestrators; marker-protocol bail reasons live in
 - **Gh stage names**: `plan`, `implement`, `commit-pr`, `request-copilot`, `ghreview`, `wait-copilot`, `ghaddress`.
 - **Marker-protocol bail reasons**: `diagnosis_no_marker`, `diagnosis_bad_marker`, `diagnosis_claude_error`, `diagnosis_timeout`, `excluded_class:<class>`, `attempts_exhausted`, `relaunch_launcher_missing`, `relaunch_failed`.
 
-## Bash-script carve-outs
+## Stage and bail bookkeeping
 
-`state.set_stage` and `state.emit_bail` shell out to
-`~/.claude/skills/_bg/set-stage.sh` and `set-bail.sh` rather than
-patching `state.json` in Python. Those scripts are **also** invoked by
-non-gremlins writers (`session-summary.sh` hook, which sources
-`liveness.sh` for its at-startup gremlin summary), so the bash scripts
-are the single source of truth for the on-disk format. Don't reimplement
-that bookkeeping in pure Python — forks would drift.
-
-Both helpers no-op without `GR_ID` and never raise: stage / bail
-bookkeeping must not crash a running gremlin.
+`state.set_stage` and `state.emit_bail` write to `state.json` atomically
+in pure Python via `patch_state`. Both helpers no-op without `GR_ID` and
+never raise — stage / bail bookkeeping must not crash a running gremlin.
+The `~/.claude/skills/_bg/set-stage.sh` and `set-bail.sh` scripts are still
+present for non-gremlins writers (`session-summary.sh` hook, which sources
+`liveness.sh` for its at-startup gremlin summary), but `state.py` no longer
+shells out to them.
 
 ## Tests
 

--- a/gremlins/orchestrators/boss.py
+++ b/gremlins/orchestrators/boss.py
@@ -27,7 +27,7 @@ import time
 from typing import List, Tuple
 
 from ..gh_utils import get_repo, parse_issue_ref, view_issue
-from ..state import patch_state
+from ..state import patch_state, set_stage
 
 STATE_ROOT = os.path.join(
     os.environ.get("XDG_STATE_HOME", os.path.join(os.path.expanduser("~"), ".local", "state")),
@@ -106,12 +106,6 @@ def save_json(path: str, data: dict) -> None:
     with open(tmp, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
     os.replace(tmp, path)
-
-
-def set_stage(gr_id: str, stage: str) -> None:
-    script = os.path.expanduser("~/.claude/skills/_bg/set-stage.sh")
-    if os.access(script, os.X_OK):
-        subprocess.run([script, gr_id, stage], capture_output=True)
 
 
 def run_proc(cmd: list, **kwargs) -> int:
@@ -250,7 +244,7 @@ def run_handoff(gr_id: str, state_dir: str, boss_state: dict,
     right cwd/rev so handoff sees the actually-landed work, not a stale ref
     in the user's repo that may never advance during the chain.
     """
-    set_stage(gr_id, "handoff")
+    set_stage("handoff")
 
     n = boss_state["handoff_count"] + 1
     out_path = os.path.join(state_dir, f"handoff-{n:03d}.md")
@@ -711,7 +705,7 @@ def boss_main(argv: List[str]) -> int:
                         log(f"  - {item}")
                 else:
                     log("operator follow-ups: (none)")
-                set_stage(gr_id, "done")
+                set_stage("done")
                 save_boss_state(state_dir, boss_state)
                 return 0
 
@@ -791,7 +785,7 @@ def boss_main(argv: List[str]) -> int:
             child_wdir = os.path.join(STATE_ROOT, current_child_id)
 
             if not os.path.isfile(os.path.join(child_wdir, "finished")):
-                set_stage(gr_id, "waiting")
+                set_stage("waiting")
                 success = wait_for_child(current_child_id, gr_id)
             else:
                 try:
@@ -803,7 +797,7 @@ def boss_main(argv: List[str]) -> int:
             check_stop()
 
             if success:
-                set_stage(gr_id, "landing")
+                set_stage("landing")
                 into_dir = ""
                 if chain_kind == "local":
                     if not boss_workdir or not os.path.isdir(boss_workdir):
@@ -833,7 +827,7 @@ def boss_main(argv: List[str]) -> int:
                     )
 
             # Pipeline failure → rescue
-            set_stage(gr_id, "rescuing")
+            set_stage("rescuing")
             if not rescue_child(current_child_id):
                 bail_reason = get_child_bail_reason(current_child_id)
                 bail_detail = _summarize_for_log(

--- a/gremlins/state.py
+++ b/gremlins/state.py
@@ -1,16 +1,7 @@
-"""Stage and bail bookkeeping wrappers.
+"""Stage and bail bookkeeping for gremlin state.json.
 
-Both helpers shell out to the canonical bash scripts under
-``$HOME/.claude/skills/_bg/`` rather than reimplementing the state.json
-patching logic in Python. The bash scripts are also invoked by non-pipeline
-code paths (``session-summary.sh`` is a hook that sources ``liveness.sh``
-to classify gremlins for the at-startup summary), so leaving them as the
-single source of truth keeps the on-disk vocabulary stable across pipeline
-and non-pipeline writers. ``pipeline/fleet.py`` reimplements the liveness
-classifier inline rather than sourcing ``liveness.sh``; the two must be
-kept in lockstep by hand.
-
-Both helpers are no-ops outside a gremlin context (no ``GR_ID``) and never
+Both helpers write state.json atomically in pure Python. Both are no-ops
+outside a gremlin context (no ``GR_ID`` or missing state.json) and never
 raise — stage/bail bookkeeping must not break a running gremlin.
 """
 
@@ -22,10 +13,6 @@ import os
 import pathlib
 import re
 import secrets
-import subprocess
-
-SET_STAGE_SH = pathlib.Path.home() / ".claude" / "skills" / "_bg" / "set-stage.sh"
-SET_BAIL_SH = pathlib.Path.home() / ".claude" / "skills" / "_bg" / "set-bail.sh"
 
 GR_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
@@ -40,31 +27,17 @@ BAIL_CLASS_OTHER = "other"
 
 
 def set_stage(stage: str, sub_stage=None) -> None:
-    """Shell out to set-stage.sh. No-op without GR_ID or when the helper is
-    missing/non-executable."""
-    gr_id = os.environ.get("GR_ID")
-    if not gr_id:
+    """Write stage and stage_updated_at to state.json. No-op without GR_ID or missing state.json."""
+    if not os.environ.get("GR_ID"):
         return
-    try:
-        if not SET_STAGE_SH.exists() or not os.access(str(SET_STAGE_SH), os.X_OK):
-            return
-    except Exception:
+    sf = resolve_state_file()
+    if sf is None or not sf.exists():
         return
-    args = [str(SET_STAGE_SH), gr_id, stage]
+    now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
     if sub_stage is not None:
-        try:
-            args.append(json.dumps(sub_stage))
-        except Exception:
-            return
-    try:
-        subprocess.run(
-            args,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=False,
-        )
-    except Exception:
-        pass
+        patch_state(stage=stage, stage_updated_at=now, sub_stage=sub_stage)
+    else:
+        patch_state(_delete=("sub_stage",), stage=stage, stage_updated_at=now)
 
 
 def resolve_session_dir() -> pathlib.Path:
@@ -97,27 +70,16 @@ def resolve_session_dir() -> pathlib.Path:
 
 
 def emit_bail(bail_class: str, bail_detail: str = "") -> None:
-    """Shell out to set-bail.sh to record a bail_class (and optional detail)
-    on the running gremlin's state.json. No-op without GR_ID or when the
-    helper is missing — never raises."""
-    gr_id = os.environ.get("GR_ID")
-    if not gr_id:
+    """Write bail_class (and optional bail_detail) to state.json. No-op without GR_ID, empty bail_class, or missing state.json."""
+    if not os.environ.get("GR_ID") or not bail_class:
         return
-    try:
-        if not SET_BAIL_SH.exists() or not os.access(str(SET_BAIL_SH), os.X_OK):
-            return
-    except Exception:
+    sf = resolve_state_file()
+    if sf is None or not sf.exists():
         return
-    try:
-        subprocess.run(
-            [str(SET_BAIL_SH), gr_id, bail_class, bail_detail],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=False,
-            timeout=5,
-        )
-    except Exception:
-        pass
+    if bail_detail:
+        patch_state(bail_class=bail_class, bail_detail=bail_detail)
+    else:
+        patch_state(_delete=("bail_detail",), bail_class=bail_class)
 
 
 def resolve_state_file() -> "Optional[pathlib.Path]":
@@ -132,8 +94,8 @@ def resolve_state_file() -> "Optional[pathlib.Path]":
     return state_root / gr_id / "state.json"
 
 
-def patch_state(**fields) -> None:
-    """Merge keyword fields into state.json atomically.
+def patch_state(_delete=(), **fields) -> None:
+    """Merge keyword fields into state.json atomically, deleting any keys in _delete.
 
     No-op when GR_ID is unset, when state.json doesn't exist, or when the
     write fails — stage bookkeeping must not crash a running gremlin.
@@ -143,6 +105,8 @@ def patch_state(**fields) -> None:
         return
     try:
         data = json.loads(sf.read_text(encoding="utf-8"))
+        for key in _delete:
+            data.pop(key, None)
         data.update(fields)
         tmp = sf.with_name(
             f"{sf.name}.{os.getpid()}.{secrets.token_hex(8)}.tmp"

--- a/gremlins/state.py
+++ b/gremlins/state.py
@@ -27,17 +27,20 @@ BAIL_CLASS_OTHER = "other"
 
 
 def set_stage(stage: str, sub_stage=None) -> None:
-    """Write stage and stage_updated_at to state.json. No-op without GR_ID or missing state.json."""
-    if not os.environ.get("GR_ID"):
-        return
-    sf = resolve_state_file()
-    if sf is None or not sf.exists():
-        return
-    now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
-    if sub_stage is not None:
-        patch_state(stage=stage, stage_updated_at=now, sub_stage=sub_stage)
-    else:
-        patch_state(_delete=("sub_stage",), stage=stage, stage_updated_at=now)
+    """Write stage and stage_updated_at to state.json. No-op without GR_ID, empty stage, or missing state.json."""
+    try:
+        if not stage or not os.environ.get("GR_ID"):
+            return
+        sf = resolve_state_file()
+        if sf is None or not sf.exists():
+            return
+        now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        if sub_stage is not None:
+            patch_state(stage=stage, stage_updated_at=now, sub_stage=sub_stage)
+        else:
+            patch_state(_delete=("sub_stage",), stage=stage, stage_updated_at=now)
+    except Exception:
+        pass
 
 
 def resolve_session_dir() -> pathlib.Path:
@@ -71,15 +74,18 @@ def resolve_session_dir() -> pathlib.Path:
 
 def emit_bail(bail_class: str, bail_detail: str = "") -> None:
     """Write bail_class (and optional bail_detail) to state.json. No-op without GR_ID, empty bail_class, or missing state.json."""
-    if not os.environ.get("GR_ID") or not bail_class:
-        return
-    sf = resolve_state_file()
-    if sf is None or not sf.exists():
-        return
-    if bail_detail:
-        patch_state(bail_class=bail_class, bail_detail=bail_detail)
-    else:
-        patch_state(_delete=("bail_detail",), bail_class=bail_class)
+    try:
+        if not os.environ.get("GR_ID") or not bail_class:
+            return
+        sf = resolve_state_file()
+        if sf is None or not sf.exists():
+            return
+        if bail_detail:
+            patch_state(bail_class=bail_class, bail_detail=bail_detail)
+        else:
+            patch_state(_delete=("bail_detail",), bail_class=bail_class)
+    except Exception:
+        pass
 
 
 def resolve_state_file() -> "Optional[pathlib.Path]":

--- a/gremlins/tests/test_orchestrator_boss.py
+++ b/gremlins/tests/test_orchestrator_boss.py
@@ -49,6 +49,10 @@ def _common_boss_patches(monkeypatch, tmp_path, gr_id):
     monkeypatch.setenv("GR_ID", gr_id)
     monkeypatch.setattr(boss_mod, "STATE_ROOT", str(tmp_path))
     monkeypatch.setattr(boss_mod, "_stop_requested", False)
+    # Stub out set_stage so tests don't touch the developer's real ~/.local/state.
+    # (state.set_stage resolves XDG_STATE_HOME at call time; patching the name
+    # imported into boss_mod keeps all boss call-sites covered.)
+    monkeypatch.setattr(boss_mod, "set_stage", lambda *a, **kw: None)
     monkeypatch.setattr(boss_mod, "get_head_ref", lambda p: "abc123def456abc1")
     monkeypatch.setattr(boss_mod, "get_current_branch", lambda p: "main")
 

--- a/gremlins/tests/test_orchestrator_boss.py
+++ b/gremlins/tests/test_orchestrator_boss.py
@@ -49,7 +49,6 @@ def _common_boss_patches(monkeypatch, tmp_path, gr_id):
     monkeypatch.setenv("GR_ID", gr_id)
     monkeypatch.setattr(boss_mod, "STATE_ROOT", str(tmp_path))
     monkeypatch.setattr(boss_mod, "_stop_requested", False)
-    monkeypatch.setattr(boss_mod, "set_stage", lambda *a: None)
     monkeypatch.setattr(boss_mod, "get_head_ref", lambda p: "abc123def456abc1")
     monkeypatch.setattr(boss_mod, "get_current_branch", lambda p: "main")
 

--- a/gremlins/tests/test_state_isolation.py
+++ b/gremlins/tests/test_state_isolation.py
@@ -1,10 +1,10 @@
 """Regression tests for the GR_ID-leakage bug captured on PR #140.
 
 When `pytest` runs as a subprocess of an implement-stage gremlin, GR_ID is
-inherited. Without isolation, gremlins.state.set_stage shells out to
-set-stage.sh against the parent gremlin's state.json, corrupting its
-`stage` and `sub_stage` fields — observable in `/gremlins --watch` and
-dangerous for any rescue-flow logic that branches on `stage`.
+inherited. Without isolation, gremlins.state.set_stage would write the
+parent gremlin's state.json and corrupt its `stage` and `sub_stage` fields
+— observable in `/gremlins --watch` and dangerous for any rescue-flow logic
+that branches on `stage`.
 
 The fix is the autouse `_isolate_gr_id` fixture in conftest.py, which
 delenv's GR_ID before every test. These tests verify both layers:
@@ -15,19 +15,15 @@ delenv's GR_ID before every test. These tests verify both layers:
   hop, this test would pass trivially in any clean CI environment (no
   GR_ID inherited) regardless of whether the autouse fixture was present.
 - test_*_does_not_clobber_external_state: per-orchestrator end-to-end
-  checks that running each entry point does not invoke set-stage.sh
-  against a pre-staged parent gremlin's state.json. Each orchestrator is
-  exercised in its own test so a regression message names the offender.
+  checks that running each entry point does not modify a pre-staged parent
+  gremlin's state.json. Each orchestrator is exercised in its own test so a
+  regression message names the offender.
 
 Coverage envelope: with GR_ID unset (the post-fix invariant), set_stage
-early-returns before subprocess.run, so these tests verify that guard
-plus the autouse fixture's delenv. They do NOT catch hypothetical future
-code paths that resolve GR_ID from somewhere other than os.environ (a
-config file, a passed-in arg) — those bypass the autouse delenv. To
-make any leak that *does* hit subprocess.run deterministic regardless of
-whether ~/.claude/skills/_bg/set-stage.sh exists on the test machine,
-the orchestrator tests monkeypatch gremlins.state.SET_STAGE_SH to a
-real executable in tmp_path.
+early-returns before touching state.json, so these tests verify that guard
+plus the autouse fixture's delenv. The orchestrator tests also verify
+on-disk contents directly — no fake executables or subprocess interception
+needed since set_stage is pure Python.
 """
 
 import json
@@ -37,6 +33,7 @@ import subprocess
 import sys
 import textwrap
 
+import gremlins.state as state_mod
 from conftest import (
     MINIMAL_EVENTS,
     REVIEW_LABELS as _REVIEW_LABELS,
@@ -99,28 +96,9 @@ def test_autouse_isolate_gr_id_unsets_gr_id_under_inherited_env(tmp_path):
     )
 
 
-def _recording_run(recorded_calls):
-    """Build a subprocess.run replacement that records each call's argv and
-    returns a successful CompletedProcess. Module-scope helper so we don't
-    rebuild the closure target type on every recorded call."""
-
-    def recording_run(*args, **kwargs):
-        recorded_calls.append(args[0] if args else kwargs.get("args"))
-        return subprocess.CompletedProcess(
-            args=args[0] if args else (),
-            returncode=0,
-            stdout="",
-            stderr="",
-        )
-
-    return recording_run
-
-
 def _stage_parent_state(tmp_path, monkeypatch):
-    """Pre-create a parent gremlin's state.json under XDG_STATE_HOME and
-    install a fake set-stage.sh so any leak deterministically hits the
-    recorded subprocess.run. Returns (parent_state_file, original_content,
-    parent_mtime, recorded_calls).
+    """Pre-create a parent gremlin's state.json under XDG_STATE_HOME.
+    Returns (parent_state_file, original_content, parent_mtime).
     """
     xdg = tmp_path / "xdg"
     parent_id = "parent-gremlin-deadbeef"
@@ -131,46 +109,18 @@ def _stage_parent_state(tmp_path, monkeypatch):
     parent_state_file.write_text(original_content)
     parent_mtime = parent_state_file.stat().st_mtime_ns
     monkeypatch.setenv("XDG_STATE_HOME", str(xdg))
-
-    # Install a fake set-stage.sh executable so gremlins.state.set_stage's
-    # exists()/access(X_OK) preflight succeeds. Without this, a future
-    # regression that re-leaked GR_ID could still silently pass on a CI
-    # machine that has no ~/.claude/skills/_bg/set-stage.sh, because the
-    # preflight would early-return before our recorded subprocess.run hook.
-    fake_helper = tmp_path / "set-stage.sh"
-    fake_helper.write_text("#!/bin/sh\nexit 0\n")
-    fake_helper.chmod(0o755)
-    monkeypatch.setattr("gremlins.state.SET_STAGE_SH", fake_helper)
-
-    recorded_calls = []
-    monkeypatch.setattr("gremlins.state.subprocess.run", _recording_run(recorded_calls))
-
-    # GR_ID intentionally NOT set here — the autouse _isolate_gr_id fixture
-    # in conftest.py has removed it. With Layer 1 in place, set_stage
-    # no-ops because GR_ID is empty, so subprocess.run is never invoked
-    # against set-stage.sh. If autouse delenv is removed AND GR_ID is
-    # inherited from the parent env, the recorded_calls assertion fires.
-    return parent_state_file, original_content, parent_mtime, recorded_calls
+    # GR_ID intentionally NOT set — the autouse _isolate_gr_id fixture in
+    # conftest.py has removed it. set_stage no-ops because GR_ID is empty.
+    return parent_state_file, original_content, parent_mtime
 
 
-def _assert_no_state_clobber(parent_state_file, original_content, parent_mtime, recorded_calls):
-    # File byte-equality covers any direct write path that resolves through
-    # XDG_STATE_HOME (the asserts on stage / sub_stage that used to live
-    # here were redundant — they're implied by content equality).
+def _assert_no_state_clobber(parent_state_file, original_content, parent_mtime):
     assert parent_state_file.stat().st_mtime_ns == parent_mtime
     assert parent_state_file.read_text() == original_content
 
-    leaked = [
-        c for c in recorded_calls
-        if c and len(c) >= 1 and "set-stage.sh" in str(c[0])
-    ]
-    assert not leaked, (
-        f"orchestrator leaked set-stage.sh calls under unset GR_ID: {leaked}"
-    )
-
 
 def test_local_main_does_not_clobber_external_state(tmp_path, monkeypatch):
-    parent_state_file, original_content, parent_mtime, recorded_calls = (
+    parent_state_file, original_content, parent_mtime = (
         _stage_parent_state(tmp_path, monkeypatch)
     )
 
@@ -200,11 +150,11 @@ def test_local_main_does_not_clobber_external_state(tmp_path, monkeypatch):
         }
     )
     assert local_main(["--plan", str(plan_file)], client=client) == 0
-    _assert_no_state_clobber(parent_state_file, original_content, parent_mtime, recorded_calls)
+    _assert_no_state_clobber(parent_state_file, original_content, parent_mtime)
 
 
 def test_review_main_does_not_clobber_external_state(tmp_path, monkeypatch):
-    parent_state_file, original_content, parent_mtime, recorded_calls = (
+    parent_state_file, original_content, parent_mtime = (
         _stage_parent_state(tmp_path, monkeypatch)
     )
 
@@ -217,11 +167,11 @@ def test_review_main_does_not_clobber_external_state(tmp_path, monkeypatch):
         fixtures={lbl: MINIMAL_EVENTS for lbl in _REVIEW_LABELS}
     )
     assert review_main(["--dir", str(review_dir)], client=client) == 0
-    _assert_no_state_clobber(parent_state_file, original_content, parent_mtime, recorded_calls)
+    _assert_no_state_clobber(parent_state_file, original_content, parent_mtime)
 
 
 def test_address_main_does_not_clobber_external_state(tmp_path, monkeypatch):
-    parent_state_file, original_content, parent_mtime, recorded_calls = (
+    parent_state_file, original_content, parent_mtime = (
         _stage_parent_state(tmp_path, monkeypatch)
     )
 
@@ -236,4 +186,143 @@ def test_address_main_does_not_clobber_external_state(tmp_path, monkeypatch):
     monkeypatch.setattr("gremlins.orchestrators.local.in_git_repo", lambda: False)
     client = FakeClaudeClient(fixtures={"address-code": MINIMAL_EVENTS})
     assert address_main(["--dir", str(address_dir)], client=client) == 0
-    _assert_no_state_clobber(parent_state_file, original_content, parent_mtime, recorded_calls)
+    _assert_no_state_clobber(parent_state_file, original_content, parent_mtime)
+
+
+# ---------------------------------------------------------------------------
+# set_stage direct tests
+# ---------------------------------------------------------------------------
+
+def _make_state_dir(tmp_path, gr_id):
+    """Create state dir with a minimal state.json and return the file path."""
+    xdg = tmp_path / "xdg"
+    state_dir = xdg / "claude-gremlins" / gr_id
+    state_dir.mkdir(parents=True)
+    sf = state_dir / "state.json"
+    sf.write_text(json.dumps({"id": gr_id, "stage": "implement"}))
+    return xdg, sf
+
+
+def test_set_stage_noop_when_gr_id_unset(tmp_path, monkeypatch):
+    """set_stage is a no-op when GR_ID is absent (autouse already clears it)."""
+    xdg, sf = _make_state_dir(tmp_path, "gr-noop-test")
+    monkeypatch.setenv("XDG_STATE_HOME", str(xdg))
+    # GR_ID is already unset via autouse fixture
+    mtime_before = sf.stat().st_mtime_ns
+    state_mod.set_stage("running")
+    assert sf.stat().st_mtime_ns == mtime_before
+
+
+def test_set_stage_writes_stage_and_timestamp(tmp_path, monkeypatch):
+    """set_stage writes stage and stage_updated_at to state.json."""
+    gr_id = "gr-stage-write-test"
+    xdg, sf = _make_state_dir(tmp_path, gr_id)
+    monkeypatch.setenv("XDG_STATE_HOME", str(xdg))
+    monkeypatch.setenv("GR_ID", gr_id)
+
+    state_mod.set_stage("review-code")
+
+    data = json.loads(sf.read_text())
+    assert data["stage"] == "review-code"
+    assert "stage_updated_at" in data
+    # ISO-8601 UTC second-precision format
+    ts = data["stage_updated_at"]
+    assert ts.endswith("Z")
+    assert len(ts) == 20  # e.g. "2026-04-29T12:00:00Z"
+
+
+def test_set_stage_with_sub_stage(tmp_path, monkeypatch):
+    """set_stage with sub_stage writes the sub_stage key."""
+    gr_id = "gr-substage-test"
+    xdg, sf = _make_state_dir(tmp_path, gr_id)
+    monkeypatch.setenv("XDG_STATE_HOME", str(xdg))
+    monkeypatch.setenv("GR_ID", gr_id)
+
+    state_mod.set_stage("implement", sub_stage={"attempt": 2})
+
+    data = json.loads(sf.read_text())
+    assert data["stage"] == "implement"
+    assert data["sub_stage"] == {"attempt": 2}
+
+
+def test_set_stage_removes_sub_stage_when_none(tmp_path, monkeypatch):
+    """Calling set_stage without sub_stage removes a previously written sub_stage key."""
+    gr_id = "gr-substage-del-test"
+    xdg, sf = _make_state_dir(tmp_path, gr_id)
+    monkeypatch.setenv("XDG_STATE_HOME", str(xdg))
+    monkeypatch.setenv("GR_ID", gr_id)
+
+    state_mod.set_stage("implement", sub_stage={"k": 1})
+    assert "sub_stage" in json.loads(sf.read_text())
+
+    state_mod.set_stage("review-code")
+    data = json.loads(sf.read_text())
+    assert data["stage"] == "review-code"
+    assert "sub_stage" not in data
+
+
+def test_set_stage_noop_when_state_json_missing(tmp_path, monkeypatch):
+    """set_stage is a no-op when state.json doesn't exist (no crash)."""
+    gr_id = "gr-missing-state-test"
+    xdg = tmp_path / "xdg"
+    state_dir = xdg / "claude-gremlins" / gr_id
+    state_dir.mkdir(parents=True)
+    # No state.json written
+    monkeypatch.setenv("XDG_STATE_HOME", str(xdg))
+    monkeypatch.setenv("GR_ID", gr_id)
+    state_mod.set_stage("running")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# emit_bail direct tests
+# ---------------------------------------------------------------------------
+
+def test_emit_bail_writes_bail_class(tmp_path, monkeypatch):
+    """emit_bail writes bail_class to state.json."""
+    gr_id = "gr-bail-write-test"
+    xdg, sf = _make_state_dir(tmp_path, gr_id)
+    monkeypatch.setenv("XDG_STATE_HOME", str(xdg))
+    monkeypatch.setenv("GR_ID", gr_id)
+
+    state_mod.emit_bail("other", "something went wrong")
+
+    data = json.loads(sf.read_text())
+    assert data["bail_class"] == "other"
+    assert data["bail_detail"] == "something went wrong"
+
+
+def test_emit_bail_removes_bail_detail_when_empty(tmp_path, monkeypatch):
+    """Calling emit_bail without detail removes a previously written bail_detail key."""
+    gr_id = "gr-bail-del-test"
+    xdg, sf = _make_state_dir(tmp_path, gr_id)
+    monkeypatch.setenv("XDG_STATE_HOME", str(xdg))
+    monkeypatch.setenv("GR_ID", gr_id)
+
+    state_mod.emit_bail("other", "detail")
+    assert "bail_detail" in json.loads(sf.read_text())
+
+    state_mod.emit_bail("other")
+    data = json.loads(sf.read_text())
+    assert data["bail_class"] == "other"
+    assert "bail_detail" not in data
+
+
+def test_emit_bail_noop_when_gr_id_unset(tmp_path, monkeypatch):
+    """emit_bail is a no-op when GR_ID is absent."""
+    gr_id = "gr-bail-noop-test"
+    xdg, sf = _make_state_dir(tmp_path, gr_id)
+    monkeypatch.setenv("XDG_STATE_HOME", str(xdg))
+    mtime_before = sf.stat().st_mtime_ns
+    state_mod.emit_bail("other")
+    assert sf.stat().st_mtime_ns == mtime_before
+
+
+def test_emit_bail_noop_when_bail_class_empty(tmp_path, monkeypatch):
+    """emit_bail is a no-op when bail_class is empty."""
+    gr_id = "gr-bail-empty-test"
+    xdg, sf = _make_state_dir(tmp_path, gr_id)
+    monkeypatch.setenv("XDG_STATE_HOME", str(xdg))
+    monkeypatch.setenv("GR_ID", gr_id)
+    mtime_before = sf.stat().st_mtime_ns
+    state_mod.emit_bail("")
+    assert sf.stat().st_mtime_ns == mtime_before


### PR DESCRIPTION
## Summary

- Replaces subprocess shell-outs to `set-stage.sh` / `set-bail.sh` with atomic in-process writes to `state.json`
- Expands `patch_state` to accept a `_delete=()` argument so both helpers can remove keys (`sub_stage`, `bail_detail`) without a sentinel
- Removes the local `set_stage` from `boss.py` and imports from `state` instead; updates all five call sites to drop the `gr_id` argument
- Rewrites `test_state_isolation` to assert on-disk `state.json` contents directly and adds coverage for the key-deletion behavior

## Test plan

- [ ] `cd gremlins && PYTHONPATH=. python -m pytest` — all 208 tests pass
- [ ] `grep -n "subprocess\|SET_STAGE_SH\|SET_BAIL_SH" gremlins/state.py` — returns nothing
- [ ] Verify `set_stage("foo")` with `GR_ID` set writes `stage` + `stage_updated_at`, no `sub_stage`
- [ ] Verify `set_stage("foo", sub_stage={...})` writes `sub_stage`; subsequent `set_stage("bar")` removes it

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)