### PR TITLE
feat(test-stage): add test stage to local gremlin pipeline

### DIFF
--- a/gremlins/CLAUDE.md
+++ b/gremlins/CLAUDE.md
@@ -17,7 +17,7 @@ ghgremlin branch lifecycle, launcher contract, and phase rollout history.
 - `handoff.py` — chain-step decision agent (next-plan / chain-done / bail).
 - `clients/claude.py` — `ClaudeClient` Protocol + `SubprocessClaudeClient` (production).
 - `clients/fake.py` — `FakeClaudeClient` recording test double; replays canned stream-json from fixtures keyed by `label`.
-- `stages/` — per-stage bodies: `plan`, `implement`, `review_code`, `address_code`, `commit_pr`, `ghreview`, `ghaddress`, `wait_copilot`. (The `request-copilot` stage body is inlined as a closure in `orchestrators/gh.py`.)
+- `stages/` — per-stage bodies: `plan`, `implement`, `review_code`, `address_code`, `test`, `commit_pr`, `ghreview`, `ghaddress`, `wait_copilot`. (The `request-copilot` stage body is inlined as a closure in `orchestrators/gh.py`.)
 - `orchestrators/local.py` — `local_main`, `review_main`, `address_main`.
 - `orchestrators/gh.py` — `gh_main`. Drives the gh pipeline.
 - `orchestrators/boss.py` — `boss_main`. Subprocesses out to `python -m gremlins.cli handoff` and `python -m gremlins.cli fleet {stop,land,rescue}` between child gremlins.
@@ -63,7 +63,7 @@ validated in the orchestrators; marker-protocol bail reasons live in
 [`DESIGN.md`](DESIGN.md) (§Marker-protocol bail reasons).
 
 - **Bail classes** (`state.json.bail_class`): `reviewer_requested_changes`, `security`, `secrets`, `other`.
-- **Local stage names**: `plan`, `implement`, `review-code`, `address-code`.
+- **Local stage names**: `plan`, `implement`, `review-code`, `address-code`, `test`.
 - **Gh stage names**: `plan`, `implement`, `commit-pr`, `request-copilot`, `ghreview`, `wait-copilot`, `ghaddress`.
 - **Marker-protocol bail reasons**: `diagnosis_no_marker`, `diagnosis_bad_marker`, `diagnosis_claude_error`, `diagnosis_timeout`, `excluded_class:<class>`, `attempts_exhausted`, `relaunch_launcher_missing`, `relaunch_failed`.
 

--- a/gremlins/orchestrators/CLAUDE.md
+++ b/gremlins/orchestrators/CLAUDE.md
@@ -6,9 +6,10 @@ Per-pipeline orchestrator entry points. Each module owns one CLI subcommand
 
 ## Modules
 
-- `local.py` — `local_main` (full local chain), `review_main` (review-code
-  only), `address_main` (address-code only). Subcommands: `local`, `review`,
-  `address`.
+- `local.py` — `local_main` (full local chain: `plan → implement → review-code →
+  address-code → test`), `review_main` (review-code only), `address_main`
+  (address-code only). Subcommands: `local`, `review`, `address`. The `test`
+  stage is a no-op when `--test` is omitted.
 - `gh.py` — `gh_main`. Subcommand: `gh`. Drives the gh pipeline:
   `plan → implement → commit-pr → request-copilot → ghreview →
   wait-copilot → ghaddress`. The `request-copilot` stage body is inlined

--- a/gremlins/orchestrators/boss.py
+++ b/gremlins/orchestrators/boss.py
@@ -199,7 +199,9 @@ def get_remote_branch_sha(project_root: str, branch: str) -> str:
 
 def init_boss_state(spec_path: str, chain_kind: str, chain_base_ref: str,
                     target_branch: str, state_dir: str,
-                    issue_url: str = "", issue_num: str = "") -> dict:
+                    issue_url: str = "", issue_num: str = "",
+                    test_cmd: str = "", test_max_attempts: int = 3,
+                    test_fix_model: str = "") -> dict:
     boss_state = {
         "spec_path": spec_path,
         "chain_kind": chain_kind,
@@ -220,6 +222,11 @@ def init_boss_state(spec_path: str, chain_kind: str, chain_base_ref: str,
         # agent produced, so by chain-done it holds the final list of
         # operator tasks the human still owes between phase landings.
         "operator_followups": [],
+        # Test command forwarded to every child local gremlin. Persisted so
+        # a rescued boss continues forwarding the same command after a crash.
+        "test_cmd": test_cmd,
+        "test_max_attempts": test_max_attempts,
+        "test_fix_model": test_fix_model,
     }
     save_json(os.path.join(state_dir, "boss_state.json"), boss_state)
     return boss_state
@@ -354,11 +361,22 @@ def launch_child(gr_id: str, launch_kind: str, child_plan: str) -> str:
     boss_state = load_boss_state(os.path.join(STATE_ROOT, gr_id))
     spec_path = boss_state.get("spec_path") or None
 
+    test_cmd = boss_state.get("test_cmd") or None
+    test_max = boss_state.get("test_max_attempts")
+    test_model = boss_state.get("test_fix_model") or None
+    extra: list = []
+    if test_cmd:
+        extra += ["--test", test_cmd]
+        if test_max is not None:
+            extra += ["--test-max-attempts", str(test_max)]
+        if test_model:
+            extra += ["-t", test_model]
+
     log(f"launching child ({launch_kind}): {child_plan}, base={base_ref[:12]}")
     try:
         child_id = _launch(launch_kind, plan=child_plan, parent_id=gr_id,
                            project_root=project_root, base_ref=base_ref,
-                           spec_path=spec_path)
+                           spec_path=spec_path, pipeline_args=tuple(extra))
     except (ValueError, RuntimeError) as exc:
         die(f"launcher failed: {exc}")
 
@@ -478,6 +496,9 @@ def _parse_boss_args(argv: List[str]) -> argparse.Namespace:
     p.add_argument("--chain-kind", required=True, choices=["local", "gh"])
     p.add_argument("--model", default="sonnet")
     p.add_argument("--resume-from", default=None)
+    p.add_argument("--test", dest="test_cmd", default=None)
+    p.add_argument("--test-max-attempts", dest="test_max_attempts", type=int, default=3)
+    p.add_argument("-t", dest="test_fix_model", default="sonnet")
     args, _ = p.parse_known_args(argv)
     return args
 
@@ -640,6 +661,11 @@ def boss_main(argv: List[str]) -> int:
         # input cannot perturb later handoffs. For issue refs, the fetch
         # happens here (after launch.sh has detached) so a transient GitHub
         # outage is reported in the boss log instead of failing the launch.
+        if args.test_cmd and chain_kind == "gh":
+            die(
+                "--test is not supported for --chain-kind gh "
+                "(gh pipeline test integration is a separate plan)"
+            )
         spec_path, issue_url, issue_num = _resolve_plan_source(args.plan, state_dir)
         if issue_url:
             log(f"chain start: kind={chain_kind}, spec={spec_path}, issue={issue_url}")
@@ -665,6 +691,9 @@ def boss_main(argv: List[str]) -> int:
             state_dir=state_dir,
             issue_url=issue_url,
             issue_num=issue_num,
+            test_cmd=args.test_cmd or "",
+            test_max_attempts=args.test_max_attempts,
+            test_fix_model=args.test_fix_model,
         )
         # Record initial boss HEAD so local children branch from the right commit.
         if chain_kind == "local" and boss_workdir and os.path.isdir(boss_workdir):

--- a/gremlins/orchestrators/local.py
+++ b/gremlins/orchestrators/local.py
@@ -32,10 +32,11 @@ from ..stages.address_code import run_address_code_stage
 from ..stages.implement import run_implement_stage
 from ..stages.plan import run_plan_stage
 from ..stages.review_code import run_review_code_stage
+from ..stages.test import run_test_stage
 from ..state import patch_state, resolve_session_dir, set_stage
 
 MODEL_RE = re.compile(r"^[A-Za-z0-9._-]+$")
-VALID_RESUME_STAGES = ["plan", "implement", "review-code", "address-code"]
+VALID_RESUME_STAGES = ["plan", "implement", "review-code", "address-code", "test"]
 
 
 def die(msg: str) -> None:
@@ -56,17 +57,23 @@ def _parse_local_args(argv: List[str]) -> argparse.Namespace:
     usage = (
         'usage: gremlins.cli local [-p <plan-model>] [-i <impl-model>] '
         '[-x <address-model>] [-b <detail-review-model>] '
-        '[--resume-from <stage>] [--plan <path>] [--spec <path>] "<instructions>"'
+        '[--resume-from <stage>] [--plan <path>] [--spec <path>] '
+        '[--test "<command>"] [--test-max-attempts <n>] [-t <test-fix-model>] '
+        '"<instructions>"'
     )
     parser = argparse.ArgumentParser(add_help=False, usage=usage)
     parser.add_argument("-p", dest="plan_model", default="sonnet")
     parser.add_argument("-i", dest="impl", default="sonnet")
     parser.add_argument("-x", dest="address", default="sonnet")
     parser.add_argument("-b", dest="detail", default="sonnet")
+    parser.add_argument("-t", dest="test_fix_model", default="sonnet")
     parser.add_argument("--resume-from", dest="resume_from", default=None,
                         choices=VALID_RESUME_STAGES)
     parser.add_argument("--plan", dest="plan_path", default=None)
     parser.add_argument("--spec", dest="spec_path", default=None)
+    parser.add_argument("--test", dest="test_cmd", default=None)
+    parser.add_argument("--test-max-attempts", dest="test_max_attempts",
+                        type=int, default=3)
     parser.add_argument("instructions", nargs="*")
     args = parser.parse_args(argv)
     # launch.sh resume may pass an empty-string positional when a --plan
@@ -82,9 +89,11 @@ def _parse_local_args(argv: List[str]) -> argparse.Namespace:
     else:
         if not args.instructions:
             die(usage)
-    for m in (args.plan_model, args.impl, args.address, args.detail):
+    for m in (args.plan_model, args.impl, args.address, args.detail, args.test_fix_model):
         if not MODEL_RE.match(m):
             die(f"invalid model: {m}")
+    if args.test_max_attempts <= 0:
+        die("--test-max-attempts must be a positive integer")
     return args
 
 
@@ -187,12 +196,12 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
     def stage_plan() -> None:
         if args.plan_path:
             if plan_copied_from_source:
-                print(f"==> [1/4] plan supplied via --plan (copied) -> {plan_file}", flush=True)
+                print(f"==> [1/5] plan supplied via --plan (copied) -> {plan_file}", flush=True)
             else:
-                print(f"==> [1/4] plan reused from snapshot -> {plan_file}", flush=True)
+                print(f"==> [1/5] plan reused from snapshot -> {plan_file}", flush=True)
         else:
             set_stage("plan")
-            print(f"==> [1/4] planning (model: {args.plan_model}) -> {plan_file}", flush=True)
+            print(f"==> [1/5] planning (model: {args.plan_model}) -> {plan_file}", flush=True)
             run_plan_stage(
                 client=client,
                 plan_model=args.plan_model,
@@ -214,7 +223,7 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
             except (OSError, UnicodeDecodeError) as exc:
                 print(f"warning: could not read spec.md ({exc}); proceeding without north-star context", flush=True, file=sys.stderr)
         set_stage("implement")
-        print(f"==> [2/4] implementing (model: {args.impl}, from {plan_file})", flush=True)
+        print(f"==> [2/5] implementing (model: {args.impl}, from {plan_file})", flush=True)
         run_implement_stage(
             client=client,
             impl_model=args.impl,
@@ -230,7 +239,7 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
         plan_text = plan_text_holder.get("text") or plan_file.read_text(encoding="utf-8")
         set_stage("review-code")
         print(
-            f"==> [3/4] reviewing code (model: {args.detail})",
+            f"==> [3/5] reviewing code (model: {args.detail})",
             flush=True,
         )
         review_file = run_review_code_stage(
@@ -245,7 +254,7 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
 
     def stage_address_code() -> None:
         set_stage("address-code")
-        print(f"==> [4/4] addressing code reviews (model: {args.address})", flush=True)
+        print(f"==> [4/5] addressing code reviews (model: {args.address})", flush=True)
         run_address_code_stage(
             client=client,
             session_dir=session_dir,
@@ -254,11 +263,32 @@ def local_main(argv: List[str], *, client: Optional[ClaudeClient] = None) -> int
             code_style=code_style,
         )
 
+    def stage_test() -> None:
+        set_stage("test")
+        if args.test_cmd:
+            print(
+                f"==> [5/5] running tests (cmd: {args.test_cmd!r}, "
+                f"max-attempts: {args.test_max_attempts}, model: {args.test_fix_model})",
+                flush=True,
+            )
+        cwd = pathlib.Path.cwd()
+        run_test_stage(
+            client=client,
+            session_dir=session_dir,
+            test_cmd=args.test_cmd,
+            max_attempts=args.test_max_attempts,
+            test_fix_model=args.test_fix_model,
+            is_git=is_git,
+            cwd=cwd,
+            code_style=code_style,
+        )
+
     stages = [
         ("plan", stage_plan),
         ("implement", stage_implement),
         ("review-code", stage_review_code),
         ("address-code", stage_address_code),
+        ("test", stage_test),
     ]
     run_stages(stages, resume_from=args.resume_from)
 

--- a/gremlins/orchestrators/local.py
+++ b/gremlins/orchestrators/local.py
@@ -94,6 +94,8 @@ def _parse_local_args(argv: List[str]) -> argparse.Namespace:
             die(f"invalid model: {m}")
     if args.test_max_attempts <= 0:
         die("--test-max-attempts must be a positive integer")
+    if args.test_cmd is not None and not args.test_cmd.strip():
+        die("--test: command must be a non-empty string")
     return args
 
 

--- a/gremlins/prompts/test_fix.md
+++ b/gremlins/prompts/test_fix.md
@@ -7,7 +7,7 @@ The test command `{test_cmd}` failed. Read the captured output below, then fix t
 **Important constraints:**
 - Do not modify the test command itself.
 - Do not modify test files or test fixtures to make tests pass — fix the implementation code only.
-- {commit_instr}
+{commit_instr}
 
 ---
 

--- a/gremlins/prompts/test_fix.md
+++ b/gremlins/prompts/test_fix.md
@@ -1,0 +1,27 @@
+When writing code, follow these principles:
+
+{code_style}
+
+The test command `{test_cmd}` failed. Read the captured output below, then fix the code so the command exits 0.
+
+**Important constraints:**
+- Do not modify the test command itself.
+- Do not modify test files or test fixtures to make tests pass — fix the implementation code only.
+- {commit_instr}
+
+---
+
+**Test output:**
+
+```
+{test_output}
+```
+
+---
+
+**Current diff (uncommitted changes):**
+
+```
+{diff_text}
+```
+{bail_section}

--- a/gremlins/stages/test.py
+++ b/gremlins/stages/test.py
@@ -12,7 +12,7 @@ import pathlib
 import subprocess
 
 from ..clients.claude import ClaudeClient
-from ..state import emit_bail
+from ..state import check_bail, emit_bail
 
 PROMPT_TEMPLATE_PATH = pathlib.Path(__file__).resolve().parent.parent / "prompts" / "test_fix.md"
 
@@ -59,7 +59,7 @@ def run_test_stage(
     commit_instr = ""
     if is_git:
         commit_instr = (
-            "After fixing, stage the changed files by name and create a single git "
+            "- After fixing, stage the changed files by name and create a single git "
             "commit titled 'Fix failing tests'. Do not push."
         )
 
@@ -75,6 +75,7 @@ def run_test_stage(
     template = PROMPT_TEMPLATE_PATH.read_text(encoding="utf-8")
 
     _exhausted = False
+    _agent_bailed = False
     try:
         for attempt in range(1, max_attempts + 1):
             log_file = session_dir / f"test-attempt-{attempt}.log"
@@ -96,10 +97,10 @@ def run_test_stage(
             diff = _diff_text(is_git, cwd)
             test_output = log_file.read_text(encoding="utf-8")
             fix_prompt = template.format(
-                code_style=code_style,
-                test_cmd=_escape_fmt(test_cmd),
-                test_output=_escape_fmt(test_output),
-                diff_text=_escape_fmt(diff),
+                code_style=_escape_fmt(code_style),
+                test_cmd=test_cmd,
+                test_output=test_output,
+                diff_text=diff,
                 commit_instr=commit_instr,
                 bail_section=bail_section,
             )
@@ -109,11 +110,16 @@ def run_test_stage(
                 model=test_fix_model,
                 raw_path=session_dir / f"stream-test-{attempt}.jsonl",
             )
+            # Propagate immediately if the agent wrote a bail marker; don't
+            # overwrite it by running another test attempt or exhaustion bail.
+            _agent_bailed = True
+            check_bail(f"test-fix-{attempt}")
+            _agent_bailed = False
 
         _exhausted = True
         emit_bail("other", f"tests failed after {max_attempts} attempts")
         raise RuntimeError(f"test stage exhausted {max_attempts} attempts")
     except (SystemExit, Exception) as exc:
-        if not _exhausted:
+        if not _exhausted and not _agent_bailed:
             emit_bail("other", f"test stage failed: {exc}"[:200])
         raise

--- a/gremlins/stages/test.py
+++ b/gremlins/stages/test.py
@@ -1,0 +1,119 @@
+"""Test stage.
+
+Runs the user-supplied test command in a loop. On failure, invokes claude to
+fix the code and retries. Succeeds when the command exits 0 or bails after
+max_attempts.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+
+from ..clients.claude import ClaudeClient
+from ..state import emit_bail
+
+PROMPT_TEMPLATE_PATH = pathlib.Path(__file__).resolve().parent.parent / "prompts" / "test_fix.md"
+
+
+def _diff_text(is_git: bool, cwd: pathlib.Path) -> str:
+    if not is_git:
+        return ""
+    try:
+        unstaged = subprocess.run(
+            ["git", "diff"], capture_output=True, text=True, cwd=cwd, check=False,
+        )
+        staged = subprocess.run(
+            ["git", "diff", "--cached"], capture_output=True, text=True, cwd=cwd, check=False,
+        )
+        return (unstaged.stdout + staged.stdout).strip()
+    except Exception:
+        return ""
+
+
+def _escape_fmt(s: str) -> str:
+    """Escape curly braces so str.format() treats content as literal text."""
+    return s.replace("{", "{{").replace("}", "}}")
+
+
+def run_test_stage(
+    *,
+    client: ClaudeClient,
+    session_dir: pathlib.Path,
+    test_cmd: str | None,
+    max_attempts: int,
+    test_fix_model: str,
+    is_git: bool,
+    cwd: pathlib.Path,
+    code_style: str,
+) -> None:
+    """Run the user-supplied test command, looping on failure until green or exhausted.
+
+    When test_cmd is None, logs a skip line and returns immediately (no-op stage).
+    """
+    if test_cmd is None:
+        print("==> [5/5] test stage skipped (no --test)", flush=True)
+        return
+
+    commit_instr = ""
+    if is_git:
+        commit_instr = (
+            "After fixing, stage the changed files by name and create a single git "
+            "commit titled 'Fix failing tests'. Do not push."
+        )
+
+    bail_section = ""
+    if os.environ.get("GR_ID"):
+        bail_section = (
+            "\n\nIf you cannot fix the failure (e.g. the test checks behaviour you "
+            "legitimately cannot implement), run:\n"
+            "  `python -m gremlins.cli bail other \"<one-line reason>\"`\n"
+            "before finishing."
+        )
+
+    template = PROMPT_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    _exhausted = False
+    try:
+        for attempt in range(1, max_attempts + 1):
+            log_file = session_dir / f"test-attempt-{attempt}.log"
+            result = subprocess.run(
+                test_cmd, shell=True, cwd=cwd,
+                capture_output=True, text=True,
+            )
+            log_file.write_text(result.stdout + result.stderr, encoding="utf-8")
+
+            if result.returncode == 0:
+                print(f"    test attempt {attempt}: green", flush=True)
+                return
+
+            print(f"    test attempt {attempt}: failed (exit {result.returncode})", flush=True)
+
+            if attempt == max_attempts:
+                break
+
+            diff = _diff_text(is_git, cwd)
+            test_output = log_file.read_text(encoding="utf-8")
+            fix_prompt = template.format(
+                code_style=code_style,
+                test_cmd=_escape_fmt(test_cmd),
+                test_output=_escape_fmt(test_output),
+                diff_text=_escape_fmt(diff),
+                commit_instr=commit_instr,
+                bail_section=bail_section,
+            )
+            client.run(
+                fix_prompt,
+                label=f"test-fix-{attempt}",
+                model=test_fix_model,
+                raw_path=session_dir / f"stream-test-{attempt}.jsonl",
+            )
+
+        _exhausted = True
+        emit_bail("other", f"tests failed after {max_attempts} attempts")
+        raise RuntimeError(f"test stage exhausted {max_attempts} attempts")
+    except (SystemExit, Exception) as exc:
+        if not _exhausted:
+            emit_bail("other", f"test stage failed: {exc}"[:200])
+        raise

--- a/gremlins/tests/test_stage_test.py
+++ b/gremlins/tests/test_stage_test.py
@@ -1,6 +1,5 @@
 """Tests for gremlins.stages.test."""
 import json
-import pathlib
 
 import pytest
 

--- a/gremlins/tests/test_stage_test.py
+++ b/gremlins/tests/test_stage_test.py
@@ -1,0 +1,295 @@
+"""Tests for gremlins.stages.test."""
+import json
+import pathlib
+
+import pytest
+
+import gremlins.launcher as launcher_mod
+import gremlins.orchestrators.boss as boss_mod
+from conftest import MINIMAL_EVENTS
+from gremlins.clients.fake import FakeClaudeClient
+from gremlins.stages.test import run_test_stage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(tmp_path, *, test_cmd, max_attempts=3, client=None, is_git=False,
+         code_style="Be good.", test_fix_model="sonnet"):
+    if client is None:
+        client = FakeClaudeClient(fixtures={})
+    run_test_stage(
+        client=client,
+        session_dir=tmp_path,
+        test_cmd=test_cmd,
+        max_attempts=max_attempts,
+        test_fix_model=test_fix_model,
+        is_git=is_git,
+        cwd=tmp_path,
+        code_style=code_style,
+    )
+    return client
+
+
+# ---------------------------------------------------------------------------
+# No-op when test_cmd is None
+# ---------------------------------------------------------------------------
+
+def test_noop_when_no_test_cmd(tmp_path, capsys):
+    client = FakeClaudeClient(fixtures={})
+    run_test_stage(
+        client=client,
+        session_dir=tmp_path,
+        test_cmd=None,
+        max_attempts=3,
+        test_fix_model="sonnet",
+        is_git=False,
+        cwd=tmp_path,
+        code_style="Be good.",
+    )
+    assert len(client.calls) == 0
+    out = capsys.readouterr().out
+    assert "skipped" in out
+    assert "no --test" in out
+
+
+# ---------------------------------------------------------------------------
+# Green on first try
+# ---------------------------------------------------------------------------
+
+def test_green_on_first_try(tmp_path):
+    client = _run(tmp_path, test_cmd="true")
+    assert len(client.calls) == 0
+    assert (tmp_path / "test-attempt-1.log").exists()
+
+
+# ---------------------------------------------------------------------------
+# Fix then green
+# ---------------------------------------------------------------------------
+
+def test_fix_then_green(tmp_path):
+    flag = tmp_path / "flag.txt"
+    flag.write_text("fail\n")
+    test_cmd = f"grep -q '^pass$' {flag}"
+
+    class _FixingClient(FakeClaudeClient):
+        def run(self, prompt, *, label, **kwargs):
+            flag.write_text("pass\n")
+            return super().run(prompt, label=label, **kwargs)
+
+    client = _FixingClient(fixtures={"test-fix-1": MINIMAL_EVENTS})
+    run_test_stage(
+        client=client,
+        session_dir=tmp_path,
+        test_cmd=test_cmd,
+        max_attempts=3,
+        test_fix_model="haiku",
+        is_git=False,
+        cwd=tmp_path,
+        code_style="Be good.",
+    )
+
+    assert len(client.calls) == 1
+    assert client.calls[0].label == "test-fix-1"
+    assert client.calls[0].model == "haiku"
+    assert (tmp_path / "test-attempt-1.log").exists()
+    assert (tmp_path / "test-attempt-2.log").exists()
+    assert (tmp_path / "stream-test-1.jsonl").exists()
+
+
+# ---------------------------------------------------------------------------
+# Attempts exhausted → RuntimeError + bail
+# ---------------------------------------------------------------------------
+
+def test_attempts_exhausted_bails(tmp_path, monkeypatch):
+    monkeypatch.delenv("GR_ID", raising=False)
+
+    client = FakeClaudeClient(fixtures={
+        "test-fix-1": MINIMAL_EVENTS,
+        "test-fix-2": MINIMAL_EVENTS,
+    })
+
+    with pytest.raises(RuntimeError, match="exhausted 3 attempts"):
+        run_test_stage(
+            client=client,
+            session_dir=tmp_path,
+            test_cmd="false",
+            max_attempts=3,
+            test_fix_model="sonnet",
+            is_git=False,
+            cwd=tmp_path,
+            code_style="Be good.",
+        )
+
+    # 3 attempts: fix after 1, fix after 2, bail after 3 (no fix on last attempt)
+    assert len(client.calls) == 2
+    assert (tmp_path / "test-attempt-1.log").exists()
+    assert (tmp_path / "test-attempt-2.log").exists()
+    assert (tmp_path / "test-attempt-3.log").exists()
+
+
+def test_attempts_exhausted_with_max_1(tmp_path):
+    client = FakeClaudeClient(fixtures={})
+
+    with pytest.raises(RuntimeError, match="exhausted 1 attempts"):
+        run_test_stage(
+            client=client,
+            session_dir=tmp_path,
+            test_cmd="false",
+            max_attempts=1,
+            test_fix_model="sonnet",
+            is_git=False,
+            cwd=tmp_path,
+            code_style="Be good.",
+        )
+
+    assert len(client.calls) == 0  # no fix on last (only) attempt
+    assert (tmp_path / "test-attempt-1.log").exists()
+
+
+# ---------------------------------------------------------------------------
+# code_style appears verbatim in fix prompt
+# ---------------------------------------------------------------------------
+
+def test_code_style_in_fix_prompt(tmp_path):
+    flag = tmp_path / "flag.txt"
+    flag.write_text("fail\n")
+    test_cmd = f"grep -q '^pass$' {flag}"
+
+    class _FixingClient(FakeClaudeClient):
+        def run(self, prompt, *, label, **kwargs):
+            flag.write_text("pass\n")
+            return super().run(prompt, label=label, **kwargs)
+
+    client = _FixingClient(fixtures={"test-fix-1": MINIMAL_EVENTS})
+    run_test_stage(
+        client=client,
+        session_dir=tmp_path,
+        test_cmd=test_cmd,
+        max_attempts=3,
+        test_fix_model="sonnet",
+        is_git=False,
+        cwd=tmp_path,
+        code_style="My custom style rules.",
+    )
+
+    assert len(client.calls) == 1
+    assert "My custom style rules." in client.calls[0].prompt
+
+
+# ---------------------------------------------------------------------------
+# Log file content
+# ---------------------------------------------------------------------------
+
+def test_log_file_captures_output(tmp_path):
+    client = FakeClaudeClient(fixtures={})
+
+    # "true" produces no output; check that log is created and can be empty
+    run_test_stage(
+        client=client,
+        session_dir=tmp_path,
+        test_cmd="echo hello",
+        max_attempts=3,
+        test_fix_model="sonnet",
+        is_git=False,
+        cwd=tmp_path,
+        code_style="",
+    )
+
+    log = tmp_path / "test-attempt-1.log"
+    assert log.exists()
+    assert "hello" in log.read_text()
+
+
+# ---------------------------------------------------------------------------
+# boss: launch_child forwards --test flags via pipeline_args
+# ---------------------------------------------------------------------------
+
+def test_launch_child_forwards_test_flags(tmp_path, monkeypatch):
+    gr_id = "test-boss-testcmd-aa1122"
+    state_dir = tmp_path / gr_id
+    state_dir.mkdir()
+    (state_dir / "state.json").write_text(json.dumps({
+        "id": gr_id,
+        "project_root": str(tmp_path / "repo"),
+        "current_head": "abc123def456abc1",
+    }))
+    (state_dir / "boss_state.json").write_text(json.dumps({
+        "spec_path": "/some/spec.md",
+        "chain_kind": "local",
+        "chain_base_ref": "abc123def456abc1",
+        "target_branch": "main",
+        "current_plan": "/some/spec.md",
+        "handoff_count": 0,
+        "current_child_id": None,
+        "children": [],
+        "handoff_records": [],
+        "operator_followups": [],
+        "test_cmd": "pytest -x",
+        "test_max_attempts": 5,
+        "test_fix_model": "opus",
+    }))
+
+    captured_pipeline_args = []
+
+    def fake_launch(kind, *, plan=None, parent_id=None, project_root=None,
+                    base_ref="HEAD", pipeline_args=(), **kw):
+        captured_pipeline_args.extend(pipeline_args)
+        return "child-testcmd-bb2233"
+
+    monkeypatch.setattr(boss_mod, "STATE_ROOT", str(tmp_path))
+    monkeypatch.setattr(launcher_mod, "launch", fake_launch)
+
+    result = boss_mod.launch_child(gr_id, "localgremlin", "/tmp/child-plan.md")
+
+    assert result == "child-testcmd-bb2233"
+    assert "--test" in captured_pipeline_args
+    assert "pytest -x" in captured_pipeline_args
+    assert "--test-max-attempts" in captured_pipeline_args
+    assert "5" in captured_pipeline_args
+    assert "-t" in captured_pipeline_args
+    assert "opus" in captured_pipeline_args
+
+
+def test_launch_child_no_test_flags_when_absent(tmp_path, monkeypatch):
+    """When boss_state has no test_cmd, launch_child omits test flags."""
+    gr_id = "test-boss-notest-cc3344"
+    state_dir = tmp_path / gr_id
+    state_dir.mkdir()
+    (state_dir / "state.json").write_text(json.dumps({
+        "id": gr_id,
+        "project_root": str(tmp_path / "repo"),
+        "current_head": "abc123def456abc1",
+    }))
+    (state_dir / "boss_state.json").write_text(json.dumps({
+        "spec_path": "/some/spec.md",
+        "chain_kind": "local",
+        "chain_base_ref": "abc123def456abc1",
+        "target_branch": "main",
+        "current_plan": "/some/spec.md",
+        "handoff_count": 0,
+        "current_child_id": None,
+        "children": [],
+        "handoff_records": [],
+        "operator_followups": [],
+        "test_cmd": "",
+        "test_max_attempts": 3,
+        "test_fix_model": "",
+    }))
+
+    captured_pipeline_args = []
+
+    def fake_launch(kind, *, plan=None, parent_id=None, project_root=None,
+                    base_ref="HEAD", pipeline_args=(), **kw):
+        captured_pipeline_args.extend(pipeline_args)
+        return "child-notest-dd4455"
+
+    monkeypatch.setattr(boss_mod, "STATE_ROOT", str(tmp_path))
+    monkeypatch.setattr(launcher_mod, "launch", fake_launch)
+
+    boss_mod.launch_child(gr_id, "localgremlin", "/tmp/child-plan.md")
+
+    assert "--test" not in captured_pipeline_args
+    assert "--test-max-attempts" not in captured_pipeline_args
+    assert captured_pipeline_args == []

--- a/skills/bossgremlin/SKILL.md
+++ b/skills/bossgremlin/SKILL.md
@@ -41,6 +41,9 @@ Flags:
   At chain start, the boss snapshots the spec into `<state-dir>/spec.md` and reads only the snapshot for the rest of the chain. The original input is never re-read, so a deleted file or mutated GitHub issue cannot perturb a running chain. On rescue, the snapshot is authoritative — no re-fetch.
 - `--chain-kind local|gh` — (required) whether children are `localgremlin` (local branch, squash-merged) or `ghgremlin` (GitHub PR, squash-merged to main). A chain is homogeneous — all children are the same kind.
 - `--model <model>` — model to use for handoff agent calls (default: `sonnet`).
+- `--test "<command>"` — optional test command forwarded to every child local gremlin (e.g. `--test "pytest -x"`). Each child runs it after address-code and loops on failure. Only supported for `--chain-kind local`; rejected for `--chain-kind gh`.
+- `--test-max-attempts <n>` — cap the per-child test fix loop (default: 3).
+- `-t <model>` — model for per-child test-fix claude calls (default: `sonnet`).
 
 ## Where artifacts go
 

--- a/skills/localgremlin/SKILL.md
+++ b/skills/localgremlin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: localgremlin
-description: Run the end-to-end plan → implement → review-code → address-code workflow in the background by invoking `python -m gremlins.cli launch`. Plan and code review land in `~/.local/state/claude-gremlins/<gremlin-id>/artifacts/` alongside the run log (kept off the product branch); a single detail review is produced. The launcher returns immediately; you'll be notified when the gremlin finishes.
-argument-hint: [-p <plan-model>] [-i <impl-model>] [-x <address-model>] [-b <detail-review-model>] [--plan <path> | --instructions <instructions>]
+description: Run the end-to-end plan → implement → review-code → address-code → test workflow in the background by invoking `python -m gremlins.cli launch`. Plan and code review land in `~/.local/state/claude-gremlins/<gremlin-id>/artifacts/` alongside the run log (kept off the product branch); a single detail review is produced. The launcher returns immediately; you'll be notified when the gremlin finishes.
+argument-hint: [-p <plan-model>] [-i <impl-model>] [-x <address-model>] [-b <detail-review-model>] [--test "<command>"] [--test-max-attempts <n>] [-t <test-fix-model>] [--plan <path> | --instructions <instructions>]
 allowed-tools: Bash(python -m gremlins.cli launch:*)
 ---
 
@@ -25,7 +25,7 @@ Plan and code-review artifacts live outside the product branch — they are scaf
 - `~/.local/state/claude-gremlins/<gremlin-id>/state.json` — gremlin status, exit code, workdir path, branch name.
 - `bg/localgremlin/<gremlin-id>` — durable branch with **only** the code changes (no scaffolding). From the main working tree: `git checkout bg/localgremlin/<gremlin-id>` to inspect, merge, or discard. A squash-merge pulls in product code cleanly.
 
-Commits on the branch, in order: implementation → "Address review feedback" (absent if reviewers found nothing).
+Commits on the branch, in order: implementation → "Address review feedback" (absent if reviewers found nothing) → "Fix failing tests" (one per test-fix attempt, absent if `--test` was not supplied or tests passed on first try).
 
 On success the isolated worktree is removed — `state.json`'s `workdir` field will point to a nonexistent path, which is expected (the branch is the durable code record; the artifacts directory is the durable review record). On failure the worktree is preserved for debugging at the path still recorded in `state.json`.
 
@@ -69,6 +69,19 @@ the plan stage. The file's contents are copied into the gremlin's session as
 - Errors (file missing, file empty, both `--plan` and `--instructions` supplied,
   neither supplied) are surfaced in `python -m gremlins.cli launch` before the
   state directory is created, so a bad invocation leaves no state-dir litter behind.
+
+## `--test "<command>"`
+
+Optional. When supplied, adds a final **test** stage after address-code that runs
+the command in a loop until it exits 0 or the attempt cap is hit:
+
+- `--test "pytest -x"` — run pytest; fix and retry on failure.
+- `--test "npm test && npm run lint"` — chain commands with `&&`.
+- `--test-max-attempts <n>` — cap the fix loop (default: 3).
+- `-t <model>` — model for test-fix claude calls (default: sonnet).
+
+If `--test` is omitted, the test stage is a no-op and the pipeline behaves
+exactly as before.
 
 ## Do not
 


### PR DESCRIPTION
## Summary

- Adds a final `test` stage to the local pipeline (`plan → implement → review-code → address-code → test`)
- `--test "<command>"` runs the command in a loop, invoking claude to fix on failure until green or `--test-max-attempts` is exhausted
- Omitting `--test` is a no-op — existing pipelines are unchanged
- `bossgremlin` forwards `--test` / `--test-max-attempts` / `-t` to every child local gremlin; rejected for `--chain-kind gh`

## Test plan

- [ ] `test_noop_when_no_test_cmd` — stage skips cleanly when `--test` omitted
- [ ] `test_green_on_first_try` — no claude calls when command exits 0 immediately
- [ ] `test_fix_then_green` — one fix call, then green on retry
- [ ] `test_attempts_exhausted_bails` — raises `RuntimeError` and emits bail after cap
- [ ] `test_code_style_in_fix_prompt` — custom style appears in fix prompt
- [ ] `test_launch_child_forwards_test_flags` — boss forwards all three flags via `pipeline_args`
- [ ] `test_launch_child_no_test_flags_when_absent` — no spurious flags when `test_cmd` empty

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)