### PR TITLE
feat: add bail subcommand to gremlins.cli (Phase 3)

### DIFF
--- a/gremlins/cli.py
+++ b/gremlins/cli.py
@@ -14,6 +14,7 @@ The first positional argument selects the subcommand:
 - ``launch``  — launch a new background gremlin (replaces launch.sh forward path)
 - ``resume``  — re-spawn an existing gremlin from its recorded stage (replaces
                 launch.sh --resume)
+- ``bail``    — mark the running gremlin as bailed (reads GR_ID from env)
 - ``_run-pipeline`` — internal spawn boundary; not for direct human use
 
 Remaining argv is forwarded to the chosen orchestrator entry point with
@@ -33,7 +34,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     if not argv:
         sys.stderr.write(
             "usage: python -m gremlins.cli "
-            "{local|review|address|gh|boss|fleet|handoff|launch|resume} [args...]\n"
+            "{local|review|address|gh|boss|fleet|handoff|launch|resume|bail} [args...]\n"
         )
         return 1
     sub = argv[0]
@@ -63,6 +64,8 @@ def main(argv: Optional[List[str]] = None) -> int:
         return _launch_main(rest)
     if sub == "resume":
         return _resume_main(rest)
+    if sub == "bail":
+        return _bail_main(rest)
     if sub == "_run-pipeline":
         return _run_pipeline_main(rest)
     sys.stderr.write(f"unknown subcommand: {sub}\n")
@@ -169,6 +172,37 @@ def _run_pipeline_main(argv: List[str]) -> int:
         from .launcher import write_terminal_state
         write_terminal_state(gr_id, exit_code=rc)
     sys.exit(rc)
+
+
+def _bail_main(argv: List[str]) -> int:
+    """CLI front-end for state.emit_bail. Reads GR_ID from env (set by
+    the launcher when spawning the pipeline). Exit 0 always — never
+    breaks the calling agent."""
+    import argparse
+    from .state import (
+        emit_bail,
+        BAIL_CLASS_REVIEWER_REQUESTED_CHANGES,
+        BAIL_CLASS_SECURITY,
+        BAIL_CLASS_SECRETS,
+        BAIL_CLASS_OTHER,
+    )
+
+    valid = {
+        BAIL_CLASS_REVIEWER_REQUESTED_CHANGES,
+        BAIL_CLASS_SECURITY,
+        BAIL_CLASS_SECRETS,
+        BAIL_CLASS_OTHER,
+    }
+    p = argparse.ArgumentParser(
+        prog="python -m gremlins.cli bail",
+        description="Mark the running gremlin as bailed.",
+    )
+    p.add_argument("bail_class", choices=sorted(valid))
+    p.add_argument("bail_detail", nargs="?", default="")
+    args = p.parse_args(argv)
+
+    emit_bail(args.bail_class, args.bail_detail)
+    return 0
 
 
 def _get_state_root():

--- a/gremlins/cli.py
+++ b/gremlins/cli.py
@@ -175,9 +175,14 @@ def _run_pipeline_main(argv: List[str]) -> int:
 
 
 def _bail_main(argv: List[str]) -> int:
-    """CLI front-end for state.emit_bail. Reads GR_ID from env (set by
-    the launcher when spawning the pipeline). Exit 0 always — never
-    breaks the calling agent."""
+    """CLI front-end for state.emit_bail.
+
+    Reads GR_ID from env (set by the launcher when spawning the
+    pipeline). Returns 0 for valid invocations (including when GR_ID is
+    unset — emit_bail no-ops); invalid CLI usage is handled by argparse
+    and exits non-zero (typically 2). A typo like ``bail othr`` should
+    surface as an error rather than be silently swallowed.
+    """
     import argparse
     from .state import (
         emit_bail,

--- a/gremlins/stages/CLAUDE.md
+++ b/gremlins/stages/CLAUDE.md
@@ -45,8 +45,9 @@ closure inside `../orchestrators/gh.py` rather than living here.
   resolves into `~/.claude/gremlins/...` regardless of the orchestrator's
   cwd.
 - Stages that should respect a bail marker (set by the agent via
-  `set-bail.sh`) call `check_bail(<phase-name>)` from `..state` after the
-  claude run. The runner inspects the bail and halts the pipeline.
+  `python -m gremlins.cli bail`) call `check_bail(<phase-name>)` from
+  `..state` after the claude run. The runner inspects the bail and
+  halts the pipeline.
 - Most stages return `None`. Stages that produce information the
   orchestrator needs (`implement.py` → `ImplStageResult`,
   `commit_pr.py` → PR URL string) return it; the orchestrator threads

--- a/gremlins/stages/address_code.py
+++ b/gremlins/stages/address_code.py
@@ -87,8 +87,8 @@ def run_address_code_stage(
             bail_section = """
 
 If a finding asks you to change something that touches secrets/credentials, or you decline to address one or more findings for any other reason that should halt automated recovery, run the bail helper before finishing:
-  - `~/.claude/skills/_bg/set-bail.sh "$GR_ID" secrets "<one-line reason>"` if the blocked finding touches secrets.
-  - `~/.claude/skills/_bg/set-bail.sh "$GR_ID" other "<one-line reason>"` for any other reason you cannot proceed.
+  - `python -m gremlins.cli bail secrets "<one-line reason>"` if the blocked finding touches secrets.
+  - `python -m gremlins.cli bail other "<one-line reason>"` for any other reason you cannot proceed.
 Do not call this helper if you successfully addressed every actionable finding.
 """
 

--- a/gremlins/tests/test_cli.py
+++ b/gremlins/tests/test_cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import pathlib
 
 import pytest
@@ -71,7 +70,7 @@ def test_bail_without_gr_id_exits_zero_no_write(tmp_path, monkeypatch):
     assert not (tmp_path / "claude-gremlins").exists()
 
 
-def test_bail_invalid_class_exits_nonzero(tmp_path, monkeypatch, capsys):
+def test_bail_invalid_class_exits_nonzero(tmp_path, monkeypatch):
     monkeypatch.setenv("GR_ID", "test-gremlin-003")
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
 

--- a/gremlins/tests/test_cli.py
+++ b/gremlins/tests/test_cli.py
@@ -1,0 +1,99 @@
+"""Tests for gremlins/cli.py bail subcommand."""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+
+import pytest
+
+from gremlins.cli import main
+
+
+def _make_state(tmp_path: pathlib.Path, gr_id: str) -> pathlib.Path:
+    """Create a minimal state.json under tmp_path/claude-gremlins/<gr_id>/state.json.
+
+    XDG_STATE_HOME must be set to tmp_path so resolve_state_file() finds it.
+    """
+    state_dir = tmp_path / "claude-gremlins" / gr_id
+    state_dir.mkdir(parents=True)
+    sf = state_dir / "state.json"
+    sf.write_text(json.dumps({"status": "running"}), encoding="utf-8")
+    return sf
+
+
+# ---------------------------------------------------------------------------
+# bail subcommand — with GR_ID set
+# ---------------------------------------------------------------------------
+
+def test_bail_writes_bail_class_and_detail(tmp_path, monkeypatch):
+    gr_id = "test-gremlin-001"
+    sf = _make_state(tmp_path, gr_id)
+    monkeypatch.setenv("GR_ID", gr_id)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+
+    rc = main(["bail", "other", "test reason"])
+
+    assert rc == 0
+    data = json.loads(sf.read_text())
+    assert data["bail_class"] == "other"
+    assert data["bail_detail"] == "test reason"
+
+
+def test_bail_without_detail_omits_bail_detail_key(tmp_path, monkeypatch):
+    gr_id = "test-gremlin-002"
+    sf = _make_state(tmp_path, gr_id)
+    # Pre-seed a bail_detail so we can verify it gets deleted.
+    data = json.loads(sf.read_text())
+    data["bail_detail"] = "stale"
+    sf.write_text(json.dumps(data))
+
+    monkeypatch.setenv("GR_ID", gr_id)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+
+    rc = main(["bail", "secrets"])
+
+    assert rc == 0
+    result = json.loads(sf.read_text())
+    assert result["bail_class"] == "secrets"
+    assert "bail_detail" not in result
+
+
+def test_bail_without_gr_id_exits_zero_no_write(tmp_path, monkeypatch):
+    monkeypatch.delenv("GR_ID", raising=False)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+
+    rc = main(["bail", "other", "no gremlin context"])
+
+    assert rc == 0
+    # No claude-gremlins state directory should have been created.
+    assert not (tmp_path / "claude-gremlins").exists()
+
+
+def test_bail_invalid_class_exits_nonzero(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("GR_ID", "test-gremlin-003")
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["bail", "bogus_class"])
+    assert exc_info.value.code != 0
+
+
+@pytest.mark.parametrize("bail_class", [
+    "reviewer_requested_changes",
+    "security",
+    "secrets",
+    "other",
+])
+def test_bail_all_valid_classes_accepted(tmp_path, monkeypatch, bail_class):
+    gr_id = f"test-gremlin-{bail_class}"
+    sf = _make_state(tmp_path, gr_id)
+    monkeypatch.setenv("GR_ID", gr_id)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+
+    rc = main(["bail", bail_class, "reason"])
+
+    assert rc == 0
+    data = json.loads(sf.read_text())
+    assert data["bail_class"] == bail_class


### PR DESCRIPTION
Phase 3 of removing skills/ references from the gremlins package.

## Summary

- New `python -m gremlins.cli bail <class> [detail]` subcommand wraps `state.emit_bail`. Reads `GR_ID` from env (set by the launcher).
- Rewrites the `address_code` stage's prompt to instruct the agent to call `python -m gremlins.cli bail` instead of `~/.claude/skills/_bg/set-bail.sh`.
- Updates `gremlins/stages/CLAUDE.md` to reflect the new contract.
- Adds `gremlins/tests/test_cli.py` with 8 tests covering all four bail classes, detail set/empty, GR_ID unset, and invalid class rejection.

## Recovery context

This PR was assembled from commit \`2bef381\` produced by the gremlin \`replace-set-bail-sh-with-gremlins-cli-4dafd4\`. The gremlin's \`commit-pr\` stage failed (auth-403) and could not be cleanly resumed because \`IMPL_SESSION\` isn't persisted across crashes. The implementation work itself was complete and tests pass — pushing it directly.

Closes #178