### PR TITLE
feat(boss-chain): thread chain spec to child gremlins as north-star context

### DIFF
--- a/gremlins/launcher.py
+++ b/gremlins/launcher.py
@@ -184,6 +184,7 @@ def launch(
     project_root: Optional[str] = None,
     base_ref: str = "HEAD",
     pipeline_args: tuple = (),
+    spec_path: Optional[str] = None,
 ) -> str:
     """Set up state dir + worktree, spawn the pipeline detached, return gremlin id.
 
@@ -210,6 +211,14 @@ def launch(
         if os.path.getsize(plan) == 0:
             raise ValueError(f"--plan: file is empty: {plan}")
 
+    # Validate and normalize spec_path to absolute
+    if spec_path is not None:
+        if not os.path.isfile(spec_path):
+            raise ValueError(f"--spec: file not found: {spec_path}")
+        if os.path.getsize(spec_path) == 0:
+            raise ValueError(f"--spec: file is empty: {spec_path}")
+        spec_path = str(pathlib.Path(spec_path).resolve())
+
     # Normalize plan path to absolute
     if plan and os.path.isfile(plan):
         plan = str(pathlib.Path(plan).resolve())
@@ -233,8 +242,10 @@ def launch(
     state_dir = _state_root() / gr_id
     state_dir.mkdir(parents=True, exist_ok=True)
 
-    # pipeline_args for state.json: includes --plan when plan is set
+    # pipeline_args for state.json: includes --plan and --spec when set
     stored_pipeline_args = list(pipeline_args)
+    if spec_path and "--spec" not in stored_pipeline_args:
+        stored_pipeline_args = ["--spec", spec_path] + stored_pipeline_args
     if plan and "--plan" not in stored_pipeline_args:
         stored_pipeline_args = ["--plan", plan] + stored_pipeline_args
 

--- a/gremlins/orchestrators/boss.py
+++ b/gremlins/orchestrators/boss.py
@@ -351,11 +351,14 @@ def launch_child(gr_id: str, launch_kind: str, child_plan: str) -> str:
     gremlin_state = load_json(os.path.join(STATE_ROOT, gr_id, "state.json"))
     project_root = gremlin_state.get("project_root") or None
     base_ref = gremlin_state.get("current_head") or "HEAD"
+    boss_state = load_boss_state(os.path.join(STATE_ROOT, gr_id))
+    spec_path = boss_state.get("spec_path") or None
 
     log(f"launching child ({launch_kind}): {child_plan}, base={base_ref[:12]}")
     try:
         child_id = _launch(launch_kind, plan=child_plan, parent_id=gr_id,
-                           project_root=project_root, base_ref=base_ref)
+                           project_root=project_root, base_ref=base_ref,
+                           spec_path=spec_path)
     except (ValueError, RuntimeError) as exc:
         die(f"launcher failed: {exc}")
 

--- a/gremlins/orchestrators/gh.py
+++ b/gremlins/orchestrators/gh.py
@@ -82,7 +82,7 @@ def _load_core_principles() -> str:
 def _parse_gh_args(argv: List[str]) -> argparse.Namespace:
     usage = (
         'usage: gremlins.cli gh [-r <ref>] [--resume-from <stage>] '
-        '[--plan <path|issue-ref>] [--model <model>] "<instructions>"'
+        '[--plan <path|issue-ref>] [--spec <path>] [--model <model>] "<instructions>"'
     )
     parser = argparse.ArgumentParser(add_help=False, usage=usage)
     parser.add_argument("-r", dest="ref", default="")
@@ -291,6 +291,9 @@ def gh_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int:
 
     # --spec staging: snapshot into session_dir/spec.md on first launch.
     # On resume, reuse the existing snapshot (rescue-determinism).
+    # launcher.py normalizes spec_path before spawning the subprocess, so the
+    # is_file / size checks below are only reachable on a direct (non-launcher)
+    # invocation of the orchestrator — they guard that path.
     if args.spec_path and not spec_file.exists():
         spec_src = pathlib.Path(args.spec_path)
         if not spec_src.is_file():
@@ -392,7 +395,12 @@ def gh_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int:
     def stage_implement() -> None:
         set_stage("implement")
         print("==> [2a/6] implementing plan", flush=True)
-        spec_text = spec_file.read_text(encoding="utf-8") if spec_file.exists() else ""
+        spec_text = ""
+        if spec_file.exists():
+            try:
+                spec_text = spec_file.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as exc:
+                print(f"warning: could not read spec.md ({exc}); proceeding without north-star context", flush=True, file=sys.stderr)
         result = run_implement_stage(
             client=client,
             impl_model=model,

--- a/gremlins/orchestrators/gh.py
+++ b/gremlins/orchestrators/gh.py
@@ -88,6 +88,7 @@ def _parse_gh_args(argv: List[str]) -> argparse.Namespace:
     parser.add_argument("-r", dest="ref", default="")
     parser.add_argument("--resume-from", dest="resume_from", default=None)
     parser.add_argument("--plan", dest="plan_source", default=None)
+    parser.add_argument("--spec", dest="spec_path", default=None)
     parser.add_argument("--model", dest="model", default=None)
     parser.add_argument("instructions", nargs="*")
     args = parser.parse_args(argv)
@@ -284,8 +285,19 @@ def gh_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int:
     session_dir = resolve_session_dir()
     state_file = resolve_state_file()
     plan_md = session_dir / "plan.md"
+    spec_file = session_dir / "spec.md"
 
     print(f"==> session: {session_dir}", flush=True)
+
+    # --spec staging: snapshot into session_dir/spec.md on first launch.
+    # On resume, reuse the existing snapshot (rescue-determinism).
+    if args.spec_path and not spec_file.exists():
+        spec_src = pathlib.Path(args.spec_path)
+        if not spec_src.is_file():
+            die(f"--spec: file not found: {args.spec_path}")
+        if spec_src.stat().st_size == 0:
+            die(f"--spec: file is empty: {args.spec_path}")
+        shutil.copyfile(spec_src, spec_file)
 
     # Restore model from state.json when --model not supplied (resume path),
     # then fall back to "sonnet" for fresh launches without an explicit --model.
@@ -380,6 +392,7 @@ def gh_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int:
     def stage_implement() -> None:
         set_stage("implement")
         print("==> [2a/6] implementing plan", flush=True)
+        spec_text = spec_file.read_text(encoding="utf-8") if spec_file.exists() else ""
         result = run_implement_stage(
             client=client,
             impl_model=model,
@@ -389,6 +402,7 @@ def gh_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int:
             is_git=True,
             kind="gh",
             issue_num=issue_num,
+            spec_text=spec_text,
         )
         impl_result_holder["result"] = result
         # Persist for commit-pr resume: base_ref and handoff branch are all

--- a/gremlins/orchestrators/local.py
+++ b/gremlins/orchestrators/local.py
@@ -83,7 +83,7 @@ def _parse_local_args(argv: List[str]) -> argparse.Namespace:
     usage = (
         'usage: gremlins.cli local [-p <plan-model>] [-i <impl-model>] '
         '[-x <address-model>] [-b <detail-review-model>] '
-        '[--resume-from <stage>] [--plan <path>] "<instructions>"'
+        '[--resume-from <stage>] [--plan <path>] [--spec <path>] "<instructions>"'
     )
     parser = argparse.ArgumentParser(add_help=False, usage=usage)
     parser.add_argument("-p", dest="plan_model", default="sonnet")
@@ -151,6 +151,9 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
 
     # --spec staging: snapshot into session_dir/spec.md on first launch.
     # On resume, reuse the existing snapshot (same rescue-determinism rule as --plan).
+    # launcher.py normalizes spec_path before spawning the subprocess, so the
+    # is_file / size checks below are only reachable on a direct (non-launcher)
+    # invocation of the orchestrator — they guard that path.
     spec_file = session_dir / "spec.md"
     if args.spec_path and not spec_file.exists():
         spec_src = pathlib.Path(args.spec_path)
@@ -230,7 +233,12 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
         # snapshot from disk rather than relying on in-memory state.
         plan_text = plan_file.read_text(encoding="utf-8")
         plan_text_holder["text"] = plan_text
-        spec_text = spec_file.read_text(encoding="utf-8") if spec_file.exists() else ""
+        spec_text = ""
+        if spec_file.exists():
+            try:
+                spec_text = spec_file.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as exc:
+                print(f"warning: could not read spec.md ({exc}); proceeding without north-star context", flush=True, file=sys.stderr)
         set_stage("implement")
         print(f"==> [2/4] implementing (model: {args.impl}, from {plan_file})", flush=True)
         run_implement_stage(

--- a/gremlins/orchestrators/local.py
+++ b/gremlins/orchestrators/local.py
@@ -93,6 +93,7 @@ def _parse_local_args(argv: List[str]) -> argparse.Namespace:
     parser.add_argument("--resume-from", dest="resume_from", default=None,
                         choices=VALID_RESUME_STAGES)
     parser.add_argument("--plan", dest="plan_path", default=None)
+    parser.add_argument("--spec", dest="spec_path", default=None)
     parser.add_argument("instructions", nargs="*")
     args = parser.parse_args(argv)
     # launch.sh resume may pass an empty-string positional when a --plan
@@ -147,6 +148,17 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
             die(f"--plan: file is empty: {args.plan_path}")
         shutil.copyfile(src, plan_file)
         plan_copied_from_source = True
+
+    # --spec staging: snapshot into session_dir/spec.md on first launch.
+    # On resume, reuse the existing snapshot (same rescue-determinism rule as --plan).
+    spec_file = session_dir / "spec.md"
+    if args.spec_path and not spec_file.exists():
+        spec_src = pathlib.Path(args.spec_path)
+        if not spec_src.is_file():
+            die(f"--spec: file not found: {args.spec_path}")
+        if spec_src.stat().st_size == 0:
+            die(f"--spec: file is empty: {args.spec_path}")
+        shutil.copyfile(spec_src, spec_file)
 
     is_git = in_git_repo()
     core_principles = _load_core_principles()
@@ -218,6 +230,7 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
         # snapshot from disk rather than relying on in-memory state.
         plan_text = plan_file.read_text(encoding="utf-8")
         plan_text_holder["text"] = plan_text
+        spec_text = spec_file.read_text(encoding="utf-8") if spec_file.exists() else ""
         set_stage("implement")
         print(f"==> [2/4] implementing (model: {args.impl}, from {plan_file})", flush=True)
         run_implement_stage(
@@ -228,6 +241,7 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
             core_principles=core_principles,
             session_dir=session_dir,
             is_git=is_git,
+            spec_text=spec_text,
         )
 
     def stage_review_code() -> None:

--- a/gremlins/prompts/implement_gh.md
+++ b/gremlins/prompts/implement_gh.md
@@ -2,7 +2,7 @@ When writing code, follow these principles:
 
 {core_principles}
 
-The following is the implementation plan {plan_source_label}:
+{spec_block}The following is the implementation plan {plan_source_label}:
 
 {issue_body}
 

--- a/gremlins/prompts/implement_local.md
+++ b/gremlins/prompts/implement_local.md
@@ -2,6 +2,6 @@ When writing code, follow these principles:
 
 {core_principles}
 
-{plan_text}
+{spec_block}{plan_text}
 
 Implement every task in the plan above by editing code in this repo. When the implementation is complete{impl_commit_instr}

--- a/gremlins/stages/implement.py
+++ b/gremlins/stages/implement.py
@@ -79,10 +79,13 @@ def changes_outside_git(sentinel: pathlib.Path, session_dir: pathlib.Path) -> bo
 def _render_spec_block(spec_text: str) -> str:
     if not spec_text or not spec_text.strip():
         return ""
-    body = spec_text[:50000]
     trunc = ""
     if len(spec_text) > 50000:
-        trunc = f"\n(spec truncated to 50000 chars; {len(spec_text)} chars total)"
+        cut = spec_text.rfind('\n', 0, 50000)
+        body = spec_text[:cut] if cut > 0 else spec_text[:50000]
+        trunc = f"\n(spec truncated; {len(spec_text)} chars total)"
+    else:
+        body = spec_text
     return (
         "## Overarching goal (north star)\n\n"
         "This is the original chain spec. It is read-only context for\n"

--- a/gremlins/stages/implement.py
+++ b/gremlins/stages/implement.py
@@ -76,6 +76,24 @@ def changes_outside_git(sentinel: pathlib.Path, session_dir: pathlib.Path) -> bo
     return False
 
 
+def _render_spec_block(spec_text: str) -> str:
+    if not spec_text or not spec_text.strip():
+        return ""
+    body = spec_text[:50000]
+    trunc = ""
+    if len(spec_text) > 50000:
+        trunc = f"\n(spec truncated to 50000 chars; {len(spec_text)} chars total)"
+    return (
+        "## Overarching goal (north star)\n\n"
+        "This is the original chain spec. It is read-only context for\n"
+        "understanding what the chain as a whole is working toward. Use\n"
+        "it to make coherent local decisions while implementing the plan\n"
+        "below — not as a task list. Do not expand scope beyond the\n"
+        "Tasks in the plan.\n\n"
+        f"~~~~\n{body}\n~~~~{trunc}\n\n"
+    )
+
+
 def run_implement_stage(
     *,
     client: ClaudeClient,
@@ -85,6 +103,7 @@ def run_implement_stage(
     session_dir: pathlib.Path,
     is_git: bool,
     kind: str = "local",
+    spec_text: str = "",
     # local-only (kept for API compatibility, not used in function body)
     plan_file: Optional[pathlib.Path] = None,
     # gh-only
@@ -105,6 +124,7 @@ def run_implement_stage(
             session_dir=session_dir,
             issue_num=issue_num,
             cwd=cwd,
+            spec_text=spec_text,
         )
 
     # --- local path ---
@@ -130,6 +150,7 @@ def run_implement_stage(
     template = PROMPT_LOCAL_PATH.read_text(encoding="utf-8")
     prompt = template.format(
         core_principles=core_principles,
+        spec_block=_render_spec_block(spec_text),
         plan_text=plan_text,
         impl_commit_instr=impl_commit_instr,
     )
@@ -165,6 +186,7 @@ def _run_implement_gh(
     session_dir: pathlib.Path,
     issue_num: str,
     cwd: Optional[str],
+    spec_text: str = "",
 ) -> ImplStageResult:
     """gh-specific implement: run claude, then orchestrate the handoff branch lifecycle."""
     if issue_num:
@@ -183,6 +205,7 @@ def _run_implement_gh(
     template = PROMPT_GH_PATH.read_text(encoding="utf-8")
     prompt = template.format(
         core_principles=core_principles,
+        spec_block=_render_spec_block(spec_text),
         plan_source_label=plan_source_label,
         issue_body=plan_text,
         plan_location_note=plan_location_note,

--- a/gremlins/tests/test_launcher.py
+++ b/gremlins/tests/test_launcher.py
@@ -566,3 +566,49 @@ def test_pipeline_survives_worktree_pipeline_rename(lenv, monkeypatch):
         f"expected exit 0; status={state.get('status')!r}; log tail:\n"
         f"{log_path.read_text(errors='replace')[-2000:] if log_path.exists() else '<log missing>'}"
     )
+
+
+# ---------------------------------------------------------------------------
+# spec_path forwarding
+# ---------------------------------------------------------------------------
+
+def test_launch_threads_spec_path_into_pipeline_args(lenv):
+    """launch(spec_path=<abs>) puts --spec <abs> into state.json pipeline_args."""
+    plan_file = lenv.repo / "plan.md"
+    plan_file.write_text("# Plan\n\nDo stuff.\n", encoding="utf-8")
+    spec_file = lenv.repo / "spec.md"
+    spec_file.write_text("the overall spec", encoding="utf-8")
+
+    launcher = _launcher()
+    gr_id = launcher.launch("localgremlin", plan=str(plan_file),
+                            spec_path=str(spec_file))
+    state = _read_state(_gremlins_state_root(lenv) / gr_id)
+    assert "--spec" in state["pipeline_args"]
+    idx = state["pipeline_args"].index("--spec")
+    assert state["pipeline_args"][idx + 1] == str(spec_file.resolve())
+    _wait_for_finished(_gremlins_state_root(lenv) / gr_id, timeout=60)
+
+
+def test_launch_rejects_missing_spec_path(lenv):
+    """spec_path that doesn't exist raises ValueError before any state-dir setup."""
+    plan_file = lenv.repo / "plan.md"
+    plan_file.write_text("# Plan\n", encoding="utf-8")
+    launcher = _launcher()
+    with pytest.raises(ValueError, match="--spec"):
+        launcher.launch("localgremlin", plan=str(plan_file),
+                        spec_path="/nonexistent/spec.md")
+    dirs = list(_gremlins_state_root(lenv).glob("*")) \
+        if _gremlins_state_root(lenv).exists() else []
+    assert dirs == [], f"missing-spec failure must not create state: {dirs}"
+
+
+def test_launch_rejects_empty_spec_path(lenv):
+    """spec_path pointing to an empty file raises ValueError."""
+    plan_file = lenv.repo / "plan.md"
+    plan_file.write_text("# Plan\n", encoding="utf-8")
+    spec_file = lenv.repo / "empty-spec.md"
+    spec_file.write_text("", encoding="utf-8")
+    launcher = _launcher()
+    with pytest.raises(ValueError, match="--spec"):
+        launcher.launch("localgremlin", plan=str(plan_file),
+                        spec_path=str(spec_file))

--- a/gremlins/tests/test_orchestrator_boss.py
+++ b/gremlins/tests/test_orchestrator_boss.py
@@ -1137,6 +1137,20 @@ def test_boss_launches_child_against_current_head(tmp_path, monkeypatch):
         captured["project_root"] = project_root
         return "child-abc-123456"
 
+    # boss_state.json required by launch_child to load spec_path
+    (state_dir / "boss_state.json").write_text(json.dumps({
+        "spec_path": "/some/spec.md",
+        "chain_kind": "local",
+        "chain_base_ref": expected_sha,
+        "target_branch": "main",
+        "current_plan": "/some/spec.md",
+        "handoff_count": 0,
+        "current_child_id": None,
+        "children": [],
+        "handoff_records": [],
+        "operator_followups": [],
+    }))
+
     monkeypatch.setattr(boss_mod, "STATE_ROOT", str(tmp_path))
     monkeypatch.setattr(launcher_mod, "launch", fake_launch)
 
@@ -1214,3 +1228,90 @@ def test_boss_records_current_head_after_land(tmp_path, monkeypatch):
     assert current_head_calls[1]["current_head"] == expected_new_head, (
         f"post-land current_head should be {expected_new_head!r}, got {current_head_calls[1]!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# launch_child spec_path passthrough
+# ---------------------------------------------------------------------------
+
+def test_launch_child_forwards_spec_path(tmp_path, monkeypatch):
+    """When boss_state has spec_path set, launch_child passes it as spec_path= to launcher.launch."""
+    import gremlins.launcher as launcher_mod
+
+    gr_id = "test-boss-spec-dd9900"
+    state_dir = tmp_path / gr_id
+    state_dir.mkdir()
+    spec_path = "/path/to/boss/spec.md"
+    (state_dir / "state.json").write_text(json.dumps({
+        "id": gr_id,
+        "project_root": str(tmp_path / "repo"),
+        "current_head": "abc123def456abc1",
+    }))
+    (state_dir / "boss_state.json").write_text(json.dumps({
+        "spec_path": spec_path,
+        "chain_kind": "local",
+        "chain_base_ref": "abc123def456abc1",
+        "target_branch": "main",
+        "current_plan": spec_path,
+        "handoff_count": 0,
+        "current_child_id": None,
+        "children": [],
+        "handoff_records": [],
+        "operator_followups": [],
+    }))
+
+    captured = {}
+
+    def fake_launch(kind, *, plan=None, parent_id=None, project_root=None,
+                    base_ref="HEAD", pipeline_args=(), **kw):
+        captured.update(kw)
+        captured["plan"] = plan
+        return "child-spec-ee1122"
+
+    monkeypatch.setattr(boss_mod, "STATE_ROOT", str(tmp_path))
+    monkeypatch.setattr(launcher_mod, "launch", fake_launch)
+
+    result = boss_mod.launch_child(gr_id, "localgremlin", "/tmp/child-plan.md")
+
+    assert result == "child-spec-ee1122"
+    assert captured.get("spec_path") == spec_path
+
+
+def test_launch_child_no_spec_path_when_absent(tmp_path, monkeypatch):
+    """When boss_state has no spec_path, launch_child passes spec_path=None."""
+    import gremlins.launcher as launcher_mod
+
+    gr_id = "test-boss-nospec-ff2233"
+    state_dir = tmp_path / gr_id
+    state_dir.mkdir()
+    (state_dir / "state.json").write_text(json.dumps({
+        "id": gr_id,
+        "project_root": str(tmp_path / "repo"),
+        "current_head": "abc123def456abc1",
+    }))
+    (state_dir / "boss_state.json").write_text(json.dumps({
+        "spec_path": "",
+        "chain_kind": "local",
+        "chain_base_ref": "abc123def456abc1",
+        "target_branch": "main",
+        "current_plan": "",
+        "handoff_count": 0,
+        "current_child_id": None,
+        "children": [],
+        "handoff_records": [],
+        "operator_followups": [],
+    }))
+
+    captured = {}
+
+    def fake_launch(kind, *, plan=None, parent_id=None, project_root=None,
+                    base_ref="HEAD", pipeline_args=(), **kw):
+        captured.update(kw)
+        return "child-nospec-gg3344"
+
+    monkeypatch.setattr(boss_mod, "STATE_ROOT", str(tmp_path))
+    monkeypatch.setattr(launcher_mod, "launch", fake_launch)
+
+    boss_mod.launch_child(gr_id, "localgremlin", "/tmp/child-plan.md")
+
+    assert captured.get("spec_path") is None

--- a/gremlins/tests/test_stages_local.py
+++ b/gremlins/tests/test_stages_local.py
@@ -6,7 +6,7 @@ import pytest
 from conftest import MINIMAL_EVENTS
 from gremlins.clients.fake import FakeClaudeClient
 from gremlins.stages.address_code import run_address_code_stage
-from gremlins.stages.implement import run_implement_stage
+from gremlins.stages.implement import _render_spec_block, run_implement_stage
 from gremlins.stages.plan import run_plan_stage
 
 
@@ -27,6 +27,105 @@ def _init_git_repo(path: pathlib.Path) -> None:
         ["git", "commit", "-m", "init"],
         cwd=path, check=True, capture_output=True,
     )
+
+
+# ---------------------------------------------------------------------------
+# _render_spec_block
+# ---------------------------------------------------------------------------
+
+def test_render_spec_block_empty_string():
+    assert _render_spec_block("") == ""
+
+
+def test_render_spec_block_whitespace_only():
+    assert _render_spec_block("   \n  ") == ""
+
+
+def test_render_spec_block_nonempty():
+    result = _render_spec_block("my spec content")
+    assert "Overarching goal (north star)" in result
+    assert "my spec content" in result
+    assert "~~~~" in result
+    assert "read-only context" in result
+
+
+def test_render_spec_block_truncates_at_50000():
+    long_spec = "x" * 60000
+    result = _render_spec_block(long_spec)
+    assert "x" * 50000 in result
+    assert "truncated to 50000 chars" in result
+    assert "60000 chars total" in result
+
+
+def test_render_spec_block_no_truncation_note_when_short():
+    result = _render_spec_block("short spec")
+    assert "truncated" not in result
+
+
+# ---------------------------------------------------------------------------
+# implement stage spec_text rendering
+# ---------------------------------------------------------------------------
+
+def test_implement_renders_spec_block_when_present(tmp_path, monkeypatch):
+    git_dir = tmp_path / "repo"
+    git_dir.mkdir()
+    _init_git_repo(git_dir)
+    monkeypatch.chdir(git_dir)
+
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+
+    class _CommittingClient(FakeClaudeClient):
+        def run(self, prompt, *, label, **kwargs):
+            (git_dir / "newfile.txt").write_text("change\n")
+            subprocess.run(["git", "add", "newfile.txt"], cwd=git_dir, check=True, capture_output=True)
+            subprocess.run(["git", "commit", "-m", "implement"], cwd=git_dir, check=True, capture_output=True)
+            return super().run(prompt, label=label, **kwargs)
+
+    client = _CommittingClient(fixtures={"implement": MINIMAL_EVENTS})
+    run_implement_stage(
+        client=client,
+        impl_model="sonnet",
+        plan_text="task 1: do something",
+        core_principles="Be good.",
+        session_dir=session_dir,
+        is_git=True,
+        spec_text="overall spec body",
+    )
+    prompt = client.calls[0].prompt
+    assert "Overarching goal (north star)" in prompt
+    assert "overall spec body" in prompt
+    assert prompt.index("overall spec body") < prompt.index("task 1: do something")
+
+
+def test_implement_omits_spec_block_when_absent(tmp_path, monkeypatch):
+    git_dir = tmp_path / "repo"
+    git_dir.mkdir()
+    _init_git_repo(git_dir)
+    monkeypatch.chdir(git_dir)
+
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+
+    class _CommittingClient(FakeClaudeClient):
+        def run(self, prompt, *, label, **kwargs):
+            (git_dir / "newfile.txt").write_text("change\n")
+            subprocess.run(["git", "add", "newfile.txt"], cwd=git_dir, check=True, capture_output=True)
+            subprocess.run(["git", "commit", "-m", "implement"], cwd=git_dir, check=True, capture_output=True)
+            return super().run(prompt, label=label, **kwargs)
+
+    client = _CommittingClient(fixtures={"implement": MINIMAL_EVENTS})
+    run_implement_stage(
+        client=client,
+        impl_model="sonnet",
+        plan_text="task 1: do something",
+        core_principles="Be good.",
+        session_dir=session_dir,
+        is_git=True,
+        spec_text="",
+    )
+    prompt = client.calls[0].prompt
+    assert "Overarching goal" not in prompt
 
 
 # ---------------------------------------------------------------------------

--- a/gremlins/tests/test_stages_local.py
+++ b/gremlins/tests/test_stages_local.py
@@ -52,9 +52,20 @@ def test_render_spec_block_nonempty():
 def test_render_spec_block_truncates_at_50000():
     long_spec = "x" * 60000
     result = _render_spec_block(long_spec)
+    # no newlines → falls back to hard 50000-char cut
     assert "x" * 50000 in result
-    assert "truncated to 50000 chars" in result
+    assert "truncated" in result
     assert "60000 chars total" in result
+
+
+def test_render_spec_block_truncates_at_newline_boundary():
+    # 49990 x's, a newline, then a run of z's that push past the 50000 limit.
+    # Using 'z' avoids false positives from the header prose (which contains 'y').
+    long_spec = "x" * 49990 + "\n" + "z" * 10100
+    result = _render_spec_block(long_spec)
+    # cut at the newline before 50000 → no z's in the body
+    assert "z" not in result
+    assert "truncated" in result
 
 
 def test_render_spec_block_no_truncation_note_when_short():


### PR DESCRIPTION
## Summary

- Boss `launch_child` now forwards `spec_path` from `boss_state` to `launcher.launch`, which injects `--spec` into `stored_pipeline_args` so resume rehydrates it automatically
- Local and gh orchestrators accept `--spec`, snapshot it into `session_dir/spec.md` on first launch (reusing the snapshot on resume), and pass `spec_text` into `run_implement_stage`
- The implement stage renders an "Overarching goal (north star)" block above the plan when `spec_text` is non-empty, mirroring the shape `handoff.py` already uses; direct invocations without `--spec` continue to behave unchanged

## Test plan

- [ ] `test_launch_threads_spec_path_into_pipeline_args` — verifies `--spec` lands in `state.json pipeline_args`
- [ ] `test_launch_rejects_missing_spec_path` / `test_launch_rejects_empty_spec_path` — error-path validation
- [ ] `test_launch_child_forwards_spec_path` / `test_launch_child_no_spec_path_when_absent` — boss passthrough
- [ ] `test_render_spec_block_*` — unit tests for truncation, empty, whitespace cases
- [ ] `test_implement_renders_spec_block_when_present` / `test_implement_omits_spec_block_when_absent` — prompt rendering

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)