### PR TITLE
chore(gremlins): sweep residual skills/ refs from tests (Phase 5a)

### DIFF
--- a/gremlins/tests/fixtures/handoff_bad_chain_done.md
+++ b/gremlins/tests/fixtures/handoff_bad_chain_done.md
@@ -4,7 +4,7 @@ Chain complete. All six phases of the implementation have been merged:
 
 - Phase 0: Initial sync script and tracked-path inventory
 - Phase 1: Skill directory structure and shim entrypoints
-- Phase 2: Gremlins package extraction from monolithic skills
+- Phase 2: Gremlins package extraction
 - Phase 3: Fleet manager package refactor
 - Phase 4: Boss gremlin chained workflow
 - Phase 5: Handoff agent sanitize pass

--- a/gremlins/tests/fixtures/shell_env.py
+++ b/gremlins/tests/fixtures/shell_env.py
@@ -46,11 +46,11 @@ def install_fake_bin(bin_dir: pathlib.Path, name: str, target: pathlib.Path) -> 
 
 
 def setup_fake_home(home: pathlib.Path) -> None:
-    """Build a minimal ``$HOME/.claude/`` that launch.sh and the gremlins package can
-    resolve: skills/, gremlins/, agents/ symlink to the repo's source dirs."""
+    """Build a minimal ``$HOME/.claude/`` that the gremlins package can
+    resolve: gremlins/, agents/ symlink to the repo's source dirs."""
     claude_dir = home / ".claude"
     claude_dir.mkdir(parents=True, exist_ok=True)
-    for name in ("skills", "gremlins", "agents"):
+    for name in ("gremlins", "agents"):
         link = claude_dir / name
         if link.is_symlink() or link.exists():
             continue
@@ -109,7 +109,7 @@ def setup_shell_env(
         "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
         "FAKE_CLAUDE_LOG": str(fake_claude_log),
         "FAKE_GH_LOG": str(fake_gh_log),
-        # Strip caller's PYTHONPATH; launch.sh will set its own.
+        # Strip caller's PYTHONPATH; the launcher will set its own.
     }
     env.pop("PYTHONPATH", None)
     # Disable git's optional locks to reduce lock contention across parallel

--- a/gremlins/tests/test_fleet.py
+++ b/gremlins/tests/test_fleet.py
@@ -1,4 +1,4 @@
-"""Tests for gremlins/fleet.py (formerly skills/gremlins/gremlins.py)."""
+"""Tests for gremlins/fleet.py."""
 
 import json
 import os

--- a/gremlins/tests/test_handoff.py
+++ b/gremlins/tests/test_handoff.py
@@ -1,4 +1,4 @@
-"""Tests for gremlins/handoff.py (formerly skills/handoff/handoff.py)."""
+"""Tests for gremlins/handoff.py."""
 
 import json
 import pathlib

--- a/gremlins/tests/test_rescue_phase_a.py
+++ b/gremlins/tests/test_rescue_phase_a.py
@@ -84,40 +84,6 @@ def _patch_state_root(gremlins_mod, state_root: pathlib.Path, monkeypatch):
     )
 
 
-def _install_stub_launcher(home: pathlib.Path) -> pathlib.Path:
-    """Replace fake_home/.claude/skills/_bg/launch.sh with a stub that records
-    its argv and exits 0. Returns the path to the recording file.
-
-    The default fake home symlinks ``~/.claude/skills`` straight at the repo's
-    ``skills/`` dir, so writing through that path would clobber the real
-    ``launch.sh`` on disk. Peel the symlink back into a real directory of
-    per-child symlinks so we can replace just ``_bg`` with a stub copy.
-    """
-    skills_dir = home / ".claude" / "skills"
-    if skills_dir.is_symlink():
-        # Peel: replace the symlink with a real directory of per-child links,
-        # then materialize a real `_bg` dir we can safely write into.
-        target = skills_dir.resolve()
-        skills_dir.unlink()
-        skills_dir.mkdir()
-        for child in target.iterdir():
-            (skills_dir / child.name).symlink_to(child)
-    bg = skills_dir / "_bg"
-    if bg.is_symlink():
-        bg.unlink()
-    bg.mkdir(parents=True, exist_ok=True)
-    record_file = home / "stub_launcher_calls.log"
-    record_file.write_text("", encoding="utf-8")
-    launcher = bg / "launch.sh"
-    launcher.write_text(
-        "#!/usr/bin/env bash\n"
-        f"echo \"$@\" >> '{record_file}'\n"
-        "exit 0\n",
-        encoding="utf-8",
-    )
-    launcher.chmod(0o755)
-    return record_file
-
 
 def test_rescue_diagnosis_runs_in_scratch_dir_not_worktree(tmp_path, monkeypatch):
     """The diagnosis agent's cwd is a /tmp scratch dir, not the gremlin's worktree."""


### PR DESCRIPTION
Delete dead `_install_stub_launcher` helper in `test_rescue_phase_a.py`, drop `skills/` from the `shell_env` fixture symlink list, and remove historical "(formerly skills/...)" parentheticals from module docstrings.

- `grep -ri skills gremlins/ --include="*.py" --include="*.md" --exclude="DESIGN.md"` → zero hits
- 207/207 tests pass

Closes #184