### PR TITLE
feat(fleet): add MODEL column to /gremlins status table

### DIFF
--- a/gremlins/fleet/constants.py
+++ b/gremlins/fleet/constants.py
@@ -9,7 +9,7 @@ STATE_ROOT = os.path.join(
     "claude-gremlins",
 )
 
-FMT = "%-5s  %-47s  %-22s  %-28s  %-5s  %-20s  %s"
+FMT = "%-5s  %-47s  %-22s  %-28s  %-5s  %-20s  %-10s  %s"
 
 # Headless rescue caps. The attempt cap is shared across interactive and
 # headless rescues — both check `rescue_count`, but interactive only warns

--- a/gremlins/fleet/render.py
+++ b/gremlins/fleet/render.py
@@ -43,6 +43,9 @@ def build_row(gr_id, sf, wdir, state, live):
     parent_id = state.get("parent_id") or ""
     boss_disp = display_id(parent_id)[:20] if parent_id else ""
 
+    impl_model = state.get("impl_model") or state.get("model") or "—"
+    model_trim = impl_model[:10]
+
     return {
         "started_at": started_at,
         "kind": k,
@@ -52,6 +55,7 @@ def build_row(gr_id, sf, wdir, state, live):
         "live": live_trim,
         "live_full": live,
         "age": age,
+        "model": model_trim,
         "desc": desc_trim,
         "project_root": pr,
         "gr_id": gr_id,
@@ -63,6 +67,6 @@ def build_row(gr_id, sf, wdir, state, live):
 
 def print_table(rows):
     """Print header + rows using the fixed format string."""
-    print(FMT % ("KIND", "ID", "STAGE", "LIVENESS", "AGE", "BOSS", "DESCRIPTION"))
+    print(FMT % ("KIND", "ID", "STAGE", "LIVENESS", "AGE", "BOSS", "MODEL", "DESCRIPTION"))
     for r in rows:
-        print(FMT % (r["kind"], r["sid"], r["stage"], r["live"], r["age"], r["boss"], r["desc"]))
+        print(FMT % (r["kind"], r["sid"], r["stage"], r["live"], r["age"], r["boss"], r["model"], r["desc"]))

--- a/gremlins/launcher.py
+++ b/gremlins/launcher.py
@@ -132,7 +132,7 @@ def _extract_impl_model(pipeline_args: list, kind: str) -> str:
         for i, a in enumerate(args):
             if a == "--model" and i + 1 < len(args):
                 return args[i + 1]
-            if isinstance(a, str) and a.startswith("--model="):
+            if a.startswith("--model="):
                 return a[len("--model="):]
         return "sonnet"
 

--- a/gremlins/launcher.py
+++ b/gremlins/launcher.py
@@ -116,6 +116,27 @@ def _patch_state(state_dir: pathlib.Path, **fields) -> None:
         pass
 
 
+def _extract_impl_model(pipeline_args: list, kind: str) -> str:
+    """Extract the implementation model alias from pipeline_args.
+
+    Returns the alias as passed (e.g. 'opus', 'sonnet') or 'sonnet' as the
+    default when no model flag is present — matching each orchestrator's default.
+    """
+    args = list(pipeline_args)
+    if kind == "localgremlin":
+        for i, a in enumerate(args):
+            if a == "-i" and i + 1 < len(args):
+                return args[i + 1]
+        return "sonnet"
+    else:  # ghgremlin, bossgremlin use --model
+        for i, a in enumerate(args):
+            if a == "--model" and i + 1 < len(args):
+                return args[i + 1]
+            if isinstance(a, str) and a.startswith("--model="):
+                return a[len("--model="):]
+        return "sonnet"
+
+
 def _delete_patch_state(state_dir: pathlib.Path, delete_keys: tuple, **fields) -> None:
     """Remove delete_keys and merge fields into state.json atomically. Best-effort."""
     sf = state_dir / "state.json"
@@ -286,6 +307,7 @@ def launch(
         "description_explicit": desc_explicit,
         "parent_id": parent_id or "",
         "pipeline_args": stored_pipeline_args,
+        "impl_model": _extract_impl_model(stored_pipeline_args, kind),
         "stage": "starting",
         "pid": None,
     }

--- a/gremlins/tests/test_fleet.py
+++ b/gremlins/tests/test_fleet.py
@@ -149,6 +149,26 @@ def test_build_row_no_rescue_suffix_when_zero():
     assert "(rescue" not in row["live"]
 
 
+def test_build_row_model_from_impl_model():
+    state = {"kind": "localgremlin", "stage": "implement",
+             "started_at": "", "impl_model": "opus"}
+    row = gremlins.build_row("g1", "/sf", "/wdir", state, "running")
+    assert row["model"] == "opus"
+
+
+def test_build_row_model_falls_back_to_model_field():
+    state = {"kind": "ghgremlin", "stage": "implement",
+             "started_at": "", "model": "opus"}
+    row = gremlins.build_row("g1", "/sf", "/wdir", state, "running")
+    assert row["model"] == "opus"
+
+
+def test_build_row_model_missing_field_shows_dash():
+    state = {"kind": "localgremlin", "stage": "implement", "started_at": ""}
+    row = gremlins.build_row("g1", "/sf", "/wdir", state, "running")
+    assert row["model"] == "—"
+
+
 # ---------------------------------------------------------------------------
 # Phase A marker contract — _read_rescue_marker
 # ---------------------------------------------------------------------------

--- a/gremlins/tests/test_launcher.py
+++ b/gremlins/tests/test_launcher.py
@@ -250,6 +250,34 @@ def test_launch_persists_impl_model_default(lenv):
     _wait_for_finished(_gremlins_state_root(lenv) / gr_id, timeout=60)
 
 
+def test_launch_persists_impl_model_gh_space_form(lenv_with_gh):
+    """impl_model is extracted from space-separated --model flag for ghgremlin."""
+    lenv = lenv_with_gh
+    launcher = _launcher()
+    gr_id = launcher.launch(
+        "ghgremlin",
+        pipeline_args=("--model", "opus"),
+        instructions="test gh model space",
+    )
+    state = _read_state(_gremlins_state_root(lenv) / gr_id)
+    assert state["impl_model"] == "opus"
+    _wait_for_finished(_gremlins_state_root(lenv) / gr_id, timeout=60)
+
+
+def test_launch_persists_impl_model_gh_equals_form(lenv_with_gh):
+    """impl_model is extracted from --model=<value> flag for ghgremlin."""
+    lenv = lenv_with_gh
+    launcher = _launcher()
+    gr_id = launcher.launch(
+        "ghgremlin",
+        pipeline_args=("--model=haiku",),
+        instructions="test gh model equals",
+    )
+    state = _read_state(_gremlins_state_root(lenv) / gr_id)
+    assert state["impl_model"] == "haiku"
+    _wait_for_finished(_gremlins_state_root(lenv) / gr_id, timeout=60)
+
+
 def test_launch_plan_normalized_to_absolute(lenv):
     """A relative --plan path is resolved to absolute in state.json."""
     plan_file = lenv.repo / "my-plan.md"

--- a/gremlins/tests/test_launcher.py
+++ b/gremlins/tests/test_launcher.py
@@ -225,6 +225,31 @@ def test_launch_persists_pipeline_args(lenv):
     _wait_for_finished(_gremlins_state_root(lenv) / gr_id, timeout=60)
 
 
+def test_launch_persists_impl_model_explicit(lenv):
+    """impl_model is extracted from -i flag and stored in state.json."""
+    launcher = _launcher()
+    gr_id = launcher.launch(
+        "localgremlin",
+        pipeline_args=("-i", "opus"),
+        instructions="test impl model",
+    )
+    state = _read_state(_gremlins_state_root(lenv) / gr_id)
+    assert state["impl_model"] == "opus"
+    _wait_for_finished(_gremlins_state_root(lenv) / gr_id, timeout=60)
+
+
+def test_launch_persists_impl_model_default(lenv):
+    """impl_model defaults to 'sonnet' when no -i flag is supplied."""
+    launcher = _launcher()
+    gr_id = launcher.launch(
+        "localgremlin",
+        instructions="test impl model default",
+    )
+    state = _read_state(_gremlins_state_root(lenv) / gr_id)
+    assert state["impl_model"] == "sonnet"
+    _wait_for_finished(_gremlins_state_root(lenv) / gr_id, timeout=60)
+
+
 def test_launch_plan_normalized_to_absolute(lenv):
     """A relative --plan path is resolved to absolute in state.json."""
     plan_file = lenv.repo / "my-plan.md"


### PR DESCRIPTION
Store `impl_model` in `state.json` at launch time (extracted from `-i` for localgremlin or `--model` for gh/boss gremlins, defaulting to `'sonnet'`), then surface it as a new 10-char `MODEL` column in the fleet table between `BOSS` and `DESCRIPTION`.

## Changes
- `gremlins/fleet/constants.py`: extend `FMT` with a `%-10s` slot for MODEL
- `gremlins/fleet/render.py`: read `impl_model`/`model` from state, add `model` key to row dict, update header and row format calls
- `gremlins/launcher.py`: add `_extract_impl_model()` helper, write `impl_model` into initial state
- `gremlins/tests/test_fleet.py`: three new unit tests covering primary field, fallback field, and missing-field dash
- `gremlins/tests/test_launcher.py`: two new integration tests for explicit and default model extraction

Closes #195