### PR TITLE
chore(gremlins): drop GREMLIN_SCRIPTS and sweep skills/ references (Phase 4)

### DIFF
--- a/gremlins/CLAUDE.md
+++ b/gremlins/CLAUDE.md
@@ -1,12 +1,10 @@
 # `gremlins/`
 
-Shared plan / implement / review / address machinery extracted from
-`skills/{localgremlin,ghgremlin,bossgremlin}/`. The skill scripts under
-`skills/` are thin shims that exec into `python -m gremlins.cli`; this
-package owns the actual orchestration. [`DESIGN.md`](DESIGN.md) is the
-binding migration spec — load it for marker protocol, ghgremlin
-impl-handoff branch lifecycle, launcher contract, and per-phase rollout
-history.
+Orchestration package for background gremlins. Owns the plan / implement /
+review / address pipelines (`local`, `gh`, `boss`), the fleet manager
+(`fleet/`), the chain-step decision agent (`handoff.py`), and the launcher
+(`launcher.py`). [`DESIGN.md`](DESIGN.md) documents the marker protocol,
+ghgremlin branch lifecycle, launcher contract, and phase rollout history.
 
 ## Module layout
 
@@ -15,28 +13,28 @@ history.
 - `state.py` — session-dir resolution, `set_stage` / `emit_bail` / `patch_state` / `check_bail`.
 - `git.py` — `in_git_repo`, `git_head`, branch / worktree helpers.
 - `gh_utils.py` — `gh` CLI wrappers and stream-json URL extractors used by the gh orchestrator.
-- `fleet/` — fleet manager package: status listing + `stop` / `rescue` / `land` / `close` / `rm` / `log` subcommands. Implements the logic behind shim entrypoint `skills/gremlins/gremlins.py`. See [`fleet/CLAUDE.md`](fleet/CLAUDE.md) for the per-module breakdown.
-- `handoff.py` — chain-step decision agent (next-plan / chain-done / bail). Implements the logic behind shim entrypoint `skills/handoff/handoff.py`.
+- `fleet/` — fleet manager package: status listing + `stop` / `rescue` / `land` / `close` / `rm` / `log` subcommands. See [`fleet/CLAUDE.md`](fleet/CLAUDE.md) for the per-module breakdown.
+- `handoff.py` — chain-step decision agent (next-plan / chain-done / bail).
 - `clients/claude.py` — `ClaudeClient` Protocol + `SubprocessClaudeClient` (production).
 - `clients/fake.py` — `FakeClaudeClient` recording test double; replays canned stream-json from fixtures keyed by `label`.
 - `stages/` — per-stage bodies: `plan`, `implement`, `review_code`, `address_code`, `commit_pr`, `ghreview`, `ghaddress`, `wait_copilot`. (The `request-copilot` stage body is inlined as a closure in `orchestrators/gh.py`.)
-- `orchestrators/local.py` — `local_main`, `review_main`, `address_main`. Implements the logic behind shim entrypoint `skills/localgremlin/localgremlin.py`.
-- `orchestrators/gh.py` — `gh_main`. Implements the logic behind shim entrypoint `skills/ghgremlin/ghgremlin.sh`.
-- `orchestrators/boss.py` — `boss_main`. Implements the logic behind shim entrypoint `skills/bossgremlin/bossgremlin.py`. Subprocesses out to `python -m gremlins.cli handoff` and `python -m gremlins.cli fleet {stop,land,rescue}` between child gremlins.
+- `orchestrators/local.py` — `local_main`, `review_main`, `address_main`.
+- `orchestrators/gh.py` — `gh_main`. Drives the gh pipeline.
+- `orchestrators/boss.py` — `boss_main`. Subprocesses out to `python -m gremlins.cli handoff` and `python -m gremlins.cli fleet {stop,land,rescue}` between child gremlins.
 - `prompts/` — externalized prompt templates (plan, implement, review lenses, etc).
 - `tests/` — pytest suite; `claude` is always faked, but some tests still run local `git` subprocesses and typically stub `gh` at the `subprocess.run` level.
 
 ## Entry points
 
-| Subcommand | Module | Replaces |
-|---|---|---|
-| `local` | `orchestrators.local.local_main` | `skills/localgremlin/localgremlin.py` |
-| `review` | `orchestrators.local.review_main` | `localreview.py` |
-| `address` | `orchestrators.local.address_main` | `localaddress.py` |
-| `gh` | `orchestrators.gh.gh_main` | `skills/ghgremlin/ghgremlin.sh` |
-| `boss` | `orchestrators.boss.boss_main` | `skills/bossgremlin/bossgremlin.py` |
-| `fleet` | `fleet.main` | `skills/gremlins/gremlins.py` |
-| `handoff` | `handoff.main` | `skills/handoff/handoff.py` |
+| Subcommand | Module |
+|---|---|
+| `local` | `orchestrators.local.local_main` |
+| `review` | `orchestrators.local.review_main` |
+| `address` | `orchestrators.local.address_main` |
+| `gh` | `orchestrators.gh.gh_main` |
+| `boss` | `orchestrators.boss.boss_main` |
+| `fleet` | `fleet.main` |
+| `handoff` | `handoff.main` |
 
 ## Testability seam: `ClaudeClient`
 
@@ -62,8 +60,7 @@ protocol). Renaming any of them silently breaks cross-process
 consumers. Source of truth: bail-class constants live in
 [`state.py`](state.py); local / gh stage-name vocab is defined and
 validated in the orchestrators; marker-protocol bail reasons live in
-[`DESIGN.md`](DESIGN.md) (§Marker-protocol bail reasons) and the
-`skills/_bg/` scripts.
+[`DESIGN.md`](DESIGN.md) (§Marker-protocol bail reasons).
 
 - **Bail classes** (`state.json.bail_class`): `reviewer_requested_changes`, `security`, `secrets`, `other`.
 - **Local stage names**: `plan`, `implement`, `review-code`, `address-code`.
@@ -75,10 +72,6 @@ validated in the orchestrators; marker-protocol bail reasons live in
 `state.set_stage` and `state.emit_bail` write to `state.json` atomically
 in pure Python via `patch_state`. Both helpers no-op without `GR_ID` and
 never raise — stage / bail bookkeeping must not crash a running gremlin.
-The `~/.claude/skills/_bg/set-stage.sh` and `set-bail.sh` scripts are still
-present for non-gremlins writers (`session-summary.sh` hook, which sources
-`liveness.sh` for its at-startup gremlin summary), but `state.py` no longer
-shells out to them.
 
 ## Tests
 

--- a/gremlins/cli.py
+++ b/gremlins/cli.py
@@ -8,17 +8,15 @@ The first positional argument selects the subcommand:
 - ``gh``      — full gh-issue-driven pipeline (Phase 3)
 - ``boss``    — chained serial workflow driven by a top-level spec (Phase 4)
 - ``fleet``   — fleet-manager subcommands (status / stop / rescue / land /
-                close / rm / log) — was ``skills/gremlins/gremlins.py``
-- ``handoff`` — chain-step decision agent (next-plan / chain-done / bail) —
-                was ``skills/handoff/handoff.py``
+                close / rm / log)
+- ``handoff`` — chain-step decision agent (next-plan / chain-done / bail)
 - ``launch``  — launch a new background gremlin (replaces launch.sh forward path)
 - ``resume``  — re-spawn an existing gremlin from its recorded stage (replaces
                 launch.sh --resume)
 - ``bail``    — mark the running gremlin as bailed (reads GR_ID from env)
 - ``_run-pipeline`` — internal spawn boundary; not for direct human use
 
-Remaining argv is forwarded to the chosen orchestrator entry point with
-its own argparse contract preserved byte-stable from the old skill scripts.
+Remaining argv is forwarded to the chosen orchestrator entry point.
 """
 
 from __future__ import annotations

--- a/gremlins/fleet/CLAUDE.md
+++ b/gremlins/fleet/CLAUDE.md
@@ -10,7 +10,7 @@ Fleet manager package for background gremlins. Reads every `${XDG_STATE_HOME:-$H
 | `state.py` | `iso_to_epoch`, `humanize_age`, `display_id`, `render_sub_stage`, `liveness_of_state_file`, `iter_state_files`, `load_state`, `kind_short`, `git_toplevel` |
 | `duration.py` | `parse_duration` |
 | `render.py` | `build_row`, `print_table` |
-| `resolve.py` | `GREMLIN_STAGES`, `GREMLIN_SCRIPTS`, `resolve_gremlin` |
+| `resolve.py` | `GREMLIN_STAGES`, `resolve_gremlin` |
 | `stop.py` | `do_stop` |
 | `rescue.py` | `build_rescue_prompt`, `_atomic_patch_state`, `_write_bail`, `write_rescue_report`, `_read_rescue_marker`, `_run_headless_diagnosis`, `do_rescue` |
 | `log.py` | `do_log` |

--- a/gremlins/fleet/__init__.py
+++ b/gremlins/fleet/__init__.py
@@ -5,8 +5,7 @@ applies the shared liveness classifier inline, and prints one scannable line per
 gremlin. Subcommands (``stop``, ``rescue``, ``land``, ``rm``, ``close``, ``log``)
 operate on a single gremlin by id-prefix.
 
-Exposed via ``python -m gremlins.cli fleet`` (the ``skills/gremlins/gremlins.py``
-entrypoint is now a thin shim that execs into this module).
+Exposed via ``python -m gremlins.cli fleet``.
 
 Exit 0 on the listing path even on unexpected errors: same "never break a
 session" principle as the session-summary hook.
@@ -33,7 +32,7 @@ from gremlins.fleet.state import (
 )
 from gremlins.fleet.duration import parse_duration
 from gremlins.fleet.render import build_row, print_table
-from gremlins.fleet.resolve import GREMLIN_STAGES, GREMLIN_SCRIPTS, resolve_gremlin
+from gremlins.fleet.resolve import GREMLIN_STAGES, resolve_gremlin
 from gremlins.fleet.stop import do_stop
 from gremlins.fleet.rescue import (
     build_rescue_prompt,
@@ -95,7 +94,6 @@ __all__ = [
     "print_table",
     # resolve
     "GREMLIN_STAGES",
-    "GREMLIN_SCRIPTS",
     "resolve_gremlin",
     # stop
     "do_stop",

--- a/gremlins/fleet/rescue.py
+++ b/gremlins/fleet/rescue.py
@@ -134,7 +134,7 @@ Parent (boss) id: {parent_id or '(none)'}
      pre-fix base ref doesn't see. No change needed; rerunning the same stage
      as-is should succeed.
    - **structural**: the failure points at a real bug in the pipeline source
-     (`~/.claude/gremlins/*.py`) or in a sibling artifact (e.g. a malformed child plan
+     (`~/.claude/gremlins/`) or in a sibling artifact (e.g. a malformed child plan
      under the parent boss's state dir) that you recognize but cannot fix here.
      Use this when the remedy is "edit the pipeline" or "edit the child plan",
      not "tweak `state.json`". Articulate *what* in the pipeline / plan is wrong

--- a/gremlins/fleet/rescue.py
+++ b/gremlins/fleet/rescue.py
@@ -36,8 +36,7 @@ def build_rescue_prompt(state, log_tail, state_file_path, log_file_path,
     log_tail_safe = log_tail.replace("```", "` ` `")
 
     pipeline_paths = [
-        (f"~/.claude/skills/{kind}/", f"shell/python that drives the {kind} stages"),
-        ("~/.claude/skills/_bg/", "shared launcher, finish, set-stage, set-bail wrappers"),
+        ("~/.claude/gremlins/", "orchestrators, stages, state helpers, launcher — drives all gremlin kinds"),
     ]
     parent_state_dir = (
         os.path.join(_constants.STATE_ROOT, parent_id) if parent_id else ""
@@ -124,19 +123,18 @@ Parent (boss) id: {parent_id or '(none)'}
    could have continued.
    - **fixed**: you edited `state.json` (at `{state_file_path}`) or files inside
      the gremlin's worktree to resolve the failure; rerunning stage {stage} should
-     now succeed. **Do NOT edit pipeline source under `~/.claude/skills/`** —
+     now succeed. **Do NOT edit pipeline source under `~/.claude/gremlins/`** —
      those paths live outside the gremlin's worktree, so edits there cannot land
      in the PR diff, and may additionally be overwritten by future syncs from an
      upstream source repo. If the fix lives in pipeline source, choose
      `structural`.
    - **transient**: the failure was a flake (network, tool timeout, retriable
      infra) OR a fix has already landed elsewhere (e.g. in `main`, in a
-     `~/.claude/skills/` file outside the gremlin's worktree) that the chain's
+     `~/.claude/gremlins/` file outside the gremlin's worktree) that the chain's
      pre-fix base ref doesn't see. No change needed; rerunning the same stage
      as-is should succeed.
    - **structural**: the failure points at a real bug in the pipeline source
-     (`~/.claude/skills/<kind>/*.sh`, `~/.claude/skills/_bg/*.sh`, or the
-     associated python) or in a sibling artifact (e.g. a malformed child plan
+     (`~/.claude/gremlins/*.py`) or in a sibling artifact (e.g. a malformed child plan
      under the parent boss's state dir) that you recognize but cannot fix here.
      Use this when the remedy is "edit the pipeline" or "edit the child plan",
      not "tweak `state.json`". Articulate *what* in the pipeline / plan is wrong
@@ -174,7 +172,7 @@ Constraints:
 - Permitted edits: `state.json` at `{state_file_path}`{(", files inside the worktree at `" + workdir + "`") if workdir else ""}, the marker file at
   `{marker_path}` (you MUST write this — that's how the wrapper reads your
   verdict), and your scratch working directory.
-  Pipeline source under `~/.claude/skills/` is read-only for this rescue —
+  Pipeline source under `~/.claude/gremlins/` is read-only for this rescue —
   surface bugs there via `structural`.
 """
 

--- a/gremlins/fleet/resolve.py
+++ b/gremlins/fleet/resolve.py
@@ -8,12 +8,6 @@ GREMLIN_STAGES = {
     "bossgremlin": ["handoff", "waiting", "landing", "rescuing"],
 }
 
-GREMLIN_SCRIPTS = {
-    "localgremlin": "~/.claude/skills/localgremlin/localgremlin.py",
-    "ghgremlin": "~/.claude/skills/ghgremlin/ghgremlin.sh",
-    "bossgremlin": "~/.claude/skills/bossgremlin/bossgremlin.py",
-}
-
 
 def resolve_gremlin(target: str):
     """Resolve id prefix to a single (gr_id, sf, wdir) or print error and return None."""

--- a/gremlins/orchestrators/CLAUDE.md
+++ b/gremlins/orchestrators/CLAUDE.md
@@ -44,8 +44,7 @@ Per-pipeline orchestrator entry points. Each module owns one CLI subcommand
 - `boss.py` subprocesses out via `_gremlins_cli_cmd` / `_gremlins_cli_env`.
   The env helper sets `PYTHONSAFEPATH=1` and prepends the package's parent
   to `PYTHONPATH` so `python -m gremlins.cli` resolves to
-  `~/.claude/gremlins/` regardless of cwd (worktree-shadow protection — see
-  `skills/_bg/launch.sh`).
+  `~/.claude/gremlins/` regardless of cwd (worktree-shadow protection).
 - The `--resume-from` flag forwarded by `launch.sh --resume` is *ignored*:
   boss resumes from `boss_state.json`, not the runner's stage vocabulary.
 - `SIGTERM` is trapped to set `_stop_requested` and forward to the current

--- a/gremlins/orchestrators/boss.py
+++ b/gremlins/orchestrators/boss.py
@@ -1,7 +1,7 @@
 """Orchestrator entry point for the boss pipeline.
 
-Port of ``skills/bossgremlin/bossgremlin.py``.  The boss_state.json schema is
-preserved byte-for-byte so in-flight chains work across the migration.
+Drives a chain of child gremlins serially, invoking handoff between each step.
+Chain state lives in boss_state.json.
 
 Receives pipeline args forwarded by the launcher:
   boss_main --plan <spec-path> --chain-kind local|gh [--model <model>]

--- a/gremlins/orchestrators/gh.py
+++ b/gremlins/orchestrators/gh.py
@@ -1,6 +1,6 @@
 """Orchestrator entry point for the gh pipeline.
 
-Ports skills/ghgremlin/ghgremlin.sh stage by stage.
+Drives the gh pipeline: plan → implement → commit-pr → request-copilot → ghreview → wait-copilot → ghaddress.
 
 Stage sequence (names byte-stable for --resume-from):
   plan → implement → commit-pr → request-copilot → ghreview → wait-copilot → ghaddress


### PR DESCRIPTION
Delete the dead `GREMLIN_SCRIPTS` dict from `fleet/resolve.py`, remove its re-export from `fleet/__init__.py`, and update all prompt text and docstrings to reference `~/.claude/gremlins/` instead of `~/.claude/skills/`.

## Changes

- `fleet/resolve.py`: delete `GREMLIN_SCRIPTS`
- `fleet/__init__.py`: drop `GREMLIN_SCRIPTS` import and `__all__` entry; drop `skills/` shim reference from module docstring
- `fleet/CLAUDE.md`: drop `GREMLIN_SCRIPTS` from resolve.py row
- `fleet/rescue.py`: rewrite all six `~/.claude/skills/` references in the rescue prompt to `~/.claude/gremlins/`; collapse `pipeline_paths` to a single entry
- `cli.py`: drop "was `skills/...`" tails from subcommand list; drop historical framing from module docstring
- `orchestrators/gh.py`: replace "Ports skills/..." line with a plain description
- `orchestrators/boss.py`: replace "Port of `skills/bossgremlin/...`" docstring with a plain description
- `orchestrators/CLAUDE.md`: drop `skills/_bg/launch.sh` reference
- `gremlins/CLAUDE.md`: rewrite historical sections — drop extracted-from framing, shim-entrypoint tails, Replaces column, `skills/_bg/` reference in byte-stable section, second sentence in stage/bail bookkeeping

207 tests pass.

Closes #182