### PR TITLE
feat(style): thread code_style doc through all pipeline stages

### DIFF
--- a/gremlins/handoff.py
+++ b/gremlins/handoff.py
@@ -20,6 +20,8 @@ import subprocess
 import sys
 from typing import List, Optional, Tuple
 
+from gremlins.prompts import load_code_style
+
 
 CLAUDE_FLAGS = [
     "--permission-mode", "bypassPermissions",
@@ -105,6 +107,7 @@ def build_prompt(
     child_plan_path: pathlib.Path,
     signal_path: pathlib.Path,
     spec_text: Optional[str] = None,
+    code_style: str = "",
 ) -> str:
     diff_body = git_diff[:50000] if git_diff else "(empty — no changes yet)"
     diff_trunc = f"\n(diff truncated to 50000 chars; {len(git_diff)} chars total)" if len(git_diff) > 50000 else ""
@@ -124,9 +127,19 @@ This is the original chain spec. It does not change between handoffs and is read
 
 """
 
+    style_section = ""
+    if code_style:
+        style_section = f"""## Coding style
+
+Respect these principles when writing child plans. Avoid proposing architectures that violate them — e.g. multi-level class hierarchies, factories where a function suffices, speculative abstractions:
+
+{code_style}
+
+"""
+
     return f"""You are a chain-manager agent. Inspect the plan document and the work that has landed on the current branch, then decide whether the chain is complete or a next step is needed.
 
-{spec_section}## Input plan
+{spec_section}{style_section}## Input plan
 
 ~~~~
 {plan_text}
@@ -379,6 +392,7 @@ def main(argv: List[str]) -> int:
     except Exception as exc:
         die(f"git context collection failed: {exc}")
 
+    code_style = load_code_style()
     prompt = build_prompt(
         plan_text=plan_text,
         branch=branch,
@@ -388,6 +402,7 @@ def main(argv: List[str]) -> int:
         child_plan_path=child_plan_path,
         signal_path=signal_path,
         spec_text=spec_text,
+        code_style=code_style,
     )
 
     cmd = ["claude", "-p", "--model", args.model, *CLAUDE_FLAGS, prompt]

--- a/gremlins/orchestrators/CLAUDE.md
+++ b/gremlins/orchestrators/CLAUDE.md
@@ -33,11 +33,11 @@ Per-pipeline orchestrator entry points. Each module owns one CLI subcommand
 - Stage-name vocabulary per orchestrator is byte-stable (see parent
   CLAUDE.md §"Byte-stable strings"). `VALID_RESUME_STAGES` /
   `VALID_STAGES` constants are the source of truth.
-- `AGENT_FILE` in `local.py` and `gh.py` resolves
-  `agents/pragmatic-developer.md` via three `parent`s up from `__file__`.
-  This works because the package lives at `~/.claude/gremlins/` and the
-  agents dir is its sibling. If you move this directory deeper, update the
-  parent count.
+- Both `local.py` and `gh.py` call `load_code_style()` from
+  `gremlins.prompts`, which reads `gremlins/prompts/code_style.md` via a
+  `pathlib.Path(__file__)` resolve in `prompts/__init__.py`. This is the
+  canonical coding-style doc for all gremlin pipeline stages; edit it there
+  rather than touching `agents/pragmatic-developer.md`.
 
 ## Boss-specific notes
 

--- a/gremlins/orchestrators/gh.py
+++ b/gremlins/orchestrators/gh.py
@@ -27,6 +27,7 @@ from typing import Dict, List, Optional
 from ..clients.claude import ClaudeClient, SubprocessClaudeClient
 from ..gh_utils import extract_gh_url, get_repo, parse_issue_ref, view_issue
 from ..git import DirtyOnly, HeadAdvanced
+from ..prompts import load_code_style
 from ..runner import install_signal_handlers, run_stages
 from ..stages.commit_pr import run_commit_pr_stage
 from ..stages.ghaddress import run_ghaddress_stage
@@ -48,35 +49,11 @@ VALID_STAGES = [
     "ghaddress",
 ]
 
-AGENT_FILE = (
-    pathlib.Path(__file__).resolve().parent.parent.parent
-    / "agents"
-    / "pragmatic-developer.md"
-)
-
 
 def die(msg: str) -> None:
     sys.stderr.write(f"error: {msg}\n")
     sys.stderr.flush()
     sys.exit(1)
-
-
-def _load_core_principles() -> str:
-    if not AGENT_FILE.exists():
-        die(f"missing agent file: {AGENT_FILE}")
-    text = AGENT_FILE.read_text(encoding="utf-8")
-    in_section = False
-    lines: list = []
-    for line in text.splitlines(keepends=True):
-        if line.startswith("## Core Principles"):
-            in_section = True
-        elif in_section and line.startswith("## "):
-            break
-        elif in_section:
-            lines.append(line)
-    if not lines:
-        die("could not find '## Core Principles' section in pragmatic-developer.md")
-    return "".join(lines).rstrip()
 
 
 def _parse_gh_args(argv: List[str]) -> argparse.Namespace:
@@ -344,7 +321,7 @@ def gh_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int:
         print(f"    resumed issue: {issue_url}", flush=True)
         issue_body = _fetch_issue_body(issue_num, repo)
 
-    core_principles = _load_core_principles()
+    code_style = load_code_style()
 
     # pr_url populated by stage_commit_pr; later stages read it here.
     pr_url_holder: Dict[str, str] = {}
@@ -405,7 +382,7 @@ def gh_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int:
             client=client,
             impl_model=model,
             plan_text=issue_body,
-            core_principles=core_principles,
+            code_style=code_style,
             session_dir=session_dir,
             is_git=True,
             kind="gh",

--- a/gremlins/orchestrators/local.py
+++ b/gremlins/orchestrators/local.py
@@ -251,6 +251,7 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
             session_dir=session_dir,
             address_model=args.address,
             is_git=is_git,
+            code_style=code_style,
         )
 
     stages = [
@@ -390,6 +391,7 @@ def address_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> i
         die(f"--dir does not exist: {session_dir}")
 
     is_git = in_git_repo()
+    code_style = load_code_style()
 
     print(f"==> addressing code reviews (model: {args.address})", flush=True)
     run_address_code_stage(
@@ -397,5 +399,6 @@ def address_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> i
         session_dir=session_dir,
         address_model=args.address,
         is_git=is_git,
+        code_style=code_style,
     )
     return 0

--- a/gremlins/orchestrators/local.py
+++ b/gremlins/orchestrators/local.py
@@ -26,6 +26,7 @@ from typing import List, Optional
 
 from ..clients.claude import ClaudeClient, SubprocessClaudeClient
 from ..git import in_git_repo
+from ..prompts import load_code_style
 from ..runner import install_signal_handlers, run_stages
 from ..stages.address_code import run_address_code_stage
 from ..stages.implement import run_implement_stage
@@ -36,39 +37,11 @@ from ..state import patch_state, resolve_session_dir, set_stage
 MODEL_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 VALID_RESUME_STAGES = ["plan", "implement", "review-code", "address-code"]
 
-# `pragmatic-developer.md` is sourced from the synced agents/ dir under
-# ~/.claude. The package lives at ~/.claude/gremlins/, so the agent file
-# is three parents up from this module's location:
-# local.py → orchestrators/ → gremlins/ → ~/.claude/
-AGENT_FILE = (
-    pathlib.Path(__file__).resolve().parent.parent.parent
-    / "agents"
-    / "pragmatic-developer.md"
-)
-
 
 def die(msg: str) -> None:
     sys.stderr.write(f"error: {msg}\n")
     sys.stderr.flush()
     sys.exit(1)
-
-
-def _load_core_principles() -> str:
-    if not AGENT_FILE.exists():
-        die(f"missing agent file: {AGENT_FILE}")
-    text = AGENT_FILE.read_text(encoding="utf-8")
-    in_section = False
-    section_lines: list[str] = []
-    for line in text.splitlines(keepends=True):
-        if line.startswith("## Core Principles"):
-            in_section = True
-        elif in_section and line.startswith("## "):
-            break
-        elif in_section:
-            section_lines.append(line)
-    if not section_lines:
-        die("could not find '## Core Principles' section in pragmatic-developer.md")
-    return "".join(section_lines).rstrip()
 
 
 # ---------------------------------------------------------------------------
@@ -164,7 +137,7 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
         shutil.copyfile(spec_src, spec_file)
 
     is_git = in_git_repo()
-    core_principles = _load_core_principles()
+    code_style = load_code_style()
 
     # Resume preconditions
     start_idx = 0
@@ -226,6 +199,7 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
                 plan_file=plan_file,
                 instructions=instructions,
                 raw_path=session_dir / "stream-plan.jsonl",
+                code_style=code_style,
             )
 
     def stage_implement() -> None:
@@ -246,7 +220,7 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
             impl_model=args.impl,
             plan_file=plan_file,
             plan_text=plan_text,
-            core_principles=core_principles,
+            code_style=code_style,
             session_dir=session_dir,
             is_git=is_git,
             spec_text=spec_text,
@@ -265,6 +239,7 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
             plan_text=plan_text,
             detail=args.detail,
             is_git=is_git,
+            code_style=code_style,
         )
         print(f"    detail code review ({args.detail}): {review_file}", flush=True)
 
@@ -346,6 +321,7 @@ def review_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> in
             die(f"failed to read --plan {plan_path}: {exc}")
 
     is_git = in_git_repo()
+    code_style = load_code_style()
     if is_git:
         # Refuse to spawn three reviewers on an empty diff. HEAD~1 may not
         # exist (initial commit); in that case we require dirty tree to have
@@ -379,6 +355,7 @@ def review_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> in
         plan_text=plan_text,
         detail=args.detail,
         is_git=is_git,
+        code_style=code_style,
     )
     print(f"    detail code review ({args.detail}): {review_file}", flush=True)
     return 0

--- a/gremlins/prompts/__init__.py
+++ b/gremlins/prompts/__init__.py
@@ -1,0 +1,13 @@
+import pathlib
+import sys
+
+_CODE_STYLE_PATH = pathlib.Path(__file__).resolve().parent / "code_style.md"
+
+
+def load_code_style() -> str:
+    """Return the canonical coding-style block. Dies if the file is missing or empty."""
+    if not _CODE_STYLE_PATH.exists() or _CODE_STYLE_PATH.stat().st_size == 0:
+        sys.stderr.write(f"error: missing or empty code style file: {_CODE_STYLE_PATH}\n")
+        sys.stderr.flush()
+        sys.exit(1)
+    return _CODE_STYLE_PATH.read_text(encoding="utf-8").rstrip()

--- a/gremlins/prompts/address_code.md
+++ b/gremlins/prompts/address_code.md
@@ -1,3 +1,7 @@
+When writing code, follow these principles:
+
+{code_style}
+
 A code review of the most recent implementation follows. For every actionable finding you agree with, make the fix in the code. For findings you disagree with or choose to skip, note them briefly in your final summary with a reason.
 
 ---

--- a/gremlins/prompts/code_style.md
+++ b/gremlins/prompts/code_style.md
@@ -1,0 +1,9 @@
+1. **Clarity over cleverness**: Never use a clever trick when a straightforward approach works. No one-liners that require mental unpacking. No premature abstractions.
+
+2. **Surgical, focused changes**: Touch only what needs to change. Resist the urge to refactor adjacent code unless explicitly asked. Every modified line should directly serve the stated goal.
+
+3. **Simplicity**: Prefer the simplest solution that correctly solves the problem. Add complexity only when requirements demand it, not speculatively.
+
+4. **Readability**: Code is read far more than it is written. Use descriptive names, consistent patterns, and clear control flow. Add comments only when the *why* isn't obvious from the code itself.
+
+5. **Maintainability**: Write code that is easy to modify, debug, and extend. Favor explicit over implicit behavior. Make dependencies and side effects visible.

--- a/gremlins/prompts/implement_gh.md
+++ b/gremlins/prompts/implement_gh.md
@@ -1,6 +1,6 @@
 When writing code, follow these principles:
 
-{core_principles}
+{code_style}
 
 {spec_block}The following is the implementation plan {plan_source_label}:
 

--- a/gremlins/prompts/implement_local.md
+++ b/gremlins/prompts/implement_local.md
@@ -1,6 +1,6 @@
 When writing code, follow these principles:
 
-{core_principles}
+{code_style}
 
 {spec_block}{plan_text}
 

--- a/gremlins/prompts/plan.md
+++ b/gremlins/prompts/plan.md
@@ -1,3 +1,7 @@
+When writing code, follow these principles:
+
+{code_style}
+
 Create a detailed implementation plan for the following task and write it to the file `{plan_file}`. Use this structure:
 
 ## Context

--- a/gremlins/stages/address_code.py
+++ b/gremlins/stages/address_code.py
@@ -15,6 +15,7 @@ import pathlib
 import re
 
 from ..clients.claude import ClaudeClient
+from ..prompts import load_code_style
 from ..state import emit_bail
 
 MODEL_RE = re.compile(r"^[A-Za-z0-9._-]+$")
@@ -70,6 +71,7 @@ def run_address_code_stage(
 
         model = _model_from(review_file, "detail")
         text = review_file.read_text(encoding="utf-8")
+        code_style = load_code_style()
 
         address_commit_instr = ""
         if is_git:
@@ -94,6 +96,7 @@ Do not call this helper if you successfully addressed every actionable finding.
 
         template = PROMPT_TEMPLATE_PATH.read_text(encoding="utf-8")
         address_prompt = template.format(
+            code_style=code_style,
             model=model,
             text=text,
             address_commit_instr=address_commit_instr,

--- a/gremlins/stages/address_code.py
+++ b/gremlins/stages/address_code.py
@@ -15,7 +15,6 @@ import pathlib
 import re
 
 from ..clients.claude import ClaudeClient
-from ..prompts import load_code_style
 from ..state import emit_bail
 
 MODEL_RE = re.compile(r"^[A-Za-z0-9._-]+$")
@@ -45,6 +44,7 @@ def run_address_code_stage(
     session_dir: pathlib.Path,
     address_model: str,
     is_git: bool,
+    code_style: str,
 ) -> None:
     """Execute the address-code stage. Emits bail_class=other on failure
     when running under a gremlin (no-op otherwise) — including failures
@@ -71,7 +71,6 @@ def run_address_code_stage(
 
         model = _model_from(review_file, "detail")
         text = review_file.read_text(encoding="utf-8")
-        code_style = load_code_style()
 
         address_commit_instr = ""
         if is_git:

--- a/gremlins/stages/implement.py
+++ b/gremlins/stages/implement.py
@@ -102,7 +102,7 @@ def run_implement_stage(
     client: ClaudeClient,
     impl_model: Optional[str],
     plan_text: str,
-    core_principles: str,
+    code_style: str,
     session_dir: pathlib.Path,
     is_git: bool,
     kind: str = "local",
@@ -123,7 +123,7 @@ def run_implement_stage(
             client=client,
             impl_model=impl_model,
             plan_text=plan_text,
-            core_principles=core_principles,
+            code_style=code_style,
             session_dir=session_dir,
             issue_num=issue_num,
             cwd=cwd,
@@ -152,7 +152,7 @@ def run_implement_stage(
 
     template = PROMPT_LOCAL_PATH.read_text(encoding="utf-8")
     prompt = template.format(
-        core_principles=core_principles,
+        code_style=code_style,
         spec_block=_render_spec_block(spec_text),
         plan_text=plan_text,
         impl_commit_instr=impl_commit_instr,
@@ -185,7 +185,7 @@ def _run_implement_gh(
     client: ClaudeClient,
     impl_model: Optional[str],
     plan_text: str,
-    core_principles: str,
+    code_style: str,
     session_dir: pathlib.Path,
     issue_num: str,
     cwd: Optional[str],
@@ -207,7 +207,7 @@ def _run_implement_gh(
 
     template = PROMPT_GH_PATH.read_text(encoding="utf-8")
     prompt = template.format(
-        core_principles=core_principles,
+        code_style=code_style,
         spec_block=_render_spec_block(spec_text),
         plan_source_label=plan_source_label,
         issue_body=plan_text,

--- a/gremlins/stages/plan.py
+++ b/gremlins/stages/plan.py
@@ -21,9 +21,10 @@ def run_plan_stage(
     plan_file: pathlib.Path,
     instructions: str,
     raw_path: pathlib.Path,
+    code_style: str,
 ) -> None:
     template = PROMPT_TEMPLATE_PATH.read_text(encoding="utf-8")
-    prompt = template.format(plan_file=plan_file, instructions=instructions)
+    prompt = template.format(plan_file=plan_file, instructions=instructions, code_style=code_style)
     client.run(prompt, label="plan", model=plan_model, raw_path=raw_path)
     if not plan_file.exists() or plan_file.stat().st_size == 0:
         raise RuntimeError(f"plan stage did not produce {plan_file}")

--- a/gremlins/stages/review_code.py
+++ b/gremlins/stages/review_code.py
@@ -32,6 +32,7 @@ def run_review(
     out_file: pathlib.Path,
     focus: str,
     context: str,
+    code_style: str,
     where_field: str,
     label: str,
     raw_path: pathlib.Path,
@@ -39,7 +40,16 @@ def run_review(
     """Invoke the reviewer. CONTEXT describes what is being reviewed;
     FOCUS is the lens prose; WHERE_FIELD is the field label used to cite
     findings (e.g. `**File:** path:line` for code reviews)."""
-    prompt = f"""Read surrounding code as needed — don't review in isolation.
+    style_preamble = ""
+    if code_style:
+        style_preamble = (
+            "Follow these coding-style rules and flag violations — long functions, "
+            "inheritance where functions suffice, dead comments, speculative "
+            "abstractions — alongside the correctness, security, and performance "
+            "findings in the focus section below:\n\n"
+            f"{code_style}\n\n"
+        )
+    prompt = f"""{style_preamble}Read surrounding code as needed — don't review in isolation.
 
 {context}
 
@@ -75,6 +85,7 @@ def run_review_code_stage(
     plan_text: str,
     detail: str,
     is_git: bool,
+    code_style: str,
 ) -> pathlib.Path:
     """Execute the review-code stage: load the detail lens, run one reviewer,
     and return the output path. Emits bail_class=other on failure when
@@ -131,6 +142,7 @@ def run_review_code_stage(
             out_file=review_code,
             focus=focus,
             context=code_review_context,
+            code_style=code_style,
             where_field="**File:** `path/to/file.ext:<line>`",
             label=f"review-code:detail:{detail}",
             raw_path=session_dir / f"stream-review-code-detail-{detail}.jsonl",

--- a/gremlins/tests/test_orchestrator_gh.py
+++ b/gremlins/tests/test_orchestrator_gh.py
@@ -111,7 +111,7 @@ def _patch_common(monkeypatch, tmp_path, *, state_data: dict = None):
     monkeypatch.setattr(_shutil, "which", lambda n: f"/fake/{n}" if n in ("claude", "gh") else None)
     monkeypatch.setattr("gremlins.orchestrators.gh.install_signal_handlers", lambda c: None)
     monkeypatch.setattr("gremlins.orchestrators.gh.get_repo", lambda: "owner/repo")
-    monkeypatch.setattr("gremlins.orchestrators.gh._load_core_principles", lambda: "Be good.")
+    monkeypatch.setattr("gremlins.orchestrators.gh.load_code_style", lambda: "Be good.")
 
     session_dir = tmp_path / "session"
     session_dir.mkdir()

--- a/gremlins/tests/test_orchestrator_local.py
+++ b/gremlins/tests/test_orchestrator_local.py
@@ -28,7 +28,7 @@ def test_local_main_plan_mode(tmp_path, monkeypatch):
     # tmp_path is not a git repo → is_git=False; monkeypatch for clarity.
     monkeypatch.setattr("gremlins.orchestrators.local.in_git_repo", lambda: False)
     monkeypatch.setattr(
-        "gremlins.orchestrators.local._load_core_principles", lambda: "Be good."
+        "gremlins.orchestrators.local.load_code_style", lambda: "Be good."
     )
     # Fake that implement produced changes (FakeClaudeClient won't create files).
     monkeypatch.setattr(

--- a/gremlins/tests/test_stages_local.py
+++ b/gremlins/tests/test_stages_local.py
@@ -227,6 +227,7 @@ def test_address_code_stage_calls_client_with_review_content(tmp_path):
         session_dir=session_dir,
         address_model="sonnet",
         is_git=False,
+        code_style="",
     )
 
     assert len(client.calls) == 1
@@ -270,12 +271,9 @@ def test_review_code_stage_includes_code_style(tmp_path):
     assert "Be good." in client.calls[0].prompt
 
 
-def test_address_code_stage_includes_code_style(tmp_path, monkeypatch):
+def test_address_code_stage_includes_code_style(tmp_path):
     (tmp_path / "review-code-detail-sonnet.md").write_text(
         "# Detail Review\n\n## Findings\nNone.\n"
-    )
-    monkeypatch.setattr(
-        "gremlins.stages.address_code.load_code_style", lambda: "Be good."
     )
     client = FakeClaudeClient(fixtures={"address-code": MINIMAL_EVENTS})
     run_address_code_stage(
@@ -283,5 +281,6 @@ def test_address_code_stage_includes_code_style(tmp_path, monkeypatch):
         session_dir=tmp_path,
         address_model="sonnet",
         is_git=False,
+        code_style="Be good.",
     )
     assert "Be good." in client.calls[0].prompt

--- a/gremlins/tests/test_stages_local.py
+++ b/gremlins/tests/test_stages_local.py
@@ -3,11 +3,12 @@ import subprocess
 
 import pytest
 
-from conftest import MINIMAL_EVENTS
+from conftest import MINIMAL_EVENTS, ReviewCreatingClient
 from gremlins.clients.fake import FakeClaudeClient
 from gremlins.stages.address_code import run_address_code_stage
 from gremlins.stages.implement import _render_spec_block, run_implement_stage
 from gremlins.stages.plan import run_plan_stage
+from gremlins.stages.review_code import run_review_code_stage
 
 
 def _init_git_repo(path: pathlib.Path) -> None:
@@ -98,7 +99,7 @@ def test_implement_renders_spec_block_when_present(tmp_path, monkeypatch):
         client=client,
         impl_model="sonnet",
         plan_text="task 1: do something",
-        core_principles="Be good.",
+        code_style="Be good.",
         session_dir=session_dir,
         is_git=True,
         spec_text="overall spec body",
@@ -130,7 +131,7 @@ def test_implement_omits_spec_block_when_absent(tmp_path, monkeypatch):
         client=client,
         impl_model="sonnet",
         plan_text="task 1: do something",
-        core_principles="Be good.",
+        code_style="Be good.",
         session_dir=session_dir,
         is_git=True,
         spec_text="",
@@ -154,6 +155,7 @@ def test_plan_stage_raises_when_file_absent(tmp_path):
             plan_file=plan_file,
             instructions="do stuff",
             raw_path=tmp_path / "stream-plan.jsonl",
+            code_style="Be good.",
         )
     assert len(client.calls) == 1
     assert client.calls[0].label == "plan"
@@ -175,6 +177,7 @@ def test_plan_stage_succeeds_when_file_exists(tmp_path):
         plan_file=plan_file,
         instructions="do stuff",
         raw_path=tmp_path / "stream-plan.jsonl",
+        code_style="Be good.",
     )
     assert plan_file.exists()
     assert client.calls[0].label == "plan"
@@ -201,7 +204,7 @@ def test_implement_stage_raises_on_empty_diff(tmp_path, monkeypatch):
             impl_model="sonnet",
             plan_file=session_dir / "plan.md",
             plan_text="# Plan\nDo stuff.\n",
-            core_principles="Be good.",
+            code_style="Be good.",
             session_dir=session_dir,
             is_git=True,
         )
@@ -231,3 +234,54 @@ def test_address_code_stage_calls_client_with_review_content(tmp_path):
     assert call.label == "address-code"
     assert call.model == "sonnet"
     assert "Detail Review" in call.prompt
+
+
+# ---------------------------------------------------------------------------
+# code_style block appears in plan, review, and address prompts
+# ---------------------------------------------------------------------------
+
+def test_plan_stage_includes_code_style(tmp_path):
+    client = FakeClaudeClient(fixtures={"plan": MINIMAL_EVENTS})
+    plan_file = tmp_path / "plan.md"
+    with pytest.raises(RuntimeError, match="plan stage did not produce"):
+        run_plan_stage(
+            client=client,
+            plan_model="sonnet",
+            plan_file=plan_file,
+            instructions="do stuff",
+            raw_path=tmp_path / "stream.jsonl",
+            code_style="Be good.",
+        )
+    assert "Be good." in client.calls[0].prompt
+
+
+def test_review_code_stage_includes_code_style(tmp_path):
+    client = ReviewCreatingClient(
+        fixtures={"review-code:detail:sonnet": MINIMAL_EVENTS}
+    )
+    run_review_code_stage(
+        client=client,
+        session_dir=tmp_path,
+        plan_text="",
+        detail="sonnet",
+        is_git=False,
+        code_style="Be good.",
+    )
+    assert "Be good." in client.calls[0].prompt
+
+
+def test_address_code_stage_includes_code_style(tmp_path, monkeypatch):
+    (tmp_path / "review-code-detail-sonnet.md").write_text(
+        "# Detail Review\n\n## Findings\nNone.\n"
+    )
+    monkeypatch.setattr(
+        "gremlins.stages.address_code.load_code_style", lambda: "Be good."
+    )
+    client = FakeClaudeClient(fixtures={"address-code": MINIMAL_EVENTS})
+    run_address_code_stage(
+        client=client,
+        session_dir=tmp_path,
+        address_model="sonnet",
+        is_git=False,
+    )
+    assert "Be good." in client.calls[0].prompt

--- a/gremlins/tests/test_state_isolation.py
+++ b/gremlins/tests/test_state_isolation.py
@@ -136,7 +136,7 @@ def test_local_main_does_not_clobber_external_state(tmp_path, monkeypatch):
     )
     monkeypatch.setattr("gremlins.orchestrators.local.in_git_repo", lambda: False)
     monkeypatch.setattr(
-        "gremlins.orchestrators.local._load_core_principles", lambda: "Be good."
+        "gremlins.orchestrators.local.load_code_style", lambda: "Be good."
     )
     monkeypatch.setattr(
         "gremlins.stages.implement.changes_outside_git", lambda s, d: True


### PR DESCRIPTION
## Summary

- Creates `gremlins/prompts/code_style.md` as the single source of truth for coding-style rules, replacing the `_load_core_principles()` extract-from-agent pattern
- Wires the style block into plan, implement (local + gh), review-code, address-code, and handoff stages so every stage that produces or evaluates code sees the same rules
- Adds three new test assertions verifying style inclusion in plan, review, and address prompts

## Test plan

- [ ] Existing test suite passes (`pytest gremlins/tests/`)
- [ ] New tests: `test_plan_stage_includes_code_style`, `test_review_code_stage_includes_code_style`, `test_address_code_stage_includes_code_style`

Closes #199