### PR TITLE
feat(gh-pipeline): thread code_style into ghreview and ghaddress stages

### DIFF
--- a/gremlins/orchestrators/gh.py
+++ b/gremlins/orchestrators/gh.py
@@ -461,6 +461,7 @@ def gh_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int:
             model=model,
             pr_url=pr_url_holder["url"],
             artifacts_dir=session_dir,
+            code_style=code_style,
         )
 
     def stage_wait_copilot() -> None:
@@ -482,6 +483,7 @@ def gh_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int:
             model=model,
             pr_url=pr_url_holder["url"],
             artifacts_dir=session_dir,
+            code_style=code_style,
         )
 
     stages = [

--- a/gremlins/stages/ghaddress.py
+++ b/gremlins/stages/ghaddress.py
@@ -15,10 +15,12 @@ def run_ghaddress_stage(
     model: Optional[str],
     pr_url: str,
     artifacts_dir: pathlib.Path,
+    code_style: str,
 ) -> None:
     """Run /ghaddress on the PR. Calls check_bail after completion."""
+    prompt = f"## Coding style\n\n{code_style}\n\n/ghaddress {pr_url}"
     client.run(
-        f"/ghaddress {pr_url}",
+        prompt,
         label="ghaddress",
         model=model,
         raw_path=artifacts_dir / "stream-ghaddress.jsonl",

--- a/gremlins/stages/ghreview.py
+++ b/gremlins/stages/ghreview.py
@@ -15,10 +15,12 @@ def run_ghreview_stage(
     model: Optional[str],
     pr_url: str,
     artifacts_dir: pathlib.Path,
+    code_style: str,
 ) -> None:
     """Run /ghreview. Calls check_bail after completion."""
+    prompt = f"## Coding style\n\n{code_style}\n\n/ghreview {pr_url}"
     client.run(
-        f"/ghreview {pr_url}",
+        prompt,
         label="ghreview",
         model=model,
         raw_path=artifacts_dir / "stream-ghreview.jsonl",

--- a/gremlins/tests/fixtures/fake_claude.py
+++ b/gremlins/tests/fixtures/fake_claude.py
@@ -247,9 +247,9 @@ def classify_stage(prompt: str) -> str:
         return "plan-title"
     if "Print ONLY the PR URL on the final line" in prompt:
         return "commit-pr"
-    if prompt.startswith("/ghreview "):
+    if "/ghreview " in prompt:
         return "ghreview"
-    if prompt.startswith("/ghaddress "):
+    if "/ghaddress " in prompt:
         return "ghaddress"
     if prompt.startswith("/ghplan") or "/ghplan" in prompt[:20]:
         return "ghplan"

--- a/gremlins/tests/test_orchestrator_gh.py
+++ b/gremlins/tests/test_orchestrator_gh.py
@@ -783,6 +783,46 @@ def test_plan_file_path_includes_plan_title_cost_in_total(tmp_path, monkeypatch)
 # Regression: --resume-from commit-pr must not re-run implement
 # ---------------------------------------------------------------------------
 
+def test_code_style_forwarded_to_ghreview_and_ghaddress(tmp_path, monkeypatch):
+    """code_style is threaded into run_ghreview_stage and run_ghaddress_stage."""
+    _init_git_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    session_dir, state_file = _patch_common(monkeypatch, tmp_path)
+
+    monkeypatch.setattr(
+        subprocess, "run",
+        _make_gh_subprocess(issue_body="# Plan\nDo stuff.\n"),
+    )
+
+    captured = {}
+
+    def record_ghreview(**kw):
+        captured["ghreview"] = kw
+
+    def record_ghaddress(**kw):
+        captured["ghaddress"] = kw
+
+    monkeypatch.setattr("gremlins.orchestrators.gh.run_ghreview_stage", record_ghreview)
+    monkeypatch.setattr("gremlins.orchestrators.gh.run_wait_copilot_stage", lambda **kw: "APPROVED")
+    monkeypatch.setattr("gremlins.orchestrators.gh.run_request_copilot_stage", lambda **kw: None)
+    monkeypatch.setattr("gremlins.orchestrators.gh.run_ghaddress_stage", record_ghaddress)
+
+    client = _CommittingClient(
+        git_dir=tmp_path,
+        fixtures={
+            "implement": IMPL_EVENTS,
+            "commit-pr": _pr_events(),
+        },
+    )
+
+    result = gh_main(["--plan", "42"], client=client)
+    assert result == 0
+
+    assert captured["ghreview"]["code_style"] == "Be good."
+    assert captured["ghaddress"]["code_style"] == "Be good."
+
+
 def test_resume_from_commit_pr_skips_implement(tmp_path, monkeypatch):
     """--resume-from commit-pr picks up at commit-pr without re-running implement.
 

--- a/gremlins/tests/test_stages_gh.py
+++ b/gremlins/tests/test_stages_gh.py
@@ -1,0 +1,32 @@
+"""Stage-level tests for the gh pipeline stages (ghreview, ghaddress)."""
+
+import pathlib
+
+from conftest import MINIMAL_EVENTS
+from gremlins.clients.fake import FakeClaudeClient
+from gremlins.stages.ghaddress import run_ghaddress_stage
+from gremlins.stages.ghreview import run_ghreview_stage
+
+
+def test_ghreview_stage_includes_code_style(tmp_path):
+    client = FakeClaudeClient(fixtures={"ghreview": MINIMAL_EVENTS})
+    run_ghreview_stage(
+        client=client,
+        model="sonnet",
+        pr_url="https://github.com/owner/repo/pull/1",
+        artifacts_dir=tmp_path,
+        code_style="Be good.",
+    )
+    assert "Be good." in client.calls[0].prompt
+
+
+def test_ghaddress_stage_includes_code_style(tmp_path):
+    client = FakeClaudeClient(fixtures={"ghaddress": MINIMAL_EVENTS})
+    run_ghaddress_stage(
+        client=client,
+        model="sonnet",
+        pr_url="https://github.com/owner/repo/pull/1",
+        artifacts_dir=tmp_path,
+        code_style="Be good.",
+    )
+    assert "Be good." in client.calls[0].prompt

--- a/gremlins/uv.lock
+++ b/gremlins/uv.lock
@@ -1,8 +1,8 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [[package]]
-name = "pipeline"
+name = "gremlins"
 version = "0.1.0"
 source = { virtual = "." }


### PR DESCRIPTION
Thread `code_style` into `run_ghreview_stage` and `run_ghaddress_stage` so the coding style doc is available during review and address phases of the gh pipeline.

Closes #201