### PR TITLE
fix(commit-pr): derive prompt from diff instead of resuming implement session

### DIFF
--- a/gremlins/orchestrators/gh.py
+++ b/gremlins/orchestrators/gh.py
@@ -26,6 +26,7 @@ from typing import Dict, List, Optional
 
 from ..clients.claude import ClaudeClient, SubprocessClaudeClient
 from ..gh_utils import extract_gh_url, get_repo, parse_issue_ref, view_issue
+from ..git import DirtyOnly, HeadAdvanced
 from ..runner import install_signal_handlers, run_stages
 from ..stages.commit_pr import run_commit_pr_stage
 from ..stages.ghaddress import run_ghaddress_stage
@@ -90,15 +91,6 @@ def _parse_gh_args(argv: List[str]) -> argparse.Namespace:
     parser.add_argument("--model", dest="model", default=None)
     parser.add_argument("instructions", nargs="*")
     args = parser.parse_args(argv)
-
-    # --resume-from commit-pr: rewind to implement (IMPL_SESSION not persisted)
-    if args.resume_from == "commit-pr":
-        sys.stderr.write(
-            "    note: --resume-from commit-pr requires IMPL_SESSION which isn't "
-            "persisted; rewinding to implement\n"
-        )
-        sys.stderr.flush()
-        args.resume_from = "implement"
 
     if args.resume_from is not None and args.resume_from not in VALID_STAGES:
         die(
@@ -399,19 +391,49 @@ def gh_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int:
             issue_num=issue_num,
         )
         impl_result_holder["result"] = result
+        # Persist for commit-pr resume: base_ref and handoff branch are all
+        # that's needed to reconstruct the diff and outcome on a fresh process.
+        patch_state(
+            impl_handoff_branch=result.handoff_branch,
+            impl_base_ref=result.pre_state.head,
+        )
 
     def stage_commit_pr() -> None:
         set_stage("commit-pr")
         print("==> [2b/6] committing + opening PR", flush=True)
-        result: ImplStageResult = impl_result_holder["result"]  # type: ignore[assignment]
+
+        if "result" in impl_result_holder:
+            result: ImplStageResult = impl_result_holder["result"]  # type: ignore[assignment]
+            impl_outcome = result.outcome
+            impl_handoff_branch = result.handoff_branch
+            base_ref = result.pre_state.head
+        else:
+            # Resuming at commit-pr: reconstruct from state.json
+            impl_handoff_branch = _read_state_field(state_file, "impl_handoff_branch")
+            base_ref = _read_state_field(state_file, "impl_base_ref")
+            if not base_ref:
+                die(
+                    "--resume-from commit-pr: no impl_base_ref in state.json "
+                    "(rewind to implement?)"
+                )
+            if impl_handoff_branch:
+                count_r = subprocess.run(
+                    ["git", "rev-list", "--count", f"{base_ref}..{impl_handoff_branch}"],
+                    capture_output=True, text=True, check=False,
+                )
+                commit_count = int(count_r.stdout.strip() or "0")
+                impl_outcome = HeadAdvanced(commit_count=commit_count)
+            else:
+                impl_outcome = DirtyOnly()
+
         pr_url = run_commit_pr_stage(
             client=client,
             model=model,
-            impl_session_id=result.session_id,
-            pre_state=result.pre_state,
-            outcome=result.outcome,
-            handoff_branch=result.handoff_branch,
-            issue_num=issue_num,
+            impl_outcome=impl_outcome,
+            impl_handoff_branch=impl_handoff_branch,
+            base_ref=base_ref,
+            issue_url=issue_url,
+            cwd=None,
             session_dir=session_dir,
         )
         pr_url_holder["url"] = pr_url

--- a/gremlins/orchestrators/gh.py
+++ b/gremlins/orchestrators/gh.py
@@ -421,7 +421,13 @@ def gh_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int:
                     ["git", "rev-list", "--count", f"{base_ref}..{impl_handoff_branch}"],
                     capture_output=True, text=True, check=False,
                 )
-                commit_count = int(count_r.stdout.strip() or "0")
+                if count_r.returncode != 0:
+                    die(
+                        f"--resume-from commit-pr: impl_handoff_branch '{impl_handoff_branch}' "
+                        f"not found or base_ref invalid (rewind to implement?)\n"
+                        f"{count_r.stderr.strip()}"
+                    )
+                commit_count = int(count_r.stdout.strip())
                 impl_outcome = HeadAdvanced(commit_count=commit_count)
             else:
                 impl_outcome = DirtyOnly()

--- a/gremlins/stages/CLAUDE.md
+++ b/gremlins/stages/CLAUDE.md
@@ -11,14 +11,13 @@ sequencing logic of their own.
   `kind='gh'`). For gh: enforces the empty-implementation invariant,
   classifies the outcome (`HeadAdvanced` / `DirtyOnly` / `EmptyImpl` /
   `DivergentHead`), creates the impl-handoff branch, and returns an
-  `ImplStageResult` carrying `session_id` so commit-pr can resume the same
-  claude session.
+  `ImplStageResult` with the pre-impl state and classified outcome.
 - `review_code.py` — `run_review_code_stage`. Local pipeline only
   (single-detail-reviewer post-collapse).
 - `address_code.py` — `run_address_code_stage`. Local pipeline only.
-- `commit_pr.py` — `run_commit_pr_stage`. Gh pipeline. Resumes the
-  implement session (`claude --resume <session_id>`) so the same agent
-  that wrote the code creates the branch and opens the PR.
+- `commit_pr.py` — `run_commit_pr_stage`. Gh pipeline. Opens a fresh
+  claude session against the impl-handoff branch diff; no session_id
+  dependency, so `--resume-from commit-pr` works cleanly.
 - `ghreview.py` — `run_ghreview_stage`. Thin wrapper around `/ghreview
   <pr_url>` plus a `check_bail` call.
 - `ghaddress.py` — `run_ghaddress_stage`. Thin wrapper around `/ghaddress

--- a/gremlins/stages/commit_pr.py
+++ b/gremlins/stages/commit_pr.py
@@ -38,16 +38,19 @@ def _get_diff(
             ["git", "log", "--patch", f"{base_ref}..{impl_handoff_branch}"],
             **run_kw,
         )
-        diff = r.stdout.strip()
-        if not diff:
-            r = subprocess.run(
-                ["git", "diff", f"{base_ref}..{impl_handoff_branch}"],
-                **run_kw,
+        if r.returncode != 0:
+            raise RuntimeError(
+                f"git log --patch {base_ref}..{impl_handoff_branch} failed "
+                f"(rc={r.returncode}): {r.stderr.strip()}"
             )
-            diff = r.stdout.strip()
+        diff = r.stdout.strip()
     else:
         # DirtyOnly: uncommitted changes relative to HEAD
         r = subprocess.run(["git", "diff", "HEAD"], **run_kw)
+        if r.returncode != 0:
+            raise RuntimeError(
+                f"git diff HEAD failed (rc={r.returncode}): {r.stderr.strip()}"
+            )
         diff = r.stdout.strip()
     return diff or "(no diff available)"
 

--- a/gremlins/stages/commit_pr.py
+++ b/gremlins/stages/commit_pr.py
@@ -1,9 +1,10 @@
 """Commit-and-open-PR stage for the gh pipeline.
 
 Selects the correct action clause from ``gremlins/prompts/`` based on the
-implement stage's classified outcome, assembles the full commit-pr prompt, and
-runs claude with ``--resume <impl_session_id>`` so the same claude session that
-did the implementation also creates the branch and opens the PR.
+implement stage's classified outcome, gathers the diff from the impl-handoff
+branch, assembles the full commit-pr prompt, and runs a fresh claude session
+(no ``--resume``).  All context comes from disk state so the stage can resume
+cleanly without depending on an in-memory session_id.
 """
 
 from __future__ import annotations
@@ -13,7 +14,7 @@ import subprocess
 from typing import Optional
 
 from ..clients.claude import ClaudeClient, CompletedRun
-from ..git import DirtyOnly, HeadAdvanced, ImplOutcome, PreImplState
+from ..git import HeadAdvanced, ImplOutcome
 from ..gh_utils import extract_gh_url
 
 PROMPTS_DIR = pathlib.Path(__file__).resolve().parent.parent / "prompts"
@@ -23,45 +24,73 @@ def _load(name: str) -> str:
     return (PROMPTS_DIR / name).read_text(encoding="utf-8")
 
 
+def _get_diff(
+    outcome: ImplOutcome,
+    impl_handoff_branch: str,
+    base_ref: str,
+    cwd: Optional[str],
+) -> str:
+    run_kw: dict = dict(capture_output=True, text=True, check=False)
+    if cwd:
+        run_kw["cwd"] = cwd
+    if isinstance(outcome, HeadAdvanced):
+        r = subprocess.run(
+            ["git", "log", "--patch", f"{base_ref}..{impl_handoff_branch}"],
+            **run_kw,
+        )
+        diff = r.stdout.strip()
+        if not diff:
+            r = subprocess.run(
+                ["git", "diff", f"{base_ref}..{impl_handoff_branch}"],
+                **run_kw,
+            )
+            diff = r.stdout.strip()
+    else:
+        # DirtyOnly: uncommitted changes relative to HEAD
+        r = subprocess.run(["git", "diff", "HEAD"], **run_kw)
+        diff = r.stdout.strip()
+    return diff or "(no diff available)"
+
+
 def run_commit_pr_stage(
     *,
     client: ClaudeClient,
     model: Optional[str],
-    impl_session_id: Optional[str],
-    pre_state: PreImplState,
-    outcome: ImplOutcome,
-    handoff_branch: str,
-    issue_num: str,
+    impl_outcome: ImplOutcome,
+    impl_handoff_branch: str,
+    base_ref: str,
+    issue_url: str,
+    cwd: Optional[str],
     session_dir: pathlib.Path,
 ) -> str:
-    """Build the commit-pr prompt, run claude (resuming the implement session),
+    """Build the commit-pr prompt with diff context, run a fresh claude session,
     extract and return the PR URL from the event stream."""
+    issue_num = issue_url.split("/")[-1] if issue_url else ""
 
-    # Action clause: which of the three shapes the agent should take.
-    if isinstance(outcome, HeadAdvanced):
-        # Check whether the worktree is also dirty.
-        status_r = subprocess.run(
-            ["git", "status", "--porcelain"],
-            capture_output=True, text=True, check=False,
-        )
+    diff = _get_diff(impl_outcome, impl_handoff_branch, base_ref, cwd)
+
+    if isinstance(impl_outcome, HeadAdvanced):
+        run_kw: dict = dict(capture_output=True, text=True, check=False)
+        if cwd:
+            run_kw["cwd"] = cwd
+        status_r = subprocess.run(["git", "status", "--porcelain"], **run_kw)
         worktree_dirty = bool(status_r.stdout.strip())
         if worktree_dirty:
             action_clause = _load("commit_pr_handoff_dirty.md").format(
-                handoff_branch=handoff_branch,
-                commit_count=outcome.commit_count,
-                pre_head=pre_state.head,
+                handoff_branch=impl_handoff_branch,
+                commit_count=impl_outcome.commit_count,
+                pre_head=base_ref,
             )
         else:
             action_clause = _load("commit_pr_handoff_clean.md").format(
-                handoff_branch=handoff_branch,
-                commit_count=outcome.commit_count,
-                pre_head=pre_state.head,
+                handoff_branch=impl_handoff_branch,
+                commit_count=impl_outcome.commit_count,
+                pre_head=base_ref,
             )
     else:
         # DirtyOnly: create branch + commit + push from scratch
         action_clause = _load("commit_pr_fresh.md")
 
-    # Branch-name and closes-link clauses depend on whether we have an issue.
     if issue_num:
         branch_clause = f"Name the branch 'issue-{issue_num}-<short-slug>'."
         closes_clause = (
@@ -76,6 +105,7 @@ def run_commit_pr_stage(
         )
 
     prompt = (
+        f"Here is the implementation diff:\n\n```diff\n{diff}\n```\n\n"
         f"{action_clause} {branch_clause} {closes_clause} "
         "Print ONLY the PR URL on the final line of your response."
     )
@@ -84,7 +114,6 @@ def run_commit_pr_stage(
         prompt,
         label="commit-pr",
         model=model,
-        resume_session=impl_session_id,
         raw_path=session_dir / "stream-commit-pr.jsonl",
         capture_events=True,
     )

--- a/gremlins/stages/implement.py
+++ b/gremlins/stages/implement.py
@@ -3,12 +3,10 @@
 For ``kind='local'``: renders ``implement_local.md``, runs claude, enforces the
 empty-implementation invariant (spec: an empty impl must never flow into review).
 
-For ``kind='gh'``: renders ``implement_gh.md``, runs claude with
-``capture_events=True`` (so the caller gets the session_id for commit-pr's
-``--resume``), then runs the impl-handoff branch lifecycle from
-``gremlins/git.py``.  Returns an ``ImplStageResult`` with session_id, the
-pre-impl state snapshot, and the classified outcome.  Raises on
-``DivergentHead`` or ``EmptyImpl``.
+For ``kind='gh'``: renders ``implement_gh.md``, runs claude, then runs the
+impl-handoff branch lifecycle from ``gremlins/git.py``.  Returns an
+``ImplStageResult`` with the pre-impl state snapshot and classified outcome.
+Raises on ``DivergentHead`` or ``EmptyImpl``.
 """
 
 from __future__ import annotations
@@ -20,7 +18,7 @@ import subprocess
 import sys
 from typing import Optional
 
-from ..clients.claude import ClaudeClient, CompletedRun
+from ..clients.claude import ClaudeClient
 from ..git import (
     DirtyOnly,
     DivergentHead,
@@ -43,7 +41,6 @@ PROMPT_GH_PATH = pathlib.Path(__file__).resolve().parent.parent / "prompts" / "i
 @dataclasses.dataclass
 class ImplStageResult:
     """Returned by ``run_implement_stage`` when ``kind='gh'``."""
-    session_id: Optional[str]
     pre_state: PreImplState
     outcome: ImplOutcome
     handoff_branch: str  # empty string when outcome is DirtyOnly (no branch created)
@@ -193,7 +190,7 @@ def _run_implement_gh(
 
     pre_state = record_pre_impl_state(cwd=cwd)
 
-    completed: CompletedRun = client.run(
+    client.run(
         prompt,
         label="implement",
         model=impl_model,
@@ -212,12 +209,6 @@ def _run_implement_gh(
             "committed work to hand off"
         )
 
-    if completed.session_id is None:
-        raise RuntimeError(
-            "implement stage did not produce a session_id; "
-            "commit-pr cannot resume the session"
-        )
-
     handoff_branch = ""
     if isinstance(outcome, HeadAdvanced):
         handoff_branch = create_handoff_branch(pre_state, cwd=cwd)
@@ -232,7 +223,6 @@ def _run_implement_gh(
         sys.stdout.flush()
 
     return ImplStageResult(
-        session_id=completed.session_id,
         pre_state=pre_state,
         outcome=outcome,
         handoff_branch=handoff_branch,

--- a/gremlins/tests/test_orchestrator_gh.py
+++ b/gremlins/tests/test_orchestrator_gh.py
@@ -312,11 +312,11 @@ def test_parse_model():
     assert args.model == "claude-opus-4-7"
 
 
-def test_parse_resume_from_commit_pr_rewinds(capsys):
+def test_parse_resume_from_commit_pr(capsys):
     args = _parse_gh_args(["--plan", "42", "--resume-from", "commit-pr"])
-    assert args.resume_from == "implement"
+    assert args.resume_from == "commit-pr"
     captured = capsys.readouterr()
-    assert "rewinding to implement" in captured.err
+    assert "rewinding" not in captured.err
 
 
 def test_parse_plan_and_instructions_mutual_exclusion():
@@ -777,3 +777,76 @@ def test_plan_file_path_includes_plan_title_cost_in_total(tmp_path, monkeypatch)
         f"expected total {expected:.2f}, got {total:.4f}; "
         f"a regression dropping plan-title cost (0.13) would show total ≈ {expected - 0.13:.2f}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression: --resume-from commit-pr must not re-run implement
+# ---------------------------------------------------------------------------
+
+def test_resume_from_commit_pr_skips_implement(tmp_path, monkeypatch):
+    """--resume-from commit-pr picks up at commit-pr without re-running implement.
+
+    Regression guard for the bug where the orchestrator silently rewound
+    commit-pr → implement, which caused an EmptyImpl loop when the
+    impl-handoff branch was already present.
+    """
+    _init_git_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    # Simulate a completed implement stage: one commit above the init commit.
+    (tmp_path / "impl.txt").write_text("impl content\n")
+    subprocess.run(["git", "add", "impl.txt"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "feat: add impl.txt"],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+
+    base_ref = subprocess.run(
+        ["git", "rev-parse", "HEAD~1"],
+        cwd=tmp_path, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+    # Create the impl-handoff branch at the impl commit.
+    handoff_branch = "ghgremlin-impl-handoff-9999"
+    subprocess.run(["git", "branch", handoff_branch], cwd=tmp_path, check=True, capture_output=True)
+
+    session_dir, state_file = _patch_common(monkeypatch, tmp_path)
+
+    import gremlins.orchestrators.gh as _gh_mod
+
+    def _fake_read(sf, field):
+        if field == "issue_url":
+            return "https://github.com/owner/repo/issues/42"
+        if field == "issue_num":
+            return "42"
+        if field == "pr_url":
+            return ""
+        if field == "impl_handoff_branch":
+            return handoff_branch
+        if field == "impl_base_ref":
+            return base_ref
+        return ""
+
+    monkeypatch.setattr(_gh_mod, "_read_state_field", _fake_read)
+    monkeypatch.setattr(_gh_mod, "_fetch_issue_body", lambda num, repo: "# Plan\nDo stuff.\n")
+    monkeypatch.setattr(subprocess, "run", _make_gh_subprocess())
+    monkeypatch.setattr("gremlins.orchestrators.gh.run_ghreview_stage", lambda **kw: None)
+    monkeypatch.setattr("gremlins.orchestrators.gh.run_wait_copilot_stage", lambda **kw: "APPROVED")
+    monkeypatch.setattr("gremlins.orchestrators.gh.run_request_copilot_stage", lambda **kw: None)
+    monkeypatch.setattr("gremlins.orchestrators.gh.run_ghaddress_stage", lambda **kw: None)
+
+    client = FakeClaudeClient(fixtures={"commit-pr": _pr_events()})
+
+    result = gh_main(["--plan", "42", "--resume-from", "commit-pr"], client=client)
+    assert result == 0
+
+    labels = [c.label for c in client.calls]
+    assert "implement" not in labels, "implement must not run on commit-pr resume"
+    assert "commit-pr" in labels
+
+    # The commit-pr prompt must contain content from the impl diff.
+    commit_pr_call = next(c for c in client.calls if c.label == "commit-pr")
+    assert "impl content" in commit_pr_call.prompt or "impl.txt" in commit_pr_call.prompt
+
+    # No resume_session: commit-pr must open a fresh session.
+    assert commit_pr_call.resume_session is None


### PR DESCRIPTION
## Summary

- Drops the cross-stage `session_id` dependency in the gh pipeline's `commit-pr` stage — the stage now computes the diff from the impl-handoff branch and runs a fresh claude session with no `--resume`.
- Removes the `--resume-from commit-pr → implement` rewind hack in `gh.py` that caused an `EmptyImpl` rescue loop when the impl-handoff branch was already present.
- Persists `impl_handoff_branch` / `impl_base_ref` to `state.json` after implement so `--resume-from commit-pr` can reconstruct the outcome and diff from disk without re-running implement.

## Test plan

- [ ] `cd gremlins && PYTHONPATH=. python -m pytest` — 236 tests pass
- [ ] `test_parse_resume_from_commit_pr` asserts no rewind message for `--resume-from commit-pr`
- [ ] `test_resume_from_commit_pr_skips_implement` drives `gh_main --resume-from commit-pr` against a pre-seeded impl-handoff branch, asserts implement is skipped, diff content appears in prompt, and `resume_session` is `None`
- [ ] `grep -n "impl_session_id\|resume_session" gremlins/**/*.py` returns only client protocol and the new `assert resume_session is None` assertion

Closes #181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)