### PR TITLE
fix(clients): suppress session-summary hook in SubprocessClaudeClient

### DIFF
--- a/gremlins/clients/claude.py
+++ b/gremlins/clients/claude.py
@@ -16,6 +16,7 @@ same client without a second pass.
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import subprocess
 import sys
@@ -303,11 +304,14 @@ class SubprocessClaudeClient:
         # or EOF, it doesn't block for the buffer to fill) and throughput
         # on the big implement-stage stream-json traces jumps by orders of
         # magnitude.
+        env = os.environ.copy()
+        env["GREMLIN_SKIP_SUMMARY"] = "1"
         p = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
             stderr=None,
             start_new_session=False,
+            env=env,
         )
         self._track(p)
 

--- a/gremlins/tests/test_clients_claude.py
+++ b/gremlins/tests/test_clients_claude.py
@@ -1,0 +1,85 @@
+"""Tests for SubprocessClaudeClient (gremlins/clients/claude.py)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import sys
+import pathlib
+
+import pytest
+
+from gremlins.clients.claude import SubprocessClaudeClient
+
+TESTS_DIR = pathlib.Path(__file__).resolve().parent
+
+# ---------------------------------------------------------------------------
+# Stub claude binary
+# ---------------------------------------------------------------------------
+
+_STUB_CLAUDE_SRC = """\
+#!/usr/bin/env python3
+import json, os, sys
+
+env_out = os.environ.get("STUB_ENV_OUT")
+if env_out:
+    with open(env_out, "w", encoding="utf-8") as f:
+        json.dump(dict(os.environ), f)
+
+sys.stdout.write(json.dumps({"type": "system", "subtype": "init", "session_id": "stub-sess"}) + "\\n")
+sys.stdout.write(json.dumps({"type": "result", "subtype": "success", "num_turns": 1, "total_cost_usd": 0.0}) + "\\n")
+sys.stdout.flush()
+"""
+
+
+def _install_stub_claude(bin_dir: pathlib.Path) -> None:
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    stub_py = bin_dir / "_stub_claude.py"
+    stub_py.write_text(_STUB_CLAUDE_SRC, encoding="utf-8")
+    stub_py.chmod(0o755)
+    wrapper = bin_dir / "claude"
+    wrapper.write_text(
+        f"#!/usr/bin/env bash\nexec {shlex.quote(sys.executable)} "
+        f"{shlex.quote(str(stub_py))} \"$@\"\n",
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_subprocess_client_sets_gremlin_skip_summary(tmp_path, monkeypatch):
+    bin_dir = tmp_path / "bin"
+    _install_stub_claude(bin_dir)
+    env_out = tmp_path / "child_env.json"
+
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    monkeypatch.setenv("STUB_ENV_OUT", str(env_out))
+    monkeypatch.delenv("GREMLIN_SKIP_SUMMARY", raising=False)
+
+    client = SubprocessClaudeClient()
+    client.run("hello", label="test", output_format="stream-json")
+
+    assert env_out.exists(), "stub did not write env file"
+    child_env = json.loads(env_out.read_text(encoding="utf-8"))
+    assert child_env.get("GREMLIN_SKIP_SUMMARY") == "1"
+
+
+def test_subprocess_client_inherits_other_env_vars(tmp_path, monkeypatch):
+    bin_dir = tmp_path / "bin"
+    _install_stub_claude(bin_dir)
+    env_out = tmp_path / "child_env.json"
+
+    sentinel = "test_value_xyz_123"
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    monkeypatch.setenv("STUB_ENV_OUT", str(env_out))
+    monkeypatch.setenv("MY_SENTINEL_VAR", sentinel)
+
+    client = SubprocessClaudeClient()
+    client.run("hello", label="test", output_format="stream-json")
+
+    child_env = json.loads(env_out.read_text(encoding="utf-8"))
+    assert child_env.get("MY_SENTINEL_VAR") == sentinel


### PR DESCRIPTION
## Summary

- `SubprocessClaudeClient.run()` now builds `env = os.environ.copy()` with `GREMLIN_SKIP_SUMMARY=1` overlaid and passes it via `env=` to `subprocess.Popen`, matching the pattern already used in `fleet/land.py`.
- Adds `gremlins/tests/test_clients_claude.py` with two tests: one asserting `GREMLIN_SKIP_SUMMARY=1` is present in the child env, one asserting other parent env vars pass through unchanged.

## Test plan

- [ ] `cd gremlins && PYTHONPATH=. python -m pytest tests/test_clients_claude.py` — both new tests pass
- [ ] `cd gremlins && PYTHONPATH=. python -m pytest` — full suite (235 tests) passes with no regressions
- [ ] `grep -n "GREMLIN_SKIP_SUMMARY" gremlins/clients/claude.py` returns a hit

Closes #165