### PR TITLE
fix(boss): thread base_ref through launcher so child gremlins branch from boss's accumulated HEAD

### DIFF
--- a/gremlins/cli.py
+++ b/gremlins/cli.py
@@ -92,7 +92,9 @@ def _launch_main(argv: List[str]) -> int:
     p.add_argument("--instructions", "-c", default=None,
                    help="Instructions string (mutually exclusive with --plan).")
     p.add_argument("--base-ref", default="HEAD",
-                   help="Git ref to branch child worktree from (default: HEAD).")
+                   help="Git ref to branch the worktree from (default: HEAD). "
+                        "Applies to local gremlins only; ignored for gh gremlins, "
+                        "which always anchor to origin/<default-branch>.")
     args, rest = p.parse_known_args(argv)
 
     instructions = args.instructions

--- a/gremlins/cli.py
+++ b/gremlins/cli.py
@@ -91,6 +91,8 @@ def _launch_main(argv: List[str]) -> int:
     p.add_argument("--print-id", action="store_true")
     p.add_argument("--instructions", "-c", default=None,
                    help="Instructions string (mutually exclusive with --plan).")
+    p.add_argument("--base-ref", default="HEAD",
+                   help="Git ref to branch child worktree from (default: HEAD).")
     args, rest = p.parse_known_args(argv)
 
     instructions = args.instructions
@@ -103,6 +105,7 @@ def _launch_main(argv: List[str]) -> int:
             plan=args.plan,
             description=args.description,
             parent_id=args.parent_id,
+            base_ref=args.base_ref,
             pipeline_args=tuple(pipeline_flags),
         )
     except (ValueError, RuntimeError) as exc:

--- a/gremlins/git.py
+++ b/gremlins/git.py
@@ -30,6 +30,15 @@ def git_head() -> str:
     return r.stdout.strip() if r.returncode == 0 else ""
 
 
+def git_head_of_workdir(workdir: str) -> str:
+    r = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=False,
+        cwd=workdir,
+    )
+    return r.stdout.strip() if r.returncode == 0 else ""
+
+
 # ---------------------------------------------------------------------------
 # ghgremlin impl-handoff branch lifecycle (Phase 3)
 # ---------------------------------------------------------------------------
@@ -218,9 +227,9 @@ def resolve_default_branch(project_root: str) -> str:
 
 
 def setup_worktree_branch(
-    project_root: str, gr_id: str, branch_prefix: str = "bg/localgremlin"
+    project_root: str, gr_id: str, base_ref: str = "HEAD", branch_prefix: str = "bg/localgremlin"
 ) -> tuple:
-    """Add a named-branch worktree at HEAD. Returns (workdir_path, branch_name).
+    """Add a named-branch worktree at base_ref. Returns (workdir_path, branch_name).
 
     Raises RuntimeError on failure.
     """
@@ -229,7 +238,7 @@ def setup_worktree_branch(
     os.rmdir(workdir)
     branch = f"{branch_prefix}/{gr_id}"
     r = _git(
-        ["worktree", "add", "-b", branch, workdir, "HEAD"],
+        ["worktree", "add", "-b", branch, workdir, base_ref],
         cwd=project_root, capture_output=True, text=True,
     )
     if r.returncode != 0:

--- a/gremlins/launcher.py
+++ b/gremlins/launcher.py
@@ -95,7 +95,6 @@ def _resolve_description_and_slug(
     return "", False, "gremlin"
 
 
-
 def _write_state(state_dir: pathlib.Path, data: dict) -> None:
     """Atomically write state.json."""
     sf = state_dir / "state.json"

--- a/gremlins/launcher.py
+++ b/gremlins/launcher.py
@@ -2,7 +2,8 @@
 
 Public API:
     launch(kind, *, instructions=None, plan=None, description=None,
-           parent_id=None, pipeline_args=()) -> str
+           parent_id=None, project_root=None, base_ref="HEAD",
+           pipeline_args=()) -> str
     resume(gr_id) -> None
     write_terminal_state(gr_id, exit_code) -> None
 """
@@ -94,28 +95,6 @@ def _resolve_description_and_slug(
     return "", False, "gremlin"
 
 
-def _resolve_project_root(parent_id: Optional[str]) -> str:
-    """Return project root. Inherits from parent state when available."""
-    if parent_id:
-        parent_sf = _state_root() / parent_id / "state.json"
-        if parent_sf.is_file():
-            try:
-                data = json.loads(parent_sf.read_text(encoding="utf-8"))
-                pr = data.get("project_root", "")
-                if pr and os.path.isdir(pr):
-                    return pr
-            except Exception:
-                pass
-
-    r = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
-        capture_output=True, text=True, check=False,
-    )
-    if r.returncode == 0 and r.stdout.strip():
-        return r.stdout.strip()
-
-    return os.getcwd()
-
 
 def _write_state(state_dir: pathlib.Path, data: dict) -> None:
     """Atomically write state.json."""
@@ -203,6 +182,8 @@ def launch(
     plan: Optional[str] = None,
     description: Optional[str] = None,
     parent_id: Optional[str] = None,
+    project_root: Optional[str] = None,
+    base_ref: str = "HEAD",
     pipeline_args: tuple = (),
 ) -> str:
     """Set up state dir + worktree, spawn the pipeline detached, return gremlin id.
@@ -240,7 +221,15 @@ def launch(
     rand_hex = secrets.token_hex(3)
     gr_id = f"{slug}-{rand_hex}"
 
-    project_root = _resolve_project_root(parent_id)
+    if project_root is None:
+        r = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=False,
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            project_root = r.stdout.strip()
+        else:
+            project_root = os.getcwd()
 
     state_dir = _state_root() / gr_id
     state_dir.mkdir(parents=True, exist_ok=True)
@@ -260,7 +249,7 @@ def launch(
     if _git_mod.is_git_repo(project_root):
         if kind == "localgremlin":
             setup_kind = "worktree-branch"
-            workdir, branch = _git_mod.setup_worktree_branch(project_root, gr_id)
+            workdir, branch = _git_mod.setup_worktree_branch(project_root, gr_id, base_ref=base_ref)
         elif kind == "ghgremlin":
             default_branch = _git_mod.resolve_default_branch(project_root)
             refspec = f"refs/heads/{default_branch}:refs/remotes/origin/{default_branch}"
@@ -277,7 +266,7 @@ def launch(
             workdir = _git_mod.setup_detached_worktree(project_root, worktree_base)
         else:  # bossgremlin
             setup_kind = "worktree"
-            workdir = _git_mod.setup_detached_worktree(project_root, "HEAD")
+            workdir = _git_mod.setup_detached_worktree(project_root, base_ref)
     else:
         setup_kind = "copy"
         workdir = _git_mod.setup_copy(project_root)

--- a/gremlins/orchestrators/boss.py
+++ b/gremlins/orchestrators/boss.py
@@ -663,11 +663,12 @@ def boss_main(argv: List[str]) -> int:
             issue_url=issue_url,
             issue_num=issue_num,
         )
-        # Record initial boss HEAD so children branch from the right commit.
-        if boss_workdir and os.path.isdir(boss_workdir):
+        # Record initial boss HEAD so local children branch from the right commit.
+        if chain_kind == "local" and boss_workdir and os.path.isdir(boss_workdir):
             initial_head = _git_mod.git_head_of_workdir(boss_workdir)
-            if initial_head:
-                patch_state(current_head=initial_head)
+            if not initial_head:
+                die(f"failed to resolve HEAD for boss workdir: {boss_workdir!r}")
+            patch_state(current_head=initial_head)
     else:
         boss_state = load_boss_state(state_dir)
         log(f"resuming chain: kind={chain_kind}, completed children: {len(boss_state['children'])}")
@@ -803,8 +804,13 @@ def boss_main(argv: List[str]) -> int:
                 if land_child(current_child_id, into_dir=into_dir):
                     if chain_kind == "local" and boss_workdir and os.path.isdir(boss_workdir):
                         new_head = _git_mod.git_head_of_workdir(boss_workdir)
-                        if new_head:
-                            patch_state(current_head=new_head)
+                        if not new_head:
+                            die(
+                                f"child {current_child_id} landed locally, but could not resolve "
+                                f"HEAD for boss workdir {boss_workdir!r}; refusing to continue "
+                                f"with a stale current_head."
+                            )
+                        patch_state(current_head=new_head)
                     outcome = "rescued-then-landed" if was_rescued else "landed"
                     log(f"child {current_child_id} {outcome}")
                     boss_state["children"].append({"id": current_child_id, "outcome": outcome})

--- a/gremlins/orchestrators/boss.py
+++ b/gremlins/orchestrators/boss.py
@@ -28,6 +28,7 @@ from typing import List, Tuple
 
 from ..gh_utils import get_repo, parse_issue_ref, view_issue
 from ..state import patch_state, set_stage
+from .. import git as _git_mod
 
 STATE_ROOT = os.path.join(
     os.environ.get("XDG_STATE_HOME", os.path.join(os.path.expanduser("~"), ".local", "state")),
@@ -347,9 +348,14 @@ def launch_child(gr_id: str, launch_kind: str, child_plan: str) -> str:
     """Launch a child gremlin via the Python launcher. Returns child gremlin ID."""
     from ..launcher import launch as _launch
 
-    log(f"launching child ({launch_kind}): {child_plan}")
+    gremlin_state = load_json(os.path.join(STATE_ROOT, gr_id, "state.json"))
+    project_root = gremlin_state.get("project_root") or None
+    base_ref = gremlin_state.get("current_head") or "HEAD"
+
+    log(f"launching child ({launch_kind}): {child_plan}, base={base_ref[:12]}")
     try:
-        child_id = _launch(launch_kind, plan=child_plan, parent_id=gr_id)
+        child_id = _launch(launch_kind, plan=child_plan, parent_id=gr_id,
+                           project_root=project_root, base_ref=base_ref)
     except (ValueError, RuntimeError) as exc:
         die(f"launcher failed: {exc}")
 
@@ -657,6 +663,11 @@ def boss_main(argv: List[str]) -> int:
             issue_url=issue_url,
             issue_num=issue_num,
         )
+        # Record initial boss HEAD so children branch from the right commit.
+        if boss_workdir and os.path.isdir(boss_workdir):
+            initial_head = _git_mod.git_head_of_workdir(boss_workdir)
+            if initial_head:
+                patch_state(current_head=initial_head)
     else:
         boss_state = load_boss_state(state_dir)
         log(f"resuming chain: kind={chain_kind}, completed children: {len(boss_state['children'])}")
@@ -790,6 +801,10 @@ def boss_main(argv: List[str]) -> int:
                         die(f"boss workdir not usable for local land: {boss_workdir!r}")
                     into_dir = boss_workdir
                 if land_child(current_child_id, into_dir=into_dir):
+                    if chain_kind == "local" and boss_workdir and os.path.isdir(boss_workdir):
+                        new_head = _git_mod.git_head_of_workdir(boss_workdir)
+                        if new_head:
+                            patch_state(current_head=new_head)
                     outcome = "rescued-then-landed" if was_rescued else "landed"
                     log(f"child {current_child_id} {outcome}")
                     boss_state["children"].append({"id": current_child_id, "outcome": outcome})

--- a/gremlins/tests/test_launcher.py
+++ b/gremlins/tests/test_launcher.py
@@ -310,22 +310,18 @@ def test_launch_concurrent_no_collision(lenv):
         _wait_for_finished(_gremlins_state_root(lenv) / gr_id, timeout=60)
 
 
-def test_launch_child_inherits_project_root(lenv):
-    """--parent causes the child to inherit project_root from the parent's state.json."""
+def test_launch_explicit_project_root(lenv):
+    """Explicit project_root param is used; parent_id is recorded in state.json."""
     launcher = _launcher()
     state_root = _gremlins_state_root(lenv)
     parent_id = "fake-parent-aabbcc"
-    parent_dir = state_root / parent_id
-    parent_dir.mkdir(parents=True)
-    (parent_dir / "state.json").write_text(
-        json.dumps({"id": parent_id, "project_root": str(lenv.repo)}),
-        encoding="utf-8",
-    )
     gr_id = launcher.launch(
-        "localgremlin", instructions="child test", parent_id=parent_id
+        "localgremlin", instructions="child test",
+        parent_id=parent_id, project_root=str(lenv.repo),
     )
     state = _read_state(state_root / gr_id)
     assert state["project_root"] == str(lenv.repo)
+    assert state["parent_id"] == parent_id
     _wait_for_finished(state_root / gr_id, timeout=60)
 
 
@@ -500,6 +496,35 @@ def test_launch_ghgremlin_state_layout(lenv_with_gh):
 # ---------------------------------------------------------------------------
 # PYTHONSAFEPATH worktree-rename regression
 # ---------------------------------------------------------------------------
+
+def test_launch_passes_base_ref_to_worktree_setup(lenv, monkeypatch):
+    """launch(base_ref=<sha>) calls setup_worktree_branch with base_ref=<sha>."""
+    from gremlins import git as git_mod
+
+    captured = {}
+    real_setup = git_mod.setup_worktree_branch
+
+    def fake_setup(project_root, gr_id, base_ref="HEAD", branch_prefix="bg/localgremlin"):
+        captured["base_ref"] = base_ref
+        return real_setup(project_root, gr_id, base_ref=base_ref, branch_prefix=branch_prefix)
+
+    monkeypatch.setattr(git_mod, "setup_worktree_branch", fake_setup)
+
+    launcher = _launcher()
+    # Use the actual HEAD SHA so worktree add succeeds.
+    r = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        capture_output=True, text=True, cwd=str(lenv.repo), check=True,
+    )
+    head_sha = r.stdout.strip()
+
+    gr_id = launcher.launch("localgremlin", instructions="base_ref test", base_ref=head_sha)
+    state_dir = _gremlins_state_root(lenv) / gr_id
+    _wait_for_finished(state_dir, timeout=60)
+
+    assert captured.get("base_ref") == head_sha, \
+        f"expected base_ref={head_sha!r}, got {captured.get('base_ref')!r}"
+
 
 def test_pipeline_survives_worktree_pipeline_rename(lenv, monkeypatch):
     """Regression: pipeline completes even when implement renames worktree's gremlins/.

--- a/gremlins/tests/test_orchestrator_boss.py
+++ b/gremlins/tests/test_orchestrator_boss.py
@@ -56,6 +56,9 @@ def _common_boss_patches(monkeypatch, tmp_path, gr_id):
     monkeypatch.setattr(boss_mod, "set_stage", lambda *a, **kw: None)
     monkeypatch.setattr(boss_mod, "get_head_ref", lambda p: "abc123def456abc1")
     monkeypatch.setattr(boss_mod, "get_current_branch", lambda p: "main")
+    # Stub git_head_of_workdir so tests don't need a real git worktree.
+    # Individual tests that care about specific SHA values can override this.
+    monkeypatch.setattr(git_mod, "git_head_of_workdir", lambda w: "aaaa1111bbbb2222cccc3333dddd4444eeee5555")
 
 
 # ---------------------------------------------------------------------------
@@ -1155,8 +1158,10 @@ def test_boss_records_current_head_after_land(tmp_path, monkeypatch):
     child_plan = tmp_path / "child-plan.md"
     child_plan.write_text("# Child plan\n")
 
+    initial_head = "inithead1234567890123456789012345678ab"
     expected_new_head = "newhead12345678901234567890abcdef123456"
-    monkeypatch.setattr(git_mod, "git_head_of_workdir", lambda w: expected_new_head)
+    head_sequence = iter([initial_head, expected_new_head])
+    monkeypatch.setattr(git_mod, "git_head_of_workdir", lambda w: next(head_sequence))
 
     patch_calls = []
     monkeypatch.setattr(boss_mod, "patch_state", lambda **kw: patch_calls.append(kw))
@@ -1199,6 +1204,13 @@ def test_boss_records_current_head_after_land(tmp_path, monkeypatch):
     assert result == 0
 
     current_head_calls = [c for c in patch_calls if "current_head" in c]
-    assert current_head_calls, "patch_state should have been called with current_head"
-    assert any(c["current_head"] == expected_new_head for c in current_head_calls), \
-        f"expected current_head={expected_new_head!r} in patch_calls, got: {current_head_calls}"
+    assert len(current_head_calls) == 2, (
+        f"expected exactly 2 patch_state(current_head=...) calls "
+        f"(chain-start + post-land), got: {current_head_calls}"
+    )
+    assert current_head_calls[0]["current_head"] == initial_head, (
+        f"chain-start current_head should be {initial_head!r}, got {current_head_calls[0]!r}"
+    )
+    assert current_head_calls[1]["current_head"] == expected_new_head, (
+        f"post-land current_head should be {expected_new_head!r}, got {current_head_calls[1]!r}"
+    )

--- a/gremlins/tests/test_orchestrator_boss.py
+++ b/gremlins/tests/test_orchestrator_boss.py
@@ -7,6 +7,7 @@ import pathlib
 
 import pytest
 
+import gremlins.git as git_mod
 import gremlins.orchestrators.boss as boss_mod
 from gremlins.orchestrators.boss import (
     _resolve_plan_source,
@@ -1104,3 +1105,100 @@ def test_land_child_no_into_dir_for_gh_chain(tmp_path, monkeypatch):
     assert len(land_calls) == 1
     _, landed_into = land_calls[0]
     assert landed_into == ""
+
+
+# ---------------------------------------------------------------------------
+# Boss base-ref: current_head tracking and child launch
+# ---------------------------------------------------------------------------
+
+def test_boss_launches_child_against_current_head(tmp_path, monkeypatch):
+    """launch_child passes current_head from state.json as base_ref to launcher.launch."""
+    import gremlins.launcher as launcher_mod
+
+    gr_id = "test-boss-basref-aa1122"
+    state_dir = tmp_path / gr_id
+    state_dir.mkdir()
+    expected_sha = "deadbeef12345678deadbeef12345678deadbeef"
+    project_root_path = str(tmp_path / "repo")
+    (state_dir / "state.json").write_text(json.dumps({
+        "id": gr_id,
+        "project_root": project_root_path,
+        "current_head": expected_sha,
+    }))
+
+    captured = {}
+
+    def fake_launch(kind, *, plan=None, parent_id=None, project_root=None,
+                    base_ref="HEAD", pipeline_args=(), **kw):
+        captured["base_ref"] = base_ref
+        captured["project_root"] = project_root
+        return "child-abc-123456"
+
+    monkeypatch.setattr(boss_mod, "STATE_ROOT", str(tmp_path))
+    monkeypatch.setattr(launcher_mod, "launch", fake_launch)
+
+    result = boss_mod.launch_child(gr_id, "localgremlin", "/tmp/child-plan.md")
+
+    assert result == "child-abc-123456"
+    assert captured["base_ref"] == expected_sha
+    assert captured["project_root"] == project_root_path
+
+
+def test_boss_records_current_head_after_land(tmp_path, monkeypatch):
+    """After land_child returns True, patch_state is called with the boss worktree's new HEAD."""
+    gr_id = "test-boss-head-bb2233"
+    state_dir, project_root, workdir = _make_gremlin_state(tmp_path, gr_id)
+    _common_boss_patches(monkeypatch, tmp_path, gr_id)
+
+    spec = tmp_path / "spec.md"
+    spec.write_text("# Spec\n")
+    child_plan = tmp_path / "child-plan.md"
+    child_plan.write_text("# Child plan\n")
+
+    expected_new_head = "newhead12345678901234567890abcdef123456"
+    monkeypatch.setattr(git_mod, "git_head_of_workdir", lambda w: expected_new_head)
+
+    patch_calls = []
+    monkeypatch.setattr(boss_mod, "patch_state", lambda **kw: patch_calls.append(kw))
+
+    handoff_results = iter([
+        ("next-plan", {"exit_state": "next-plan", "child_plan": str(child_plan), "operator_followups": []}),
+        ("chain-done", {"exit_state": "chain-done", "operator_followups": []}),
+    ])
+
+    def fake_run_handoff(gr_id, state_dir, boss_state, project_root, boss_workdir, model):
+        exit_state, sig = next(handoff_results)
+        n = boss_state["handoff_count"] + 1
+        out_path = os.path.join(state_dir, f"handoff-{n:03d}.md")
+        pathlib.Path(out_path).write_text(f"# Handoff {n}\n")
+        boss_state["handoff_count"] = n
+        boss_state["current_plan"] = out_path
+        boss_state["operator_followups"] = sig.get("operator_followups", [])
+        boss_state["handoff_records"].append({
+            "timestamp": "2026-01-01T00:00:00Z", "n": n,
+            "plan_in": boss_state["spec_path"], "plan_out": out_path,
+            "signal_file": "", "exit_state": exit_state,
+            "child_plan": sig.get("child_plan"), "bail_reason": None,
+            "operator_followups": sig.get("operator_followups", []),
+        })
+        return exit_state, sig
+
+    def fake_launch_child(gr_id, launch_kind, child_plan_path):
+        child_id = "child-land-test-cc4455"
+        child_dir = tmp_path / child_id
+        child_dir.mkdir(exist_ok=True)
+        (child_dir / "state.json").write_text(json.dumps({"exit_code": 0}))
+        (child_dir / "finished").write_text("")
+        return child_id
+
+    monkeypatch.setattr(boss_mod, "run_handoff", fake_run_handoff)
+    monkeypatch.setattr(boss_mod, "launch_child", fake_launch_child)
+    monkeypatch.setattr(boss_mod, "land_child", lambda cid, into_dir="": True)
+
+    result = boss_main(["--plan", str(spec), "--chain-kind", "local"])
+    assert result == 0
+
+    current_head_calls = [c for c in patch_calls if "current_head" in c]
+    assert current_head_calls, "patch_state should have been called with current_head"
+    assert any(c["current_head"] == expected_new_head for c in current_head_calls), \
+        f"expected current_head={expected_new_head!r} in patch_calls, got: {current_head_calls}"


### PR DESCRIPTION
## Summary

- Deletes `_resolve_project_root` from `launcher.py` — the launcher no longer reads parent `state.json` to infer context; callers pass it explicitly
- `launcher.launch()` gains `project_root` and `base_ref` parameters; both worktree setup call sites forward them
- `git.py` gains `git_head_of_workdir(workdir)` and `setup_worktree_branch` gains `base_ref` param
- `boss.py` records `current_head` in `state.json` at chain start and after each successful land; `launch_child` reads it and passes it as `base_ref` to `launcher.launch()`
- CLI `launch` subcommand gains `--base-ref` flag

## Boss worktree detached-HEAD audit

`_land_local` with `into_dir=boss_workdir` uses `git merge --squash` + `git commit` on the detached HEAD — no branch is created, boss worktree stays detached throughout. Verified clean.

## Test plan

- `PYTHONPATH=. python -m pytest` — 233 passed
- `grep -n "_resolve_project_root\|parent_state\|parent_sf" gremlins/launcher.py` — returns nothing
- New tests: `test_boss_launches_child_against_current_head`, `test_boss_records_current_head_after_land`, `test_launch_passes_base_ref_to_worktree_setup`, `test_launch_explicit_project_root`

Closes #179 #188 #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)